### PR TITLE
Move media enums outside the Media class

### DIFF
--- a/LibVLCSharp.Tests/DialogTests.cs
+++ b/LibVLCSharp.Tests/DialogTests.cs
@@ -33,7 +33,7 @@ namespace LibVLCSharp.Tests
 
             var mp = new MediaPlayer(_libVLC)
             {
-                Media = new Media(_libVLC, UrlRequireAuth, Media.FromType.FromLocation)
+                Media = new Media(_libVLC, UrlRequireAuth, FromType.FromLocation)
             };
 
             mp.Play();
@@ -63,7 +63,7 @@ namespace LibVLCSharp.Tests
 
             var mp = new MediaPlayer(_libVLC)
             {
-                Media = new Media(_libVLC, UrlRequireAuth, Media.FromType.FromLocation)
+                Media = new Media(_libVLC, UrlRequireAuth, FromType.FromLocation)
             };
 
             mp.Play();
@@ -95,7 +95,7 @@ namespace LibVLCSharp.Tests
 
             var mp = new MediaPlayer(_libVLC)
             {
-                Media = new Media(_libVLC, UrlRequireAuth, Media.FromType.FromLocation)
+                Media = new Media(_libVLC, UrlRequireAuth, FromType.FromLocation)
             };
 
             mp.Play();

--- a/LibVLCSharp.Tests/EventManagerTests.cs
+++ b/LibVLCSharp.Tests/EventManagerTests.cs
@@ -14,13 +14,13 @@ namespace LibVLCSharp.Tests
         {
             var media = new Media(_libVLC, Path.GetTempFileName());
             var eventHandlerCalled = false;
-            const Media.MetadataType description = Media.MetadataType.Description;
+            const MetadataType description = MetadataType.Description;
             media.MetaChanged += (sender, args) =>
             {
                 Assert.AreEqual(description, args.MetadataType);
                 eventHandlerCalled = true;
             };
-            media.SetMeta(Media.MetadataType.Description, "test");
+            media.SetMeta(MetadataType.Description, "test");
             Assert.True(eventHandlerCalled);
         }
         

