### PR TITLE
Refactored logging API to make use of libvlcLogInterop

### DIFF
--- a/LibVLCSharp.Android.AWindow/LibVLCSharp.Android.AWindow.csproj
+++ b/LibVLCSharp.Android.AWindow/LibVLCSharp.Android.AWindow.csproj
@@ -12,7 +12,6 @@
     <RootNamespace>LibVLCSharp.Android.AWindow</RootNamespace>
     <AssemblyName>LibVLCSharp.Android.AWindow</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
+++ b/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
@@ -9,6 +9,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="LibVLCLogInterop" Version="1.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/LibVLCSharp.Tests/LibVLCTests.cs
+++ b/LibVLCSharp.Tests/LibVLCTests.cs
@@ -120,13 +120,17 @@ namespace LibVLCSharp.Tests
             var libVLC = new LibVLC();
             var logCallbackCalled = false;
 
-            void LogCallback(object sender, LogEventArgs args) => logCallbackCalled = true;
-
-            libVLC.Log += LogCallback;
+            libVLC.SetLogCallback(message =>
+            {
+                if (message.Message.Contains("VLC media player"))
+                {
+                    logCallbackCalled = true;
+                }
+            }, LibVLCLogLevel.Debug);
 
             await Task.Delay(1000);
-
-            libVLC.Log -= LogCallback;
+            
+            libVLC.SetLogCallback(null, LibVLCLogLevel.Error);
 
             Assert.IsTrue(logCallbackCalled);
         }
@@ -147,7 +151,7 @@ namespace LibVLCSharp.Tests
         {
             var libvlc = new LibVLC();
 
-            libvlc.SetLog((data, logLevel, logContext, format, args) => { });
+            libvlc.SetLogCallback(message => { }, LibVLCLogLevel.Error);
             libvlc.SetDialogHandlers((title, text) => Task.CompletedTask,
                 (dialog, title, text, defaultUsername, askStore, token) => Task.CompletedTask,
                 (dialog, title, text, type, cancelText, firstActionText, secondActonText, token) => Task.CompletedTask,

--- a/LibVLCSharp.Tests/MediaTests.cs
+++ b/LibVLCSharp.Tests/MediaTests.cs
@@ -110,7 +110,7 @@ namespace LibVLCSharp.Tests
         {
             using (var libVLC = new LibVLC())
             {
-                libVLC.Log += LibVLC_Log;
+                libVLC.SetLogCallback(LibVLC_Log, LibVLCLogLevel.Debug);
                 using (var media = new Media(libVLC, RealMp3PathSpecialCharacter, Media.FromType.FromPath))
                 {
                     Assert.False(media.IsParsed);
@@ -126,7 +126,7 @@ namespace LibVLCSharp.Tests
                         mp.Stop();
                     }
                 }
-                libVLC.Log -= LibVLC_Log;
+                libVLC.SetLogCallback(null, LibVLCLogLevel.Debug);
             }
         }
 
@@ -174,7 +174,7 @@ namespace LibVLCSharp.Tests
             return new MemoryStream(imageData);
         }
 
-        private void LibVLC_Log(object sender, LogEventArgs e)
+        private void LibVLC_Log(LogMessage e)
         {
             System.Diagnostics.Debug.WriteLine(e.Message);
         }

--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -15,8 +15,31 @@ namespace LibVLCSharp.Shared
             [DllImport(Constants.Kernel32, SetLastError = true)]
             internal static extern IntPtr LoadPackagedLibrary(string dllToLoad);
 
+            /// <summary>
+            /// Loads the specified module into the address space of the calling process. The specified module may cause other modules to be loaded.
+            /// </summary>
+            /// <param name="dllToLoad">The name of the module. This can be either a library module (a .dll file) or an executable module (an .exe file). The name specified is the file name of the module and is not related to the name stored in the library module itself, as specified by the LIBRARY keyword in the module-definition (.def) file. If the string specifies a full path, the function searches only that path for the module. If the string specifies a relative path or a module name without a path, the function uses a standard search strategy to find the module; for more information, see the Remarks. If the function cannot find the module, the function fails. When specifying a path, be sure to use backslashes (\), not forward slashes (/). For more information about paths, see Naming a File or Directory. If the string specifies a module name without a path and the file name extension is omitted, the function appends the default library extension .dll to the module name. To prevent the function from appending .dll to the module name, include a trailing point character (.) in the module name string.</param>
+            /// <returns>If the function succeeds, the return value is a handle to the module. If the function fails, the return value is NULL. To get extended error information, call GetLastError.</returns>
             [DllImport(Constants.Kernel32, SetLastError = true)]
             internal static extern IntPtr LoadLibrary(string dllToLoad);
