### PR TITLE
Feature/complete libvlc api coverage

### DIFF
--- a/LibVLCSharp.Tests/LibVLCAPICoverage.cs
+++ b/LibVLCSharp.Tests/LibVLCAPICoverage.cs
@@ -3,9 +3,8 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -20,19 +19,20 @@ namespace LibVLCSharp.Tests
         [Test]
         public async Task CheckLibVLCCoverage()
         {
-            var symPath = Path.GetTempFileName();
-            var deprecatedSymPath = Path.GetTempFileName();
+            string[] libvlc3Symbols;
+            string[] libvlc3deprecatedSym;
 
-            using (var client = new WebClient())
-            {                
-                client.DownloadFile(LibVLCSym3URL, symPath);
-                client.DownloadFile(LibVLCDeprecatedSymUrl, deprecatedSymPath);
+            using (var httpClient = new HttpClient())
+            {
+                libvlc3Symbols = (await httpClient.GetStringAsync(LibVLCSym3URL)).Split(new[] { '\r', '\n' }).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+                libvlc3deprecatedSym = (await httpClient.GetStringAsync(LibVLCDeprecatedSymUrl)).Split(new[] { '\r', '\n' }).Where(s => !string.IsNullOrEmpty(s)).ToArray();
             }
-            
+
             List<string> dllImports = new List<string>();
 
+            // retrieving EventManager using reflection because the type is internal
             var eventManager = typeof(MediaPlayer).GetRuntimeProperties()
-                .FirstOrDefault(n => n.Name.EndsWith("EventManager"))
+                .First(n => n.Name.Equals("EventManager"))
                 .PropertyType
                 .BaseType;
 
@@ -52,13 +52,12 @@ namespace LibVLCSharp.Tests
 
             var deprecatedSymbolsLine = new List<string>();
 
-            var deprecatedSymFileLines = await File.ReadAllLinesAsync(deprecatedSymPath);
-            for (var i = 0; i < deprecatedSymFileLines.Count(); i++)
+            for (var i = 0; i < libvlc3deprecatedSym.Count(); i++)
             {
-                var currentLine = deprecatedSymFileLines[i];
+                var currentLine = libvlc3deprecatedSym[i];
                 if(currentLine.StartsWith("LIBVLC_DEPRECATED"))
                 {
-                    deprecatedSymbolsLine.Add(deprecatedSymFileLines[i + 1]);
+                    deprecatedSymbolsLine.Add(libvlc3deprecatedSym[i + 1]);
                 }
             }
 
@@ -69,11 +68,12 @@ namespace LibVLCSharp.Tests
                 var libvlcIndexStart = symLine.IndexOf("libvlc");
                 var sym1 = symLine.Substring(libvlcIndexStart);
                 var finalSymbol = new string(sym1.TakeWhile(c => c != '(').ToArray());
-                if(finalSymbol.Contains('*'))
+
+                if (finalSymbol.Contains('*'))
                 {
                     finalSymbol = finalSymbol.Substring(finalSymbol.IndexOf('*') + 1);
                 }
-                
+
                 deprecatedSymbols.Add(finalSymbol.Trim());
             }
 
@@ -83,12 +83,14 @@ namespace LibVLCSharp.Tests
                 "libvlc_free" // hidden in internal type
             };
 
+            // these symbols are internal, should not be in libvlc.sym and have been removed in libvlc 4+
             List<string> internalSymbolsThatShouldNotBeThere = new List<string>
             {
                 "libvlc_get_input_thread", "libvlc_media_new_from_input_item", "libvlc_media_set_state"
             };
 
-            List<string> NotGonnaImplementYetUntilActualUserDemandAndIfItMakesSense = new List<string>
+            // not implemented symbols for lack of use case or user interest
+            List<string> notImplementedOnPurpose = new List<string>
             {
                 "libvlc_printerr", "libvlc_vprinterr", "libvlc_clock", "libvlc_dialog_get_context", "libvlc_dialog_set_context",
                 "libvlc_event_type_name", "libvlc_log_get_object", "libvlc_vlm", "libvlc_media_list_player", "libvlc_media_library"
@@ -97,7 +99,7 @@ namespace LibVLCSharp.Tests
             List<string> exclude = new List<string>();
             exclude.AddRange(implementedButHidden);
             exclude.AddRange(internalSymbolsThatShouldNotBeThere);
-            exclude.AddRange(NotGonnaImplementYetUntilActualUserDemandAndIfItMakesSense);
+            exclude.AddRange(notImplementedOnPurpose);
 
             foreach (var libvlcType in libvlcTypes)
             {
@@ -121,38 +123,22 @@ namespace LibVLCSharp.Tests
                 }
             }
 