--- a/LibVLCSharp.Tests/MediaPlayerTests.cs
+++ b/LibVLCSharp.Tests/MediaPlayerTests.cs
@@ -32,7 +32,7 @@ namespace LibVLCSharp.Tests
         public async Task TrackDescription()
         {
             var mp = new MediaPlayer(_libVLC);
-            var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", Media.FromType.FromLocation);
+            var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", FromType.FromLocation);
             var tcs = new TaskCompletionSource<bool>();
             
             mp.Media = media;
@@ -51,7 +51,7 @@ namespace LibVLCSharp.Tests
         [Test]
         public async Task Play()
         {
-            var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", Media.FromType.FromLocation);
+            var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", FromType.FromLocation);
             var mp = new MediaPlayer(media);
             var called = false;
             mp.Playing += (sender, args) =>
@@ -72,7 +72,7 @@ namespace LibVLCSharp.Tests
         {
             try
             {
-                var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", Media.FromType.FromLocation);
+                var media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", FromType.FromLocation);
                 var mp = new MediaPlayer(media);
                 
 
@@ -147,7 +147,7 @@ namespace LibVLCSharp.Tests
         {
             var mp = new MediaPlayer(_libVLC);
 
-            mp.Play(new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", Media.FromType.FromLocation));
+            mp.Play(new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", FromType.FromLocation));
 
             await Task.Delay(1000);
 
@@ -161,7 +161,7 @@ namespace LibVLCSharp.Tests
         {
             var mp = new MediaPlayer(_libVLC);
 
-            mp.Play(new Media(_libVLC, "https://streams.videolan.org/streams/360/eagle_360.mp4", Media.FromType.FromLocation));
+            mp.Play(new Media(_libVLC, "https://streams.videolan.org/streams/360/eagle_360.mp4", FromType.FromLocation));
 
             await Task.Delay(1000);
 

--- a/LibVLCSharp.Tests/MediaTests.cs
+++ b/LibVLCSharp.Tests/MediaTests.cs
@@ -53,7 +53,7 @@ namespace LibVLCSharp.Tests
         [Test]
         public async Task CreateRealMedia()
         {
-            using (var media = new Media(_libVLC, RealStreamMediaPath, Media.FromType.FromLocation))
+            using (var media = new Media(_libVLC, RealStreamMediaPath, FromType.FromLocation))
             {
                 Assert.NotZero(media.Duration);
                 using (var mp = new MediaPlayer(media))
@@ -86,9 +86,9 @@ namespace LibVLCSharp.Tests
         {
             var media = new Media(_libVLC, Path.GetTempFileName());
             const string test = "test";
-            media.SetMeta(Media.MetadataType.ShowName, test);
+            media.SetMeta(MetadataType.ShowName, test);
             Assert.True(media.SaveMeta());
-            Assert.AreEqual(test, media.Meta(Media.MetadataType.ShowName));
+            Assert.AreEqual(test, media.Meta(MetadataType.ShowName));
         }
 
         [Test]
@@ -104,14 +104,14 @@ namespace LibVLCSharp.Tests
         public async Task CreateRealMediaSpecialCharacters()
         {
             _libVLC.Log += LibVLC_Log;
-            using (var media = new Media(_libVLC, RealMp3PathSpecialCharacter, Media.FromType.FromPath))
+            using (var media = new Media(_libVLC, RealMp3PathSpecialCharacter, FromType.FromPath))
             {
                 Assert.False(media.IsParsed);
 
                 media.Parse();
                 await Task.Delay(5000);
                 Assert.True(media.IsParsed);
-                Assert.AreEqual(Media.MediaParsedStatus.Done, media.ParsedStatus);
+                Assert.AreEqual(MediaParsedStatus.Done, media.ParsedStatus);
                 using (var mp = new MediaPlayer(media))
                 {
                     Assert.True(mp.Play());

--- a/LibVLCSharp.Tests/RendererDiscovererTests.cs
+++ b/LibVLCSharp.Tests/RendererDiscovererTests.cs
@@ -22,7 +22,7 @@ namespace LibVLCSharp.Tests
             var mp = new MediaPlayer(_libVLC)
             {
                 Media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",
-                    Media.FromType.FromLocation)
+                    FromType.FromLocation)
             };
 
             Assert.True(mp.Play());

--- a/LibVLCSharp/Shared/LibVLCEvents.cs
+++ b/LibVLCSharp/Shared/LibVLCEvents.cs
@@ -243,7 +243,7 @@ namespace LibVLCSharp.Shared
         [StructLayout(LayoutKind.Sequential)]
         internal readonly struct MediaMetaChanged
         {
-            internal readonly Media.MetadataType MetaType;
+            internal readonly MetadataType MetaType;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -261,7 +261,7 @@ namespace LibVLCSharp.Shared
         [StructLayout(LayoutKind.Sequential)]
         internal readonly struct MediaParsedChanged
         {
-            internal readonly Media.MediaParsedStatus NewStatus;
+            internal readonly MediaParsedStatus NewStatus;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -441,9 +441,9 @@ namespace LibVLCSharp.Shared
 
     public class MediaMetaChangedEventArgs : EventArgs
     {
-        public readonly Media.MetadataType MetadataType;
+        public readonly MetadataType MetadataType;
 
-        internal MediaMetaChangedEventArgs(Media.MetadataType metadataType)
+        internal MediaMetaChangedEventArgs(MetadataType metadataType)
         {
             MetadataType = metadataType;
         }
@@ -451,9 +451,9 @@ namespace LibVLCSharp.Shared
 
     public class MediaParsedChangedEventArgs : EventArgs
     {
-        public readonly Media.MediaParsedStatus ParsedStatus;
+        public readonly MediaParsedStatus ParsedStatus;
 
-        internal MediaParsedChangedEventArgs(Media.MediaParsedStatus parsedStatus)
+        internal MediaParsedChangedEventArgs(MediaParsedStatus parsedStatus)
         {
             ParsedStatus = parsedStatus;
         }

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -162,117 +162,7 @@ namespace LibVLCSharp.Shared
                             EntryPoint = "libvlc_media_get_codec_description")]
             internal static extern string LibvlcMediaGetCodecDescription(TrackType type, uint codec);
         }
-
-        #region enums
-        /// <summary>Meta data types</summary>
-        public enum MetadataType
-        {
-            Title = 0,
-            Artist = 1,
-            Genre = 2,
-            Copyright = 3,
-            Album = 4,
-            TrackNumber = 5,
-            Description = 6,
-            Rating = 7,
-            Date = 8,
-            Setting = 9,
-            URL = 10,
-            Language = 11,
-            NowPlaying = 12,
-            Publisher = 13,
-            EncodedBy = 14,
-            ArtworkURL = 15,
-            TrackID = 16,
-            TrackTotal = 17,
-            Director = 18,
-            Season = 19,
-            Episode = 20,
-            ShowName = 21,
-            Actors = 22,
-            AlbumArtist = 23,
-            DiscNumber = 24,
-            DiscTotal = 25
-        }
-
-        /// <summary>
-        /// The FromType enum is used to drive the media creation.
-        /// A media is usually created using a string, which can represent one of 3 things: FromPath, FromLocation, AsNode.
-        /// </summary>
-        public enum FromType
-        {
-            /// <summary>
-            /// Create a media for a certain file path.
-            /// </summary>
-            FromPath,
-            /// <summary>
-            /// Create a media with a certain given media resource location,
-            /// for instance a valid URL.
-            /// note To refer to a local file with this function,
-            /// the file://... URI syntax <b>must</b> be used (see IETF RFC3986).
-            /// We recommend using FromPath instead when dealing with
-            ///local files.
-            /// </summary>
-            FromLocation,
-            /// <summary>
-            /// Create a media as an empty node with a given name.
-            /// </summary>
-            AsNode
-        }
-
-        /// <summary>
-        /// Parse flags used by libvlc_media_parse_with_options()
-        /// </summary>
-        /// <remarks>libvlc_media_parse_with_options</remarks>
-        [Flags]
-        public enum MediaParseOptions
-        {
-            /// <summary>Parse media if it's a local file</summary>
-            ParseLocal = 0,
-            /// <summary>Parse media even if it's a network file</summary>
-            ParseNetwork = 1,
-            /// <summary>Fetch meta and covert art using local resources</summary>
-            FetchLocal = 2,
-            /// <summary>Fetch meta and covert art using network resources</summary>
-            FetchNetwork = 4,
-            /// <summary>
-            /// Interact with the user (via libvlc_dialog_cbs) when preparsing this item
-            /// (and not its sub items). Set this flag in order to receive a callback
-            /// when the input is asking for credentials.
-            /// </summary>
-            DoInteract = 8
-        }
-
-        /// <summary>
-        /// Parse status used sent by libvlc_media_parse_with_options() or returned by
-        /// libvlc_media_get_parsed_status()
-        /// </summary>
-        /// <remarks>
-        /// libvlc_media_parse_with_options
-        /// libvlc_media_get_parsed_status
-        /// </remarks>
-        public enum MediaParsedStatus
-        {
-            Skipped = 1,
-            Failed = 2,
-            Timeout = 3,
-            Done = 4
-        }
-
-        /// <summary>Media type</summary>
-        /// <remarks>libvlc_media_get_type</remarks>
-        public enum MediaType
-        {
-            Unknown = 0,
-            File = 1,
-            Directory = 2,
-            Disc = 3,
-            Stream = 4,
-            Playlist = 5
-        }
-
-        #endregion
-
+        
         /// <summary>
         /// Media Constructs a libvlc Media instance
         /// </summary>
@@ -1030,6 +920,114 @@ namespace LibVLCSharp.Shared
         /// </summary>
         Audio = 1
     }
+
+    /// <summary>Meta data types</summary>
+    public enum MetadataType
+    {
+        Title = 0,
+        Artist = 1,
+        Genre = 2,
+        Copyright = 3,
+        Album = 4,
+        TrackNumber = 5,
+        Description = 6,
+        Rating = 7,
+        Date = 8,
+        Setting = 9,
+        URL = 10,
+        Language = 11,
+        NowPlaying = 12,
+        Publisher = 13,
+        EncodedBy = 14,
+        ArtworkURL = 15,
+        TrackID = 16,
+        TrackTotal = 17,
+        Director = 18,
+        Season = 19,
+        Episode = 20,
+        ShowName = 21,
+        Actors = 22,
+        AlbumArtist = 23,
+        DiscNumber = 24,
+        DiscTotal = 25
+    }
+
+    /// <summary>
+    /// The FromType enum is used to drive the media creation.
+    /// A media is usually created using a string, which can represent one of 3 things: FromPath, FromLocation, AsNode.
+    /// </summary>
+    public enum FromType
+    {
+        /// <summary>
+        /// Create a media for a certain file path.
+        /// </summary>
+        FromPath,
+        /// <summary>
+        /// Create a media with a certain given media resource location,
+        /// for instance a valid URL.
+        /// note To refer to a local file with this function,
+        /// the file://... URI syntax <b>must</b> be used (see IETF RFC3986).
+        /// We recommend using FromPath instead when dealing with
+        ///local files.
+        /// </summary>
+        FromLocation,
+        /// <summary>
+        /// Create a media as an empty node with a given name.
+        /// </summary>
+        AsNode
+    }
+
+    /// <summary>
+    /// Parse flags used by libvlc_media_parse_with_options()
+    /// </summary>
+    /// <remarks>libvlc_media_parse_with_options</remarks>
+    [Flags]
+    public enum MediaParseOptions
+    {
+        /// <summary>Parse media if it's a local file</summary>
+        ParseLocal = 0,
+        /// <summary>Parse media even if it's a network file</summary>
+        ParseNetwork = 1,
+        /// <summary>Fetch meta and covert art using local resources</summary>
+        FetchLocal = 2,
+        /// <summary>Fetch meta and covert art using network resources</summary>
+        FetchNetwork = 4,
+        /// <summary>
+        /// Interact with the user (via libvlc_dialog_cbs) when preparsing this item
+        /// (and not its sub items). Set this flag in order to receive a callback
+        /// when the input is asking for credentials.
+        /// </summary>
+        DoInteract = 8
+    }
+
+    /// <summary>
+    /// Parse status used sent by libvlc_media_parse_with_options() or returned by
+    /// libvlc_media_get_parsed_status()
+    /// </summary>
+    /// <remarks>
+    /// libvlc_media_parse_with_options
+    /// libvlc_media_get_parsed_status
+    /// </remarks>
+    public enum MediaParsedStatus
+    {
+        Skipped = 1,
+        Failed = 2,
+        Timeout = 3,
+        Done = 4
+    }
+
+    /// <summary>Media type</summary>
+    /// <remarks>libvlc_media_get_type</remarks>
+    public enum MediaType
+    {
+        Unknown = 0,
+        File = 1,
+        Directory = 2,
+        Disc = 3,
+        Stream = 4,
+        Playlist = 5
+    }
+
     #endregion
 
     /// <summary>

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1610,12 +1610,6 @@ namespace LibVLCSharp.Shared
             return frame;
         }
 #endif
-#region Enums
-
-
-
-
-#endregion
 
 #region Callbacks
 


### PR DESCRIPTION
- Aligns with other enum types
- Removes unneeded redundancy