+
+            /// <summary>
+            /// Retrieves the address of an exported function or variable from the specified dynamic-link library (DLL).
+            /// </summary>
+            /// <param name="hModule">A handle to the DLL module that contains the function or variable.</param>
+            /// <param name="lpProcName">he function or variable name, or the function's ordinal value. If this parameter is an ordinal value, it must be in the low-order word; the high-order word must be zero.</param>
+            /// <returns>If the function succeeds, the return value is the address of the exported function or variable. If the function fails, the return value is NULL. To get extended error information, call GetLastError.</returns>
+            [DllImport(Constants.Kernel32, CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
+            internal static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+            /// <summary>
+            /// Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count. When the reference count reaches zero, the module is unloaded from the address space of the calling process and the handle is no longer valid.
+            /// </summary>
+            /// <param name="hModule">A handle to the loaded library module.</param>
+            /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero. To get extended error information, call the GetLastError function.</returns>
+            [DllImport(Constants.Kernel32, SetLastError = true)]
+            internal static extern bool FreeLibrary(IntPtr hModule);
+
 
             [DllImport(Constants.libSystem)]
             internal static extern IntPtr dlopen(string libraryPath, int mode = 1);
@@ -26,8 +49,36 @@ namespace LibVLCSharp.Shared
 #endif
         }
 
-        static IntPtr _libvlccoreHandle;
-        static IntPtr _libvlcHandle;
+        struct LinuxNative
+        {
+            internal const int RTLD_LAZY = 1;
+            [DllImport(Constants.Libdl, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern IntPtr dlopen(string lpFileName, int flags);
+
+            [DllImport(Constants.Libdl, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+            [DllImport(Constants.Libdl, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern bool dlclose(IntPtr handle);
+
+            [DllImport(Constants.Libdl, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern string dlerror();
+        }
+
+        /// <summary>
+        /// The handle of the libvlccore library
+        /// </summary>
+        internal static IntPtr LibVLCCoreHandle { get; private set; }
+
+        /// <summary>
+        /// The handle of the libvlc library
+        /// </summary>
+        internal static IntPtr LibVLCHandle { get; private set; }
+
+        /// <summary>
+        /// The handle of the libvlcLogInterop library. https://github.com/jeremyVignelles/libvlcLogInterop
+        /// </summary>
+        internal static IntPtr LibVLCLogInteropHandle { get; private set; }
 
         /// <summary>
         /// Load the native libvlc library (if necessary depending on platform)
@@ -69,37 +120,48 @@ namespace LibVLCSharp.Shared
 #endif
             }
 
+            var arch = GetArchitectureName();
+
             if (IsWindows)
             {
-                var arch = IsX64BitProcess ? ArchitectureNames.Win64 : ArchitectureNames.Win86;
-
                 var librariesFolder = Path.Combine(appExecutionDirectory, Constants.LibrariesRepositoryFolderName, arch);
 
-                _libvlccoreHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.CoreLibraryName}.dll");
+                LibVLCCoreHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.CoreLibraryName}.dll");
                 
-                if(_libvlccoreHandle == IntPtr.Zero)
+                if(LibVLCCoreHandle == IntPtr.Zero)
                 {
                     throw new VLCException($"Failed to load required native library {Constants.CoreLibraryName}.dll");
                 }
 
-                _libvlcHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.LibraryName}.dll");
+                LibVLCHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.LibraryName}.dll");
                 
-                if(_libvlcHandle == IntPtr.Zero)
+                if(LibVLCHandle == IntPtr.Zero)
                 {
                     throw new VLCException($"Failed to load required native library {Constants.LibraryName}.dll");
                 }
+
+
+                LibVLCLogInteropHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.LibVLCLogInteropName}.dll");
+            }
+            else if (IsLinux)
+            {
+                var librariesFolder = Path.Combine(appExecutionDirectory, Constants.LibrariesRepositoryFolderName, arch);
+
+                // Try to find libvlc in the subfolder
+                LibVLCCoreHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.CoreLibraryName}.so");
+                LibVLCHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.LibraryName}.so");
+                LibVLCLogInteropHandle = PreloadNativeLibrary(librariesFolder, $"{Constants.LibVLCLogInteropName}.so");
             }
             else if (IsMac)
             {
-                _libvlcHandle = PreloadNativeLibrary(appExecutionDirectory, $"{Constants.LibraryName}.dylib");
-                if (_libvlcHandle == IntPtr.Zero)
+                LibVLCHandle = PreloadNativeLibrary(appExecutionDirectory, $"{Constants.LibraryName}.dylib");
+                if (LibVLCHandle == IntPtr.Zero)
                 {
                     throw new VLCException($"Failed to load required native library {Constants.LibraryName}.dylib");
                 }
             }
         }
 
-        //TODO: Add dlopen for UWP, Linux
         static IntPtr PreloadNativeLibrary(string nativeLibrariesPath, string libraryName)
         {
             Debug.WriteLine($"Loading {libraryName}");
@@ -112,7 +174,98 @@ namespace LibVLCSharp.Shared
                 return IntPtr.Zero;
             }
 #endif
-            return IsMac ? Native.dlopen(libraryPath) : Native.LoadLibrary(libraryPath);
+
+            if (IsWindows)
+            {
+                return Native.LoadLibrary(libraryPath);
+            }
+            else if (IsLinux)
+            {
+                return LinuxNative.dlopen(libraryPath, LinuxNative.RTLD_LAZY);
+            }
+            else if (IsMac)
+            {
+                return Native.dlopen(libraryPath);
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+
+        internal static T GetLibraryFunction<T>(IntPtr libraryHandle, string functionName)
+        {
+            //TODO : caching
+            IntPtr procAddress;
+            if (IsWindows)
+            {
+                procAddress = Native.GetProcAddress(libraryHandle, functionName);
+                if (procAddress == IntPtr.Zero)
+                {
+                    var errorMessage = $"The address of the function '{functionName}' cannot be found in the library";
+#if NETSTANDARD1_1
+                    throw new Exception(errorMessage);
+#else
+                    throw new MissingMethodException(errorMessage);
+#endif
+                }
+            }
+            else if (IsLinux)
+            {
+                procAddress = LinuxNative.dlsym(libraryHandle, functionName);
+                if (procAddress == IntPtr.Zero)
+                {
+                    var errorMessage = $"The address of the function '{functionName}' cannot be found in the library. dlsym failed with error {LinuxNative.dlerror()}";
+#if NETSTANDARD1_1
+                    throw new Exception(errorMessage);
+#else
+                    throw new MissingMethodException(errorMessage);
+#endif
+                }
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+#if NETSTANDARD1_1 || NET40
+            return (T)(object)Marshal.GetDelegateForFunctionPointer(procAddress, typeof(T));
+#else
+            return Marshal.GetDelegateForFunctionPointer<T>(procAddress);
+#endif
+        }
+
+        static string GetArchitectureName()
+        {
+            if (IsWindows)
+            {
+#if NET40 || NETSTANDARD1_1
+                return IntPtr.Size == 8 ? ArchitectureNames.Win64 : ArchitectureNames.Win86;
+#else
+                switch (RuntimeInformation.OSArchitecture)
+                {
+                    case Architecture.X86: return ArchitectureNames.Win86;
+                    case Architecture.X64: return ArchitectureNames.Win64;
+                    default: throw new PlatformNotSupportedException();
+                }
+#endif
+            }
+            else if (IsLinux)
+            {
+#if NET40 || NETSTANDARD1_1
+                // This logic is quite flawed, but we can't detect correctly on NET40 and NETSTANDARD1_1. If you're in that case, please use another framework version.
+                return IntPtr.Size == 8 ? ArchitectureNames.Lin64 : ArchitectureNames.LinArm;
+#else
+                switch (RuntimeInformation.OSArchitecture)
+                {
+                    case Architecture.Arm: return ArchitectureNames.LinArm;
+                    case Architecture.X64: return ArchitectureNames.Lin64;
+                    default: throw new PlatformNotSupportedException();
+                }
+#endif
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
         }
 
         static bool IsWindows
@@ -121,6 +274,15 @@ namespace LibVLCSharp.Shared
             get => Environment.OSVersion.Platform == PlatformID.Win32NT;
 #else
             get => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+        }
+
+        static bool IsLinux
+        {
+#if NET40
+            get => Environment.OSVersion.Platform == PlatformID.Win32NT;
+#else
+            get => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 #endif
         }
 
@@ -151,6 +313,8 @@ namespace LibVLCSharp.Shared
 #endif
         internal const string CoreLibraryName = "libvlccore";
 
+        internal const string LibVLCLogInteropName = "libvlcLogInterop";
+
         /// <summary>
         /// The name of the folder that contains the per-architecture folders
         /// </summary>
@@ -158,10 +322,18 @@ namespace LibVLCSharp.Shared
 
         internal const string Msvcrt = "msvcrt";
         internal const string Libc = "libc";
+        /// <summary>
+        /// The library that contains functions to load dynamic libraries on linux
+        /// </summary>
+        internal const string Libdl = "libdl";
         internal const string libSystem = "libSystem";
         internal const string Kernel32 = "kernel32";
     }
 
+    /// <summary>
+    /// The .net RID corresponding to the compatible architectures.
+    /// This is also the name of the folder which contains the native libraries
+    /// </summary>
     internal static class ArchitectureNames
     {
         internal const string Win64 = "win-x64";

--- a/LibVLCSharp/Shared/LibVLCEvents.cs
+++ b/LibVLCSharp/Shared/LibVLCEvents.cs
@@ -782,9 +782,9 @@ namespace LibVLCSharp.Shared
     }
 
     #endregion
-    public sealed class LogEventArgs : EventArgs
+    public sealed class LogMessage
     {
-        internal LogEventArgs(LogLevel level, string message, string module, string sourceFile, uint? sourceLine)
+        internal LogMessage(LibVLCLogLevel level, string message, string module, string sourceFile, uint? sourceLine)
         {
             Level = level;
             Message = message;
@@ -797,7 +797,7 @@ namespace LibVLCSharp.Shared
         /// The severity of the log message.
         /// By default, you will only get error messages, but you can get all messages by specifying "-vv" in the options.
         /// </summary>
-        public LogLevel Level { get; }
+        public LibVLCLogLevel Level { get; }
 
         /// <summary>
         /// The log message

--- a/Samples/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
+++ b/Samples/LibVLCSharp.Android.Sample/LibVLCSharp.Android.Sample.csproj
@@ -16,7 +16,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/Samples/LibVLCSharp.Android.Sample/Properties/AndroidManifest.xml
+++ b/Samples/LibVLCSharp.Android.Sample/Properties/AndroidManifest.xml
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" 
-          package="LibVLCSharp.Android.Sample.LibVLCSharp.Android.Sample" 
-          android:versionCode="1" 
-          android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="21" />
-  <application android:allowBackup="true" android:label="@string/app_name">
-  </application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="LibVLCSharp.Android.Sample.LibVLCSharp.Android.Sample" android:versionCode="1" android:versionName="1.0">
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
+	<application android:allowBackup="true" android:label="@string/app_name"></application>
 </manifest>


### PR DESCRIPTION
This new API lets .net user receive logs from callbacks, thanks to https://github.com/jeremyVignelles/libvlcLogInterop .

Things left to do:

- [ ] Test libvlcLogInterop on other platforms.
  - [ ] Android
  - [ ] iOS
  - [ ] macOS
  - [ ] windows x86
- [ ] Publish packages for libvlcLogInterop

Tested on :

- [x] linux x64
- [x] windows x64