-            bool ShouldExclude(string symbol)
-            {
-                foreach(var excludeSymbol in exclude)
-                {
-                    if (symbol.StartsWith(excludeSymbol))
-                        return true;
-                }
-                return false;
-            }
+            var missingApis = libvlc3Symbols
+                .Where(symbol => !exclude.Any(excludeSymbol => symbol.StartsWith(excludeSymbol))) // Filters out excluded symbols
+                .Except(dllImports)
+                .Except(deprecatedSymbols);
+
+            var missingApisCount = missingApis.Count();
 
             Debug.WriteLine($"we have {dllImports.Count} dll import statements");
+            Debug.WriteLine($"{missingApisCount} missing APIs implementation");
 
-            List<string> libvlcSymFile = new List<string>();
-            foreach(var sym in File.ReadLines(symPath))
-            {
-                if (ShouldExclude(sym)) continue;
-
-                libvlcSymFile.Add(sym);
-            }
-
-            var missingApis = libvlcSymFile
-                .Except(dllImports)
-                .Except(deprecatedSymbols)
-                .ToList();
-
-            Debug.WriteLine($"{missingApis.Count} missing APIs implementation");
-            foreach(var miss in missingApis)
+            foreach (var miss in missingApis)
             {
                 Debug.WriteLine(miss);
             }
 
-            Assert.Zero(missingApis.Count);
+            Assert.Zero(missingApisCount);
         }
     }
 }

