### PR TITLE
refactored VLCException

### DIFF
--- a/LibVLCSharp/Shared/EventManager.cs
+++ b/LibVLCSharp/Shared/EventManager.cs
@@ -1750,16 +1750,6 @@ namespace LibVLCSharp.Shared
         }
     }
 
-    public class VLCException : Exception
-    {
-        public readonly string Reason;
-
-        public VLCException(string reason = "")
-        {
-            Reason = reason;
-        }
-    }
-
     [SuppressUnmanagedCodeSecurity, UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void EventCallback(IntPtr args);
 }

--- a/LibVLCSharp/Shared/VLCException.cs
+++ b/LibVLCSharp/Shared/VLCException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace LibVLCSharp.Shared
+{
+    public class VLCException : Exception
+    {
+        public VLCException(string message = ""):base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
It should set the `Message` property by calling the constructor with a message.
Otherwise `.ToString()` does not print any useful info.

Put it in a separate file.