### PR TITLE
CI: Download different mono build

### DIFF
--- a/scripts/mac-build.yml
+++ b/scripts/mac-build.yml
@@ -7,7 +7,7 @@ steps:
 - bash: |
    #!/bin/bash
    set -ex   
-   MONO_MACOS_PKG_DOWNLOAD_URL='https://download.mono-project.com/archive/6.0.0/macos-10-universal/MonoFramework-MDK-6.0.0.macos10.xamarin.universal.pkg'
+   MONO_MACOS_PKG_DOWNLOAD_URL='https://download.mono-project.com/archive/mdk-latest-vs.pkg'
    mkdir -p /tmp/mono-install
    cd /tmp/mono-install
    mono --version


### PR DESCRIPTION
This is (hopefully) a temporary change until https://developercommunity.visualstudio.com/content/problem/557330/macos-nuget-custom-sdk.html is resolved because that URL points to mono builds that change.