--- a/LibVLCSharp.Tests/LibVLCAPICoverage.cs
+++ b/LibVLCSharp.Tests/LibVLCAPICoverage.cs
@@ -1,0 +1,158 @@
+﻿using LibVLCSharp.Shared;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace LibVLCSharp.Tests
+{
+    [TestFixture]
+    public class LibVLCAPICoverage
+    {
+        const string LibVLCSym3URL = "https://raw.githubusercontent.com/videolan/vlc-3.0/3.0.0/lib/libvlc.sym";
+        const string LibVLCDeprecatedSymUrl = "https://raw.githubusercontent.com/videolan/vlc-3.0/master/include/vlc/deprecated.h";
+
+        [Test]
+        public async Task CheckLibVLCCoverage()
+        {
+            var symPath = Path.GetTempFileName();
+            var deprecatedSymPath = Path.GetTempFileName();
+
+            using (var client = new WebClient())
+            {                
+                client.DownloadFile(LibVLCSym3URL, symPath);
+                client.DownloadFile(LibVLCDeprecatedSymUrl, deprecatedSymPath);
+            }
+            
+            List<string> dllImports = new List<string>();
+
+            var eventManager = typeof(MediaPlayer).GetRuntimeProperties()
+                .FirstOrDefault(n => n.Name.EndsWith("EventManager"))
+                .PropertyType
+                .BaseType;
+
+            List<Type> libvlcTypes = new List<Type>
+            {
+                typeof(LibVLC),
+                typeof(MediaPlayer),
+                typeof(Media),
+                typeof(MediaDiscoverer),
+                typeof(RendererDiscoverer),
+                typeof(RendererItem),
+                typeof(Dialog),
+                typeof(MediaList),
+                typeof(Equalizer),
+                eventManager
+            };
+
+            var deprecatedSymbolsLine = new List<string>();
+
+            var deprecatedSymFileLines = await File.ReadAllLinesAsync(deprecatedSymPath);
+            for (var i = 0; i < deprecatedSymFileLines.Count(); i++)
+            {
+                var currentLine = deprecatedSymFileLines[i];
+                if(currentLine.StartsWith("LIBVLC_DEPRECATED"))
+                {
+                    deprecatedSymbolsLine.Add(deprecatedSymFileLines[i + 1]);
+                }
+            }
+
+            var deprecatedSymbols = new List<string>();
+
+            foreach (var symLine in deprecatedSymbolsLine)
+            {
+                var libvlcIndexStart = symLine.IndexOf("libvlc");
+                var sym1 = symLine.Substring(libvlcIndexStart);
+                var finalSymbol = new string(sym1.TakeWhile(c => c != '(').ToArray());
+                if(finalSymbol.Contains('*'))
+                {
+                    finalSymbol = finalSymbol.Substring(finalSymbol.IndexOf('*') + 1);
+                }
+                
+                deprecatedSymbols.Add(finalSymbol.Trim());
+            }
+
+            List<string> implementedButHidden = new List<string>
+            {
+                "libvlc_media_player_set_android_context", // android build only
+                "libvlc_free" // hidden in internal type
+            };
+
+            List<string> internalSymbolsThatShouldNotBeThere = new List<string>
+            {
+                "libvlc_get_input_thread", "libvlc_media_new_from_input_item", "libvlc_media_set_state"
+            };
+
+            List<string> NotGonnaImplementYetUntilActualUserDemandAndIfItMakesSense = new List<string>
+            {
+                "libvlc_printerr", "libvlc_vprinterr", "libvlc_clock", "libvlc_dialog_get_context", "libvlc_dialog_set_context",
+                "libvlc_event_type_name", "libvlc_log_get_object", "libvlc_vlm", "libvlc_media_list_player", "libvlc_media_library"
+            };
+
+            List<string> exclude = new List<string>();
+            exclude.AddRange(implementedButHidden);
+            exclude.AddRange(internalSymbolsThatShouldNotBeThere);
+            exclude.AddRange(NotGonnaImplementYetUntilActualUserDemandAndIfItMakesSense);
+
+            foreach (var libvlcType in libvlcTypes)
+            {
+                var r = libvlcType.GetNestedType("Native", BindingFlags.NonPublic);
+                if (r == null) continue;
+
+                foreach (var method in r.GetRuntimeMethods())
+                {
+                    foreach (var attr in method.CustomAttributes)
+                    {
+                        if (attr.AttributeType.Name.Equals("DllImportAttribute"))
+                        {
+                            var arg = attr.NamedArguments.FirstOrDefault(a => a.MemberName.Equals("EntryPoint"));
+                            if (arg == null) continue;
+
+                            var sym = (string)arg.TypedValue.Value;
+
+                            dllImports.Add(sym);
+                        }
+                    }
+                }
+            }
+
+            bool ShouldExclude(string symbol)
+            {
+                foreach(var excludeSymbol in exclude)
+                {
+                    if (symbol.StartsWith(excludeSymbol))
+                        return true;
+                }
+                return false;
+            }
+
+            Debug.WriteLine($"we have {dllImports.Count} dll import statements");
+
+            List<string> libvlcSymFile = new List<string>();
+            foreach(var sym in File.ReadLines(symPath))
+            {
+                if (ShouldExclude(sym)) continue;
+
+                libvlcSymFile.Add(sym);
+            }
+
+            var missingApis = libvlcSymFile
+                .Except(dllImports)
+                .Except(deprecatedSymbols)
+                .ToList();
+
+            Debug.WriteLine($"{missingApis.Count} missing APIs implementation");
+            foreach(var miss in missingApis)
+            {
+                Debug.WriteLine(miss);
+            }
+
+            Assert.Zero(missingApis.Count);
+        }
+    }
+}

--- a/LibVLCSharp.Tests/LibVLCTests.cs
+++ b/LibVLCSharp.Tests/LibVLCTests.cs
@@ -148,5 +148,12 @@ namespace LibVLCSharp.Tests
             Assert.AreEqual(IntPtr.Zero, _libVLC.NativeReference);
             Assert.IsFalse(_libVLC.DialogHandlersSet);
         }
+
+        [Test]
+        public void LibVLCVersion()
+        {
+            var version = _libVLC.Version;
+            Assert.True(version.StartsWith("3"));
+        }
     }
 }

--- a/LibVLCSharp.Tests/LibVLCTests.cs
+++ b/LibVLCSharp.Tests/LibVLCTests.cs
@@ -152,8 +152,13 @@ namespace LibVLCSharp.Tests
         [Test]
         public void LibVLCVersion()
         {
-            var version = _libVLC.Version;
-            Assert.True(version.StartsWith("3"));
+            Assert.True(_libVLC.Version.StartsWith("3"));
+        }
+
+        [Test]
+        public void LibVLCChangeset()
+        {
+            Assert.IsNotNull(_libVLC.Changeset);
         }
     }
 }

--- a/LibVLCSharp.Tests/MediaPlayerTests.cs
+++ b/LibVLCSharp.Tests/MediaPlayerTests.cs
@@ -24,7 +24,7 @@ namespace LibVLCSharp.Tests
         public void OutputDeviceEnum()
         {
             var mp = new MediaPlayer(_libVLC);
-            var t = mp.OutputDeviceEnum;
+            var t = mp.AudioOutputDeviceEnum;
             Debug.WriteLine(t);
         }
         

--- a/LibVLCSharp.Tests/MediaPlayerTests.cs
+++ b/LibVLCSharp.Tests/MediaPlayerTests.cs
@@ -175,5 +175,22 @@ namespace LibVLCSharp.Tests
 
             Assert.AreEqual(IntPtr.Zero, mp.NativeReference);
         }
+
+        [Test]
+        public void GetMediaPlayerRole()
+        {
+            var mp = new MediaPlayer(_libVLC);
+            Assert.AreEqual(MediaPlayerRole.None, mp.Role);
+        }
+
+        [Test]
+        public void SetMediaPlayerRole()
+        {
+            var mp = new MediaPlayer(_libVLC);
+            Assert.AreEqual(MediaPlayerRole.None, mp.Role);
+
+            Assert.True(mp.SetRole(MediaPlayerRole.Video));
+            Assert.AreEqual(MediaPlayerRole.Video, mp.Role);
+        }
     }
 }

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -139,6 +139,11 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_renderer_discoverer_list_release")]
             internal static extern void LibVLCRendererDiscovererReleaseList(IntPtr discovererList, ulong count);
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_retain")]
+            internal static extern void LibVLCRetain(IntPtr libVLC);
+
+
 #if ANDROID
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_android_context")]
@@ -617,6 +622,9 @@ namespace LibVLCSharp.Shared
             module = modulePtr.FromUtf8();
             file = filePtr.FromUtf8();
         }
+
+        /// <summary>Increments the native reference counter for this libvlc instance</summary>
+        public void Retain() => Native.LibVLCRetain(NativeReference);
     }
 
     /// <summary>Logging messages level.</summary>

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -643,7 +643,7 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>Increments the native reference counter for this libvlc instance</summary>
-        public void Retain() => Native.LibVLCRetain(NativeReference);
+        internal void Retain() => Native.LibVLCRetain(NativeReference);
 
         /// <summary>The version of the LibVLC engine currently used by LibVLCSharp</summary>
         public string Version => Native.LibVLCVersion().FromUtf8();

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -150,6 +150,19 @@ namespace LibVLCSharp.Shared
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_get_changeset")]
             internal static extern IntPtr LibVLCChangeset();
+
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_errmsg")]
+            internal static extern IntPtr LibVLCErrorMessage();
+
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_clearerr")]
+            internal static extern void LibVLCClearError();
+
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_get_compiler")]
+            internal static extern IntPtr LibVLCGetCompiler();
+
 #if ANDROID
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_android_context")]
@@ -637,6 +650,27 @@ namespace LibVLCSharp.Shared
 
         /// <summary>The changeset of the LibVLC engine currently used by LibVLCSharp</summary>
         public string Changeset => Native.LibVLCChangeset().FromUtf8();
+
+        /// <summary>
+        /// A human-readable error message for the last LibVLC error in the calling
+        /// thread. The resulting string is valid until another error occurs (at least
+        /// until the next LibVLC call). 
+        /// <para/> Null if no error.
+        /// </summary>
+        public string LastLibVLCError => Native.LibVLCErrorMessage().FromUtf8();
+
+        /// <summary>
+        /// Clears the LibVLC error status for the current thread. This is optional.
+        /// By default, the error status is automatically overridden when a new error
+        /// occurs, and destroyed when the thread exits.
+        /// </summary>
+        public void ClearLibVLCError() => Native.LibVLCClearError();
+
+        /// <summary>
+        /// Retrieve the libvlc compiler version.
+        /// Example: "gcc version 4.2.3 (Ubuntu 4.2.3-2ubuntu6)"
+        /// </summary>
+        public string LibVLCCompiler => Native.LibVLCGetCompiler().FromUtf8();
     }
 
     /// <summary>Logging messages level.</summary>

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -143,6 +143,9 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_retain")]
             internal static extern void LibVLCRetain(IntPtr libVLC);
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_get_version")]
+            internal static extern IntPtr LibVLCVersion();
 
 #if ANDROID
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
@@ -625,6 +628,9 @@ namespace LibVLCSharp.Shared
 
         /// <summary>Increments the native reference counter for this libvlc instance</summary>
         public void Retain() => Native.LibVLCRetain(NativeReference);
+
+        /// <summary>The version of the LibVLC engine currently used by LibVLCSharp</summary>
+        public string Version => Native.LibVLCVersion().FromUtf8();
     }
 
     /// <summary>Logging messages level.</summary>

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -147,6 +147,9 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_get_version")]
             internal static extern IntPtr LibVLCVersion();
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_get_changeset")]
+            internal static extern IntPtr LibVLCChangeset();
 #if ANDROID
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_android_context")]
@@ -631,6 +634,9 @@ namespace LibVLCSharp.Shared
 
         /// <summary>The version of the LibVLC engine currently used by LibVLCSharp</summary>
         public string Version => Native.LibVLCVersion().FromUtf8();
+
+        /// <summary>The changeset of the LibVLC engine currently used by LibVLCSharp</summary>
+        public string Changeset => Native.LibVLCChangeset().FromUtf8();
     }
 
     /// <summary>Logging messages level.</summary>

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -556,6 +556,13 @@ namespace LibVLCSharp.Shared
             s => s.Build(),
             Native.LibVLCMediaReleaseSlaves);
 
+        /// <summary>Get a media's codec description</summary>
+        /// <param name="type">The type of the track</param>
+        /// <param name="codec">the codec or fourcc</param>
+        /// <returns>the codec description</returns>
+        public string CodecDescription(TrackType type, uint codec) 
+            => Native.LibvlcMediaGetCodecDescription(type, codec);
+
         public override bool Equals(object obj)
         {
             return obj is Media media &&

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -711,7 +711,7 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>Increments the native reference counter for the media</summary>
-        public void Retain()
+        internal void Retain()
         {
             if (NativeReference != IntPtr.Zero)
                 Native.LibVLCMediaRetain(NativeReference);

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -153,7 +153,7 @@ namespace LibVLCSharp.Shared
             internal static extern void LibVLCMediaRetain(IntPtr media);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
-                            EntryPoint = "libvlc_media_get_codec_description")]
+                EntryPoint = "libvlc_media_get_codec_description")]
             internal static extern IntPtr LibvlcMediaGetCodecDescription(TrackType type, uint codec);
         }
         

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -560,8 +560,7 @@ namespace LibVLCSharp.Shared
         /// <param name="type">The type of the track</param>
         /// <param name="codec">the codec or fourcc</param>
         /// <returns>the codec description</returns>
-        public string CodecDescription(TrackType type, uint codec) 
-            => Native.LibvlcMediaGetCodecDescription(type, codec);
+        public string CodecDescription(TrackType type, uint codec) => Native.LibvlcMediaGetCodecDescription(type, codec).FromUtf8();
 
         public override bool Equals(object obj)
         {

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -711,7 +711,8 @@ namespace LibVLCSharp.Shared
             DicStreams.TryRemove(handle, out var result);
         }
 
-        void Retain()
+        /// <summary>Increments the native reference counter for the media</summary>
+        public void Retain()
         {
             if (NativeReference != IntPtr.Zero)
                 Native.LibVLCMediaRetain(NativeReference);

--- a/LibVLCSharp/Shared/MediaList.cs
+++ b/LibVLCSharp/Shared/MediaList.cs
@@ -82,10 +82,13 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_media_list_unlock")]
             internal static extern void LibVLCMediaListUnlock(IntPtr mediaList);
 
-
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_list_event_manager")]
             internal static extern IntPtr LibVLCMediaListEventManager(IntPtr mediaList);
+
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_media_list_retain")]
+            internal static extern void LibVLCMediaListRetain(IntPtr mediaList);
         }
 
         /// <summary>
@@ -250,6 +253,9 @@ namespace LibVLCSharp.Shared
                 return _eventManager;
             }
         }
+
+        /// <summary>Increments the native reference counter for this medialist instance</summary>
+        public void Retain() => Native.LibVLCMediaListRetain(NativeReference);
 
         #region Events
 

--- a/LibVLCSharp/Shared/MediaList.cs
+++ b/LibVLCSharp/Shared/MediaList.cs
@@ -255,7 +255,7 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>Increments the native reference counter for this medialist instance</summary>
-        public void Retain() => Native.LibVLCMediaListRetain(NativeReference);
+        internal void Retain() => Native.LibVLCMediaListRetain(NativeReference);
 
         #region Events
 

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1660,7 +1660,7 @@ namespace LibVLCSharp.Shared
         public bool SetRole(MediaPlayerRole role) => Native.LibVLCMediaPlayerSetRole(NativeReference, role) == 0;
 
         /// <summary>Increments the native reference counter for this mediaplayer instance</summary>
-        public void Retain() => Native.LibVLCMediaPlayerRetain(NativeReference);
+        internal void Retain() => Native.LibVLCMediaPlayerRetain(NativeReference);
 
 #if UNITY_ANDROID
         /// <summary>

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1042,27 +1042,27 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Selects an audio output module.
         /// Note: 
-        /// Any change will take be effect only after playback is stopped and restarted.Audio output cannot be changed while playing.
+        /// Any change will take effect only after playback is stopped and restarted. Audio output cannot be changed while playing.
         /// </summary>
         /// <param name="name">name of audio output, use psz_name of</param>
-        /// <returns>0 if function succeeded, -1 on error</returns>
-        public int SetAudioOutput(string name)
+        /// <returns>true if function succeeded, false on error</returns>
+        public bool SetAudioOutput(string name)
         {
             var nameUtf8 = name.ToUtf8();
-            return MarshalUtils.PerformInteropAndFree(() => Native.LibVLCAudioOutputSet(NativeReference, nameUtf8), nameUtf8);
+            return MarshalUtils.PerformInteropAndFree(() => Native.LibVLCAudioOutputSet(NativeReference, nameUtf8), nameUtf8) == 0;
         }
 
         /// <summary>
         /// Get the current audio output device identifier.
-        /// This complements SetOutputDevice()
+        /// This complements <see cref="SetOutputDevice"/>
         /// warning The initial value for the current audio output device identifier
         /// may not be set or may be some unknown value.A LibVLC application should
         /// compare this value against the known device identifiers (e.g.those that
-        /// were previously retrieved by a call to libvlc_audio_output_device_enum or
-        /// libvlc_audio_output_device_list_get) to find the current audio output device.
+        /// were previously retrieved by a call to <see cref="AudioOutputDeviceEnum"/> or
+        /// <see cref="LibVLC.AudioOutputDevices"/>) to find the current audio output device.
         ///
         /// It is possible that the selected audio output device changes(an external
-        /// change) without a call to libvlc_audio_output_device_set.That may make this
+        /// change) without a call to <see cref="SetOutputDevice"/>.That may make this
         /// method unsuitable to use if a LibVLC application is attempting to track
         /// dynamic audio device changes as they happen.
         ///
@@ -1076,7 +1076,7 @@ namespace LibVLCSharp.Shared
         /// specified by the device identifier string immediately.This is the
         /// recommended usage.
         /// A list of adequate potential device strings can be obtained with
-        /// libvlc_audio_output_device_enum().
+        /// <see cref="AudioOutputDeviceEnum"/>
         /// However passing NULL is supported in LibVLC version 2.2.0 and later only;
         /// in earlier versions, this function would have no effects when the module
         /// parameter was NULL.
@@ -1084,7 +1084,7 @@ namespace LibVLCSharp.Shared
         /// corresponding audio output, if it exists, will be set to the specified
         /// string. 
         /// A list of adequate potential device strings can be obtained with
-        /// LibVLC.AudioOutputDevices().
+        /// <see cref="LibVLC.AudioOutputDevices"/>
         /// </summary>
         /// <param name="deviceId">device identifier string</param>
         /// <param name="module">If NULL, current audio output module. if non-NULL, name of audio output module</param>
@@ -1096,7 +1096,18 @@ namespace LibVLCSharp.Shared
                 Native.LibVLCAudioOutputDeviceSet(NativeReference, moduleUtf8, deviceIdUtf8), 
                 moduleUtf8, deviceIdUtf8);
         }
-        
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public AudioOutputDevice[] AudioOutputDeviceEnum =>
+           MarshalUtils.Retrieve(() => Native.LibVLCAudioOutputDeviceEnum(NativeReference),
+           MarshalUtils.PtrToStructure<AudioOutputDeviceStructure>,
+           s => s.Build(),
+           device => device.Next,
+           Native.LibVLCAudioOutputDeviceListRelease);
+
         /// <summary>
         /// Toggle mute status. 
         /// Warning

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -573,6 +573,14 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_media_player_set_renderer")]
             internal static extern int LibVLCMediaPlayerSetRenderer(IntPtr mediaplayer, IntPtr renderItem);
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_media_player_get_role")]
+            internal static extern MediaPlayerRole LibVLCMediaPlayerGetRole(IntPtr mediaplayer);
+
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_media_player_set_role")]
+            internal static extern int LibVLCMediaPlayerSetRole(IntPtr mediaplayer, MediaPlayerRole role);
+
 #if ANDROID
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
@@ -1596,6 +1604,17 @@ namespace LibVLCSharp.Shared
         public bool SetRenderer(RendererItem rendererItem) =>
             Native.LibVLCMediaPlayerSetRenderer(NativeReference, rendererItem.NativeReference) == 0;
 
+        /// <summary>Gets the media role.
+        /// <para/> version LibVLC 3.0.0 and later.
+        /// </summary>
+        public MediaPlayerRole Role => Native.LibVLCMediaPlayerGetRole(NativeReference);
+        
+        /// <summary>Sets the media role.
+        /// <para/> version LibVLC 3.0.0 and later.
+        /// </summary>
+        /// <returns>true on success, false otherwise</returns>
+        public bool SetRole(MediaPlayerRole role) => Native.LibVLCMediaPlayerSetRole(NativeReference, role) == 0;
+
 #if UNITY_ANDROID
         /// <summary>
         /// Retrieve a video frame from the Unity plugin.
@@ -2163,6 +2182,7 @@ namespace LibVLCSharp.Shared
         Production = 7,
         /// <summary>Accessibility</summary>
         Accessibility = 8,
+        /// <summary>Testing</summary>
         Test = 9
     }    
 }

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1098,9 +1098,11 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// 
+        /// Gets a list of potential audio output devices
+        /// <para/> Not all audio outputs support enumerating devices. The audio output may be functional even if the list is empty (NULL).
+        /// The list may not be exhaustive. Some audio output devices in the list might not actually work in some circumstances.
+        /// <para/> By default, it is recommended to not specify any explicit audio device.
         /// </summary>
-        /// <returns></returns>
         public AudioOutputDevice[] AudioOutputDeviceEnum =>
            MarshalUtils.Retrieve(() => Native.LibVLCAudioOutputDeviceEnum(NativeReference),
            MarshalUtils.PtrToStructure<AudioOutputDeviceStructure>,

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -581,6 +581,9 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_media_player_set_role")]
             internal static extern int LibVLCMediaPlayerSetRole(IntPtr mediaplayer, MediaPlayerRole role);
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_media_player_retain")]
+            internal static extern void LibVLCMediaPlayerRetain(IntPtr mediaplayer);
 #if ANDROID
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
@@ -1614,6 +1617,9 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <returns>true on success, false otherwise</returns>
         public bool SetRole(MediaPlayerRole role) => Native.LibVLCMediaPlayerSetRole(NativeReference, role) == 0;
+
+        /// <summary>Increments the native reference counter for this mediaplayer instance</summary>
+        public void Retain() => Native.LibVLCMediaPlayerRetain(NativeReference);
 
 #if UNITY_ANDROID
         /// <summary>


### PR DESCRIPTION
- Adds a bunch of missing libvlc APIs
- Add a unit test which checks API coverage of the binding against libvlc 3.0 public symbols taking into account deprecated ones, internally implemented ones etc.

Closes https://code.videolan.org/videolan/LibVLCSharp/issues/104