### PR TITLE
Improves MVVM scenario

### DIFF
--- a/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using LibVLCSharp.Forms.Platforms.GTK;
 using LibVLCSharp.Forms.Shared;
-using LibVLCSharp.Shared;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.GTK;
 
@@ -23,16 +22,20 @@ namespace LibVLCSharp.Forms.Platforms.GTK
 
             if (e.OldElement != null)
             {
-                e.OldElement.MediaPlayerChanged -= OnMediaPlayerChanged;
+                e.OldElement.MediaPlayerChanging -= OnMediaPlayerChanging;
             }
 
             if (e.NewElement != null)
             {
-                e.NewElement.MediaPlayerChanged += OnMediaPlayerChanged;
+                e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
+                if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                {
+                    OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                }
             }
         }
 
-        private void OnMediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
             if (Control == null)
             {

--- a/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using LibVLCSharp.Forms.Platforms.GTK;
 using LibVLCSharp.Forms.Shared;
+using LibVLCSharp.Shared;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.GTK;
 

--- a/LibVLCSharp.Forms.Platforms.WPF/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms.Platforms.WPF/VideoViewRenderer.cs
@@ -1,6 +1,6 @@
-﻿using LibVLCSharp.Shared;
-using LibVLCSharp.Forms.Platforms.WPF;
+﻿using LibVLCSharp.Forms.Platforms.WPF;
 using LibVLCSharp.Forms.Shared;
+using LibVLCSharp.Shared;
 using Xamarin.Forms.Platform.WPF;
 
 [assembly: ExportRenderer(typeof(VideoView), typeof(VideoViewRenderer))]
@@ -19,16 +19,20 @@ namespace LibVLCSharp.Forms.Platforms.WPF
 
             if (e.OldElement != null)
             {
-                e.OldElement.MediaPlayerChanged -= OnMediaPlayerChanged;
+                e.OldElement.MediaPlayerChanging -= OnMediaPlayerChanging;
             }
 
             if (e.NewElement != null)
             {
-                e.NewElement.MediaPlayerChanged += OnMediaPlayerChanged;
+                e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
+                if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                {
+                    OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                }
             }
         }
 
-        private void OnMediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
             Control.MediaPlayer = e.NewMediaPlayer;
         }

--- a/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
@@ -27,16 +27,20 @@ namespace LibVLCSharp.Forms.Platforms.Android
 
             if (e.OldElement != null)
             {
-                e.OldElement.MediaPlayerChanged -= OnMediaPlayerChanged;
+                e.OldElement.MediaPlayerChanging -= OnMediaPlayerChanging;
             }
 
             if (e.NewElement != null)
             {
-                e.NewElement.MediaPlayerChanged += OnMediaPlayerChanged;
+                e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
+                if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                {
+                    OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                }
             }
         }
 
-        private void OnMediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
             Control.MediaPlayer = e.NewMediaPlayer;
             Control.TriggerLayoutChangeListener();

--- a/LibVLCSharp.Forms/Platforms/Mac/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/Mac/VideoViewRenderer.cs
@@ -22,16 +22,20 @@ namespace LibVLCSharp.Forms.Platforms.Mac
 
             if (e.OldElement != null)
             {
-                e.OldElement.MediaPlayerChanged -= OnMediaPlayerChanged;
+                e.OldElement.MediaPlayerChanging -= OnMediaPlayerChanging;
             }
 
             if (e.NewElement != null)
             {
-                e.NewElement.MediaPlayerChanged += OnMediaPlayerChanged;
+                e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
+                if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                {
+                    OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                }
             }
         }
 
-        private void OnMediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
             Control.MediaPlayer = e.NewMediaPlayer;
         }

--- a/LibVLCSharp.Forms/Platforms/iOS/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/iOS/VideoViewRenderer.cs
@@ -24,16 +24,20 @@ namespace LibVLCSharp.Forms.Platforms.iOS
 
             if (e.OldElement != null)
             {
-                e.OldElement.MediaPlayerChanged -= OnMediaPlayerChanged;
+                e.OldElement.MediaPlayerChanging -= OnMediaPlayerChanging;
             }
 
             if (e.NewElement != null)
             {
-                e.NewElement.MediaPlayerChanged += OnMediaPlayerChanged;
+                e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
+                if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                {
+                    OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                }
             }    
         }
 
-        private void OnMediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
             Control.MediaPlayer = e.NewMediaPlayer;
         }

--- a/LibVLCSharp.Forms/Shared/VideoView.cs
+++ b/LibVLCSharp.Forms/Shared/VideoView.cs
@@ -8,20 +8,19 @@ namespace LibVLCSharp.Forms.Shared
     public class VideoView : View
     {
         /// <summary>
+        /// Raised when a new MediaPlayer is set and will be attached to the view
+        /// </summary>
+        public event EventHandler<MediaPlayerChangingEventArgs> MediaPlayerChanging;
+
+        /// <summary>
         /// Raised when a new MediaPlayer is set and attached to the view
         /// </summary>
         public event EventHandler<MediaPlayerChangedEventArgs> MediaPlayerChanged;
 
-        /// <summary>
-        /// Raised after the first mediaplayer has been set. 
-        /// This is mostly needed with LibVLCSharp.Forms.WPF to prevent timing issues regarding HWND creation. 
-        /// It is safe to call Play() when Loaded has been raised.
-        /// </summary>
-        public event EventHandler Loaded;
-
-        public static readonly BindableProperty MediaPlayerProperty = BindableProperty.Create(nameof(MediaPlayer), 
-                typeof(LibVLCSharp.Shared.MediaPlayer), 
+        public static readonly BindableProperty MediaPlayerProperty = BindableProperty.Create(nameof(MediaPlayer),
+                typeof(LibVLCSharp.Shared.MediaPlayer),
                 typeof(VideoView),
+                propertyChanging: OnMediaPlayerChanging,
                 propertyChanged: OnMediaPlayerChanged);
 
         /// <summary>
@@ -33,14 +32,18 @@ namespace LibVLCSharp.Forms.Shared
             set { SetValue(MediaPlayerProperty, value); }
         }
 
+        private static void OnMediaPlayerChanging(BindableObject bindable, object oldValue, object newValue)
+        {
+            var videoView = (VideoView)bindable;
+            Debug.WriteLine("OnMediaPlayerChanging");
+            videoView.MediaPlayerChanging?.Invoke(videoView, new MediaPlayerChangingEventArgs(oldValue as LibVLCSharp.Shared.MediaPlayer, newValue as LibVLCSharp.Shared.MediaPlayer));
+        }
+
         private static void OnMediaPlayerChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var videoView = (VideoView)bindable;
-            Trace.WriteLine("OnMediaPlayerChanged");
+            Debug.WriteLine("OnMediaPlayerChanged");
             videoView.MediaPlayerChanged?.Invoke(videoView, new MediaPlayerChangedEventArgs(oldValue as LibVLCSharp.Shared.MediaPlayer, newValue as LibVLCSharp.Shared.MediaPlayer));
-            
-            if(oldValue == null && newValue != null) // assuming this is the first MediaPlayer set
-                videoView.Loaded?.Invoke(videoView, EventArgs.Empty);
         }
     }
 }

--- a/LibVLCSharp.WPF/VideoView.cs
+++ b/LibVLCSharp.WPF/VideoView.cs
@@ -19,7 +19,7 @@ namespace LibVLCSharp.WPF
         {
             DefaultStyleKey = typeof(VideoView);
         }
-        
+
         public static readonly DependencyProperty MediaPlayerProperty = DependencyProperty.Register(nameof(MediaPlayer),
                 typeof(MediaPlayer),
                 typeof(VideoView),
@@ -63,7 +63,7 @@ namespace LibVLCSharp.WPF
                         Content = ViewContent
                     };
                 }
-                
+
                 Hwnd = (Template.FindName(PART_PlayerView, this) as System.Windows.Forms.Panel)?.Handle ?? IntPtr.Zero;
                 if (Hwnd == null)
                 {
@@ -116,8 +116,8 @@ namespace LibVLCSharp.WPF
             {
                 if (disposing)
                 {
-                    if(MediaPlayer != null)
-                    { 
+                    if (MediaPlayer != null)
+                    {
                         MediaPlayer.Hwnd = IntPtr.Zero;
                     }
                 }

--- a/LibVLCSharp/Shared/Events/MediaPlayerChangedEventArgs.cs
+++ b/LibVLCSharp/Shared/Events/MediaPlayerChangedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace LibVLCSharp.Shared
+{
+    public class MediaPlayerChangedEventArgs : EventArgs
+    {
+        public MediaPlayerChangedEventArgs(LibVLCSharp.Shared.MediaPlayer oldMediaPlayer, LibVLCSharp.Shared.MediaPlayer newMediaPlayer)
+        {
+            OldMediaPlayer = oldMediaPlayer;
+            NewMediaPlayer = newMediaPlayer;
+        }
+
+        public LibVLCSharp.Shared.MediaPlayer OldMediaPlayer { get; }
+        public LibVLCSharp.Shared.MediaPlayer NewMediaPlayer { get; }
+    }
+}

--- a/LibVLCSharp/Shared/Events/MediaPlayerChangingEventArgs.cs
+++ b/LibVLCSharp/Shared/Events/MediaPlayerChangingEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace LibVLCSharp.Shared
+{
+    public class MediaPlayerChangingEventArgs : EventArgs
+    {
+        public MediaPlayerChangingEventArgs(LibVLCSharp.Shared.MediaPlayer oldMediaPlayer, LibVLCSharp.Shared.MediaPlayer newMediaPlayer)
+        {
+            OldMediaPlayer = oldMediaPlayer;
+            NewMediaPlayer = newMediaPlayer;
+        }
+
+        public LibVLCSharp.Shared.MediaPlayer OldMediaPlayer { get; }
+        public LibVLCSharp.Shared.MediaPlayer NewMediaPlayer { get; }
+    }
+}

--- a/LibVLCSharp/Shared/Events/MediaPlayerEventManager.cs
+++ b/LibVLCSharp/Shared/Events/MediaPlayerEventManager.cs
@@ -103,7 +103,7 @@ namespace LibVLCSharp.Shared
         int _mutedRegistrationCount;
         int _unmutedRegistrationCount;
         int _volumeChangedRegistrationCount;
-        
+
         EventCallback _positionChangedCallback;
         EventCallback _mediaChangedCallback;
         EventCallback _nothingSpecialCallback;
@@ -137,7 +137,7 @@ namespace LibVLCSharp.Shared
 
         protected internal override void AttachEvent<T>(EventType eventType, EventHandler<T> eventHandler)
         {
-            lock(_lock)
+            lock (_lock)
             {
                 switch (eventType)
                 {
@@ -284,43 +284,43 @@ namespace LibVLCSharp.Shared
                         ref _eSSelectedRegistrationCount,
                         () => _mediaPlayerESSelected += eventHandler as EventHandler<MediaPlayerESSelectedEventArgs>,
                         () => _eSSelectedCallback = OnESSelected);
-                       break;
+                        break;
                     case EventType.MediaPlayerAudioDevice:
                         Attach(eventType,
                         ref _audioDeviceRegistrationCount,
                         () => _mediaPlayerAudioDevice += eventHandler as EventHandler<MediaPlayerAudioDeviceEventArgs>,
                         () => _audioDeviceCallback = OnAudioDevice);
-                       break;
+                        break;
                     case EventType.MediaPlayerCorked:
                         Attach(eventType,
                         ref _corkedRegistrationCount,
                         () => _mediaPlayerCorked += eventHandler as EventHandler<EventArgs>,
                         () => _corkedCallback = OnCorked);
-                       break;
+                        break;
                     case EventType.MediaPlayerUncorked:
                         Attach(eventType,
                         ref _uncorkedRegistrationCount,
                         () => _mediaPlayerUncorked += eventHandler as EventHandler<EventArgs>,
                         () => _uncorkedCallback = OnUncorked);
-                       break;
+                        break;
                     case EventType.MediaPlayerMuted:
                         Attach(eventType,
                         ref _mutedRegistrationCount,
                         () => _mediaPlayerMuted += eventHandler as EventHandler<EventArgs>,
                         () => _mutedCallback = OnMuted);
-                       break;
+                        break;
                     case EventType.MediaPlayerUnmuted:
                         Attach(eventType,
                         ref _unmutedRegistrationCount,
                         () => _mediaPlayerUnmuted += eventHandler as EventHandler<EventArgs>,
                         () => _unmutedCallback = OnUnmuted);
-                       break;
+                        break;
                     case EventType.MediaPlayerAudioVolume:
                         Attach(eventType,
                         ref _volumeChangedRegistrationCount,
                         () => _mediaPlayerVolumeChanged += eventHandler as EventHandler<MediaPlayerVolumeChangedEventArgs>,
                         () => _volumeChangedCallback = OnVolumeChanged);
-                       break;
+                        break;
                     default:
                         OnEventUnhandled(this, eventType);
                         break;
@@ -520,7 +520,7 @@ namespace LibVLCSharp.Shared
                 }
             }
         }
-        
+
 #if IOS
         [MonoPInvokeCallback(typeof(EventCallback))]
         static void OnMediaChanged(IntPtr ptr)
@@ -891,17 +891,5 @@ namespace LibVLCSharp.Shared
         }
 #endif
 
-    }
-
-    public class MediaPlayerChangedEventArgs : EventArgs
-    {
-        public MediaPlayerChangedEventArgs(LibVLCSharp.Shared.MediaPlayer oldMediaPlayer, LibVLCSharp.Shared.MediaPlayer newMediaPlayer)
-        {
-            OldMediaPlayer = oldMediaPlayer;
-            NewMediaPlayer = newMediaPlayer;
-        }
-
-        public LibVLCSharp.Shared.MediaPlayer OldMediaPlayer { get; }
-        public LibVLCSharp.Shared.MediaPlayer NewMediaPlayer { get; }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml
@@ -8,5 +8,5 @@
         <local:MainViewModel />
     </ContentPage.BindingContext>
     
-    <shared:VideoView MediaPlayer="{Binding MediaPlayer}" x:Name="videoView" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"/>
+    <shared:VideoView MediaPlayer="{Binding MediaPlayer}" MediaPlayerChanged="VideoView_MediaPlayerChanged" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"/>
 </ContentPage>

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -8,11 +8,5 @@ namespace LibVLCSharp.Forms.Sample
         {
             InitializeComponent();
         }
-
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-            ((MainViewModel)BindingContext).OnAppearing();
-        }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -9,22 +9,22 @@ namespace LibVLCSharp.Forms.Sample
         {
             InitializeComponent();
             videoView.MediaPlayerChanged += VideoView_MediaPlayerChanged;
-            BindingContext.PropertyChanged += BindingContext_PropertyChanged;
-            BindingContext.Play();
+            ViewModel.PropertyChanged += BindingContext_PropertyChanged;
+            ViewModel.Play();
         }
 
-        private new MainViewModel BindingContext => (MainViewModel)base.BindingContext;
+        private MainViewModel ViewModel => (MainViewModel)BindingContext;
 
         private void BindingContext_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName.Equals(nameof(BindingContext.MediaPlayer)))
+            if (e.PropertyName.Equals(nameof(ViewModel.MediaPlayer)))
                 Debug.WriteLine("MediaPlayer change raised from ViewModel.Propertychanged");
         }
 
         private void VideoView_MediaPlayerChanged(object sender, LibVLCSharp.Shared.MediaPlayerChangedEventArgs e)
         {
             Debug.WriteLine("VideoView_MediaPlayerChanged");
-            BindingContext.Play();
+            ViewModel.Play();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Sample
 {
@@ -8,23 +7,12 @@ namespace LibVLCSharp.Forms.Sample
         public MainPage()
         {
             InitializeComponent();
-            videoView.MediaPlayerChanged += VideoView_MediaPlayerChanged;
-            ViewModel.PropertyChanged += BindingContext_PropertyChanged;
-            ViewModel.Play();
         }
 
-        private MainViewModel ViewModel => (MainViewModel)BindingContext;
-
-        private void BindingContext_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        protected override void OnAppearing()
         {
-            if (e.PropertyName.Equals(nameof(ViewModel.MediaPlayer)))
-                Debug.WriteLine("MediaPlayer change raised from ViewModel.Propertychanged");
-        }
-
-        private void VideoView_MediaPlayerChanged(object sender, LibVLCSharp.Shared.MediaPlayerChangedEventArgs e)
-        {
-            Debug.WriteLine("VideoView_MediaPlayerChanged");
-            ViewModel.Play();
+            base.OnAppearing();
+            ((MainViewModel)BindingContext).OnAppearing();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -1,44 +1,30 @@
-﻿using LibVLCSharp.Shared;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Sample
 {
     public partial class MainPage : ContentPage
     {
-        MainViewModel _vm;
-
         public MainPage()
         {
             InitializeComponent();
-        }
-
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-
             videoView.MediaPlayerChanged += VideoView_MediaPlayerChanged;
-            videoView.Loaded += VideoView_Loaded;
-
-            _vm = BindingContext as MainViewModel;
-            _vm.PropertyChanged += Vm_PropertyChanged;
-            _vm.Initialize();
+            BindingContext.PropertyChanged += BindingContext_PropertyChanged;
+            BindingContext.Play();
         }
 
-        private void VideoView_Loaded(object sender, System.EventArgs e)
+        private new MainViewModel BindingContext => (MainViewModel)base.BindingContext;
+
+        private void BindingContext_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            _vm.MediaPlayer.Play();
+            if (e.PropertyName.Equals(nameof(BindingContext.MediaPlayer)))
+                Debug.WriteLine("MediaPlayer change raised from ViewModel.Propertychanged");
         }
 
-        private void Vm_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void VideoView_MediaPlayerChanged(object sender, LibVLCSharp.Shared.MediaPlayerChangedEventArgs e)
         {
-            if(e.PropertyName.Equals(nameof(_vm.MediaPlayer)))
-                Trace.WriteLine("MediaPlayer change raised from ViewModel.Propertychanged");
-        }
-
-        private void VideoView_MediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
-        {
-            Trace.WriteLine("VideoView_MediaPlayerChanged");
+            Debug.WriteLine("VideoView_MediaPlayerChanged");
+            BindingContext.Play();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -18,7 +18,7 @@ namespace LibVLCSharp.Forms.Sample
 
         private void VideoView_MediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
         {
-            ((MainViewModel)BindingContext).Play();
+            ((MainViewModel)BindingContext).OnVideoViewInitialized();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using LibVLCSharp.Shared;
+using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Sample
 {
@@ -7,6 +8,17 @@ namespace LibVLCSharp.Forms.Sample
         public MainPage()
         {
             InitializeComponent();
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            ((MainViewModel)BindingContext).OnAppearing();
+        }
+
+        private void VideoView_MediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
+        {
+            ((MainViewModel)BindingContext).Play();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -23,8 +23,6 @@ namespace LibVLCSharp.Forms.Sample
             private set => Set(nameof(MediaPlayer), ref _mediaPlayer, value);
         }
 
-        private bool IsLoaded { get; set; }
-
         private void Set<T>(string propertyName, ref T field, T value)
         {
             if (field == null && value != null || field != null && !field.Equals(value))
@@ -38,28 +36,14 @@ namespace LibVLCSharp.Forms.Sample
         {
             Core.Initialize();
 
-            LibVLC = new LibVLC();
+            LibVLC = new LibVLC("--no-embedded-video");
             MediaPlayer = new MediaPlayer(LibVLC)
             {
                 Media = new Media(LibVLC,
                     "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",
                     FromType.FromLocation)
             };
-            Play();
-        }
-
-        public void OnAppearing()
-        {
-            IsLoaded = true;
-            Play();
-        }
-
-        private void Play()
-        {
-            if (IsLoaded)
-            {
-                MediaPlayer?.Play();
-            }
+            MediaPlayer.Play();
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -23,6 +23,8 @@ namespace LibVLCSharp.Forms.Sample
             private set => Set(nameof(MediaPlayer), ref _mediaPlayer, value);
         }
 
+        private bool IsLoaded { get; set; }
+
         private void Set<T>(string propertyName, ref T field, T value)
         {
             if (field == null && value != null || field != null && !field.Equals(value))
@@ -43,11 +45,21 @@ namespace LibVLCSharp.Forms.Sample
                     "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",
                     FromType.FromLocation)
             };
+            Play();
         }
 
-        public void Play()
+        public void OnAppearing()
         {
-            MediaPlayer?.Play();
+            IsLoaded = true;
+            Play();
+        }
+
+        private void Play()
+        {
+            if (IsLoaded)
+            {
+                MediaPlayer?.Play();
+            }
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -23,6 +23,8 @@ namespace LibVLCSharp.Forms.Sample
             private set => Set(nameof(MediaPlayer), ref _mediaPlayer, value);
         }
 
+        private bool IsLoaded { get; set; }
+
         private void Set<T>(string propertyName, ref T field, T value)
         {
             if (field == null && value != null || field != null && !field.Equals(value))
@@ -36,14 +38,27 @@ namespace LibVLCSharp.Forms.Sample
         {
             Core.Initialize();
 
-            LibVLC = new LibVLC("--no-embedded-video");
+            LibVLC = new LibVLC();
             MediaPlayer = new MediaPlayer(LibVLC)
             {
                 Media = new Media(LibVLC,
                     "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",
                     FromType.FromLocation)
             };
-            MediaPlayer.Play();
+        }
+
+        public void OnAppearing()
+        {
+            IsLoaded = true;
+            Play();
+        }
+
+        public void Play()
+        {
+            if (IsLoaded)
+            {
+                MediaPlayer?.Play();
+            }
         }
     }
 }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -24,6 +24,7 @@ namespace LibVLCSharp.Forms.Sample
         }
 
         private bool IsLoaded { get; set; }
+        private bool IsVideoViewInitialized { get; set; }
 
         private void Set<T>(string propertyName, ref T field, T value)
         {
@@ -53,11 +54,17 @@ namespace LibVLCSharp.Forms.Sample
             Play();
         }
 
-        public void Play()
+        public void OnVideoViewInitialized()
         {
-            if (IsLoaded)
+            IsVideoViewInitialized = true;
+            Play();
+        }
+
+        private void Play()
+        {
+            if (IsLoaded && IsVideoViewInitialized)
             {
-                MediaPlayer?.Play();
+                MediaPlayer.Play();
             }
         }
     }

--- a/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/Samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -1,12 +1,20 @@
 ﻿using LibVLCSharp.Shared;
+using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace LibVLCSharp.Forms.Sample
 {
     public class MainViewModel : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
-        LibVLC _libVLC;
+
+        public MainViewModel()
+        {
+            Task.Run((Action)Initialize);
+        }
+
+        private LibVLC LibVLC { get; set; }
 
         private MediaPlayer _mediaPlayer;
         public MediaPlayer MediaPlayer
@@ -24,17 +32,22 @@ namespace LibVLCSharp.Forms.Sample
             }
         }
 
-        public void Initialize()
+        private void Initialize()
         {
             Core.Initialize();
 
-            _libVLC = new LibVLC();
-            MediaPlayer = new MediaPlayer(_libVLC)
+            LibVLC = new LibVLC();
+            MediaPlayer = new MediaPlayer(LibVLC)
             {
-                Media = new Media(_libVLC,
-                "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4", 
-                FromType.FromLocation)
+                Media = new Media(LibVLC,
+                    "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",
+                    FromType.FromLocation)
             };
+        }
+
+        public void Play()
+        {
+            MediaPlayer?.Play();
         }
     }
 }


### PR DESCRIPTION
PR to handle this [MVVM scenario](https://github.com/kakone/libvlcsharp_samples/blob/master/Samples/Samples/MvvmSampleViewModel.cs) where all the code is in the ViewModel (the [MainPage.cs](https://github.com/kakone/libvlcsharp_samples/blob/master/Samples/Samples/MvvmSamplePage.xaml.cs) has no code).

As MediaPlayerChanged event is called too early in this case, I needed to add this code in the VideoViewRenderers : 
```
if (Control.MediaPlayer != e.NewElement.MediaPlayer)
{
  OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
}
```

This PR also removed the Loaded event in the VideoView, replaced by a MediaPlayerChanged event. I use now the PropertyChanging event to set the MediaPlayer property in the native control. So, when MediaPlayerChanged event is raised, all is well set (so the HWND for WPF is well defined in the MediaPlayerChanged event).