### PR TITLE
Fixed wrong RootNamespace for Forms.Platforms.{GTK,WPF}

### DIFF
--- a/LibVLCSharp.Forms.Platforms.GTK/LibVLCSharp.Forms.Platforms.GTK.csproj
+++ b/LibVLCSharp.Forms.Platforms.GTK/LibVLCSharp.Forms.Platforms.GTK.csproj
@@ -26,7 +26,7 @@ Features:
 - DVD playback and menu navigation.
     </Description>    
     <TargetFramework>net47</TargetFramework>
-    <RootNamespace>LibVLCSharp.Forms.GTK</RootNamespace>
+    <RootNamespace>LibVLCSharp.Forms.Platforms.GTK</RootNamespace>
     <PackageVersion>0.7.0</PackageVersion>
     <PackageId>LibVLCSharp.Forms.GTK</PackageId>
     <Authors>VideoLAN</Authors>

--- a/LibVLCSharp.Forms.Platforms.WPF/LibVLCSharp.Forms.Platforms.WPF.csproj
+++ b/LibVLCSharp.Forms.Platforms.WPF/LibVLCSharp.Forms.Platforms.WPF.csproj
@@ -26,7 +26,7 @@ Features:
 - DVD playback and menu navigation.
     </Description>    
     <TargetFramework>net47</TargetFramework>
-    <RootNamespace>LibVLCSharp.Forms.WPF</RootNamespace>
+    <RootNamespace>LibVLCSharp.Forms.Platforms.WPF</RootNamespace>
     <PackageVersion>0.7.0</PackageVersion>
     <PackageId>LibVLCSharp.Forms.WPF</PackageId>
     <Authors>VideoLAN</Authors>


### PR DESCRIPTION
This does not change anything about the generated code, but it did trigger an analysis error on my visual studio (not sure whether it's VS itself or Resharper)

My IDE suggested to rename the `namespace` directive in the VideoViewRenderer file to match the RootNamespace.