### PR TITLE
Initial Core.Initialize() refactoring

### DIFF
--- a/LibVLCSharp.Tests/CoreLoadingTests.cs
+++ b/LibVLCSharp.Tests/CoreLoadingTests.cs
@@ -1,0 +1,27 @@
+﻿using LibVLCSharp.Shared;
+using NUnit.Framework;
+using System.IO;
+
+namespace LibVLCSharp.Tests
+{
+    [TestFixture]
+    public class CoreLoadingTests
+    {
+        [Test]
+        public void LoadLibVLCFromSpecificPath()
+        {
+            var dirPath = Path.GetDirectoryName(typeof(CoreLoadingTests).Assembly.Location);
+            var finalPath = Path.Combine(dirPath, "libvlc", "win-x86");
+
+            Assert.DoesNotThrow(() => Core.Initialize(finalPath), "fail to load libvlc dll at specified location");
+            var libvlc = new LibVLC();
+        }
+
+        [Test]
+        public void LoadLibVLCFromInferredPath()
+        {
+            Assert.DoesNotThrow(() => Core.Initialize(), "fail to load libvlc dll at specified location");
+            var libvlc = new LibVLC();
+        }
+    }
+}

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -69,6 +69,9 @@ Features:
   <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.TVOS'))">
     <Compile Include="Platforms\tvOS\**\*.cs" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0"/>
+  </ItemGroup>
   <Target Name="IncludeAWindow" Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)LibVLCSharp.Android.AWindow.dll" />

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -28,6 +28,7 @@ namespace LibVLCSharp.Shared
         }
         LogCallback _logCallback;
         readonly object _logLock = new object();
+#if NET || NETSTANDARD
         /// <summary>
         /// The real log event handlers.
         /// </summary>
@@ -37,8 +38,8 @@ namespace LibVLCSharp.Shared
         /// A boolean to make sure that we are calling SetLog only once
         /// </summary>
         bool _logAttached;
-
         IntPtr _logFileHandle;
+#endif
         IntPtr _dialogCbsPtr;
 
         public override int GetHashCode()

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Mono, .NET Framework and .NET Core runtimes are supported.
 - Linux (GTK)
 - Xamarin.Forms
 - .NET Standard 1.1
-- .NET Core
+- .NET Core (including ASP.NET Core)
 
 ## Installation
 

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -14,3 +14,5 @@ For ubuntu:
 
 For ubuntu:
 > `apt-get install gtk-sharp2`
+
+Should you want to load the libvlc libraries from another location than `/usr/lib`, you'd need to set `LD_LIBRARY_PATH`.


### PR DESCRIPTION
- [x] Document to callers that it may throw
- [x] provide full path of missing native library in exception.
- [x] Load libvlc libraries from specified folder.  This means we now support loading libvlc elsewhere than our libvlc nuget package.
- [x] log stuff.
- [x] Compute and try more possible locations. especially netcoreapp TFM, from `.nuget` location, etc.
- [x] load from custom path on linux
- [x] Test on blank app new projects on **all** targets with current libvlc nuget packages:
  - [x] Android
  - [x] GTK Windows, Linux
  - [x] net40 Windows
  - [x] .NET core sample app Windows, Mac, Linux
  - [x] ASP.NET Core Windows, Mac, Linux
  - [x] Mac cocoa
- [ ] Unit tests
- [x] Add ASP.NET Core compatibility on readme