### PR TITLE
[WIP] Standardized builds of LibVLCSharp + other fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 ﻿<Project>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);PORTABLE;DESKTOP</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <DefineConstants>$(DefineConstants);XAML;WINDOWS_CLASSIC;WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);XAML;DESKTOP</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
     <DefineConstants>$(DefineConstants);NETFX_CORE;XAML;WINDOWS_UWP;WINDOWS</DefineConstants>
@@ -26,6 +26,6 @@
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE;DESKTOP</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
+++ b/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
@@ -100,7 +100,7 @@
   <Import Project="..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets" Condition="Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets'))" />
   </Target>

--- a/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
+++ b/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
@@ -97,13 +97,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets" Condition="Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0-alpha\build\VideoLAN.LibVLC.Android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VideoLAN.LibVLC.Android.3.0.0-alpha\build\VideoLAN.LibVLC.Android.targets'))" />
+    <Error Condition="!Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VideoLAN.LibVLC.Android.3.0.0\build\VideoLAN.LibVLC.Android.targets'))" />
   </Target>
-  <Import Project="..\packages\VideoLAN.LibVLC.Android.3.0.0-alpha\build\VideoLAN.LibVLC.Android.targets" Condition="Exists('..\packages\VideoLAN.LibVLC.Android.3.0.0-alpha\build\VideoLAN.LibVLC.Android.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 		Other similar extension points exist, see Microsoft.Common.targets.
 		<Target Name="BeforeBuild">

--- a/LibVLCSharp.Android.Sample/packages.config
+++ b/LibVLCSharp.Android.Sample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="VideoLAN.LibVLC.Android" version="3.0.0-alpha" targetFramework="monoandroid71" />
+  <package id="VideoLAN.LibVLC.Android" version="3.0.0" targetFramework="monoandroid81" />
 </packages>

--- a/LibVLCSharp.FSharp.Sample/LibVLCSharp.FSharp.Sample.fsproj
+++ b/LibVLCSharp.FSharp.Sample/LibVLCSharp.FSharp.Sample.fsproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha2" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LibVLCSharp.Forms.Sample/LibVLCSharp.Forms.Sample.iOS/LibVLCSharp.Forms.Sample.iOS.csproj
+++ b/LibVLCSharp.Forms.Sample/LibVLCSharp.Forms.Sample.iOS/LibVLCSharp.Forms.Sample.iOS.csproj
@@ -120,7 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="VideoLAN.LibVLC.iOS">
-      <Version>3.0.0-alpha</Version>
+      <Version>3.0.0-alpha2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
   </ItemGroup>

--- a/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
+++ b/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.46">
   <PropertyGroup>
     <Title>LibVLCSharp.Forms</Title>
     <Summary>Xamarin.Forms integration for LibVLCSharp</Summary>
@@ -7,12 +7,10 @@
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10</TargetFrameworks>
     <RootNamespace>LibVLCSharp.Forms</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <DefineConstants>$(DefineConstants);</DefineConstants>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
     <Version>0.0.1-alpha</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
   </ItemGroup>
   <ItemGroup>
@@ -27,5 +25,4 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS'))">
     <Compile Include="Platforms\iOS\**\*.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
+++ b/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.7.142" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha1" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />

--- a/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
+++ b/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.41">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.46">
   <PropertyGroup>
     <Title>LibVLCSharp.WPF</Title>
     <TargetFramework>net461</TargetFramework>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -1,13 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.46">
   <PropertyGroup>
     <Title>LibVLCSharp</Title>
     <Summary>.NET bindings for LibVLC</Summary>
     <Description>.NET bindings for LibVLC</Description>
     <PackageTags>libvlc native xamarin .net video audio media mediaplayer</PackageTags>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;net461;netcoreapp2.0;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
     <RootNamespace>LibVLCSharp</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>default</LangVersion>
@@ -19,11 +18,8 @@
     <PackageProjectUrl>https://github.com/mfkl/LibVLCSharp</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <Compile Include="Shared\**\*.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <Compile Include="Platforms\Android\**\*.cs" />
@@ -41,5 +37,4 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.Mac'))">
     <Compile Include="Platforms\Mac\**\*.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -36,22 +36,12 @@ namespace LibVLCSharp.Shared
 
         public static void Initialize()
         {
-#if WINDOWS
-            InitializeWindows();
+#if DESKTOP
+            InitializeDesktop();
 #elif ANDROID
             InitializeAndroid();
-#elif NETCORE
-            InitializeNetCore();
 #endif
         }
-
-#if NETCORE
-        static void InitializeNetCore()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                InitializeWindows();
-        }
-#endif
 
 #if ANDROID
         static void InitializeAndroid()
@@ -63,24 +53,28 @@ namespace LibVLCSharp.Shared
         }
 #endif
         //TODO: Add Unload library func using handles
-        static void InitializeWindows()
+        static void InitializeDesktop()
         {
-            var myPath = new Uri(typeof(LibVLC).Assembly.CodeBase).LocalPath;
+            var myPath = typeof(LibVLC).Assembly.Location;
             var appExecutionDirectory = Path.GetDirectoryName(myPath);
             if (appExecutionDirectory == null)
                 throw new NullReferenceException(nameof(appExecutionDirectory));
 
-            var arch = Environment.Is64BitProcess ? Win64 : Win86;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
 
-            var libvlccorePath = Path.Combine(Path.Combine(appExecutionDirectory, Libvlc),
-                Path.Combine(arch, $"{Libvlccore}.dll"));
-            var libvlcPath = Path.Combine(Path.Combine(appExecutionDirectory, Libvlc),
-                Path.Combine(arch, $"{Libvlc}.dll"));
+                var arch = Environment.Is64BitProcess ? Win64 : Win86;
 
-            Debug.WriteLine(nameof(libvlccorePath) + ": " + libvlccorePath);
-            Debug.WriteLine(nameof(libvlcPath) + ": " + libvlcPath);
+                var libvlccorePath = Path.Combine(Path.Combine(appExecutionDirectory, Libvlc),
+                    Path.Combine(arch, $"{Libvlccore}.dll"));
+                var libvlcPath = Path.Combine(Path.Combine(appExecutionDirectory, Libvlc),
+                    Path.Combine(arch, $"{Libvlc}.dll"));
 
-            LoadLibvlcLibraries(libvlccorePath, libvlcPath);
+                Debug.WriteLine(nameof(libvlccorePath) + ": " + libvlccorePath);
+                Debug.WriteLine(nameof(libvlcPath) + ": " + libvlcPath);
+
+                LoadLibvlcLibraries(libvlccorePath, libvlcPath);
+            }
         }
 
         //TODO: check if Store app

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -84,7 +84,7 @@ namespace LibVLCSharp.Shared
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_get_xwindow")]
             internal static extern uint LibVLCMediaPlayerGetXwindow(IntPtr mediaPlayer);
-#if WINDOWS
+#if DESKTOP
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_hwnd")]
@@ -388,12 +388,12 @@ namespace LibVLCSharp.Shared
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_get_size")]
-            internal static extern unsafe int LibVLCVideoGetSize(IntPtr mediaPlayer, uint num, uint* px, uint* py);
+            internal static extern int LibVLCVideoGetSize(IntPtr mediaPlayer, uint num, ref uint px, ref uint py);
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_get_cursor")]
-            internal static extern unsafe int LibVLCVideoGetCursor(IntPtr mediaPlayer, uint num, int* px, int* py);
+            internal static extern int LibVLCVideoGetCursor(IntPtr mediaPlayer, uint num, ref int px, ref int py);
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
@@ -775,7 +775,7 @@ namespace LibVLCSharp.Shared
             set => Native.LibVLCMediaPlayerSetXwindow(NativeReference, value);
         }
 
-#if WINDOWS
+#if DESKTOP
         /// <summary>
         /// Set a Win32/Win64 API window handle (HWND) where the media player
         /// should render its video output. If LibVLC was built without
@@ -1311,18 +1311,7 @@ namespace LibVLCSharp.Shared
         /// <returns></returns>
         public bool Size(uint num, ref uint px, ref uint py)
         {
-            unsafe
-            {
-                fixed (uint* refPx = &px)
-                {
-                    var pxPtr = refPx;
-                    fixed (uint* refPy = &py)
-                    {
-                        var pyPtr = refPy;
-                        return Native.LibVLCVideoGetSize(NativeReference, num, pxPtr, pyPtr) == 0;
-                    }
-                }
-            }
+            return Native.LibVLCVideoGetSize(NativeReference, num, ref px, ref py) == 0;
         }
 
         /// <summary>
@@ -1343,18 +1332,7 @@ namespace LibVLCSharp.Shared
         /// <returns>true on success, false on failure</returns>
         public bool Cursor(uint num, ref int px, ref int py)
         {
-            unsafe
-            {
-                fixed (int* refPx = &px)
-                {
-                    var pxPtr = refPx;
-                    fixed (int* refPy = &py)
-                    {
-                        var pyPtr = refPy;
-                        return Native.LibVLCVideoGetCursor(NativeReference, num, pxPtr, pyPtr) == 0;
-                    }
-                }
-            }
+            return Native.LibVLCVideoGetCursor(NativeReference, num, ref px, ref py) == 0;
         }
 
         /// <summary>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -6,7 +6,7 @@
     <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha1" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.0-alpha3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />


### PR DESCRIPTION
Given that the WINDOWS constant is meaningless (Linux mono builds as
a .net framework too, and have WINDOWS set), and that .net core builds
running on windows should execute the same actions as .net fx,
I introduced a DESKTOP flag, for standard, core and framework.

Removed the need for netcoreapp and net461 in the LibVlcSharp project.

Consolidated packages versions

Updated MSBuild.Sdk.Extras

removed useless unsafe blocks

Things to do:

- [x] Did I break something? Given that I'm tired and that I did shit with the repo, it's likely...
- [x] No, really, netstandard2.0 is DESKTOP? What about X.F netstandard projects? To be checked...
- [ ] Get a review
- [ ] Remove WIP from the title
- [ ] Merge