### PR TITLE
Core: Add runtime check in Core.Initialize to check for libvlc/libvlcsharp version mismatch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,10 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
+    <DefineConstants>$(DefineConstants);UWP;NET</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
-    <DefineConstants>$(DefineConstants);UWP;NET;UWP10_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);UWP10_0</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
-    <DefineConstants>$(DefineConstants);UWP;NET</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
+    <DefineConstants>$(DefineConstants);UWP;NET;UWP10_0</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -21,12 +21,13 @@
     </Description>
     <TargetFrameworks>netstandard2.0;netstandard1.1;net40;net471</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0;uap10.0.16299</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAWindow</TargetsForTfmSpecificBuildOutput>
     <RootNamespace>LibVLCSharp</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>7.3</LangVersion>
     <PackageVersion>3.0.0</PackageVersion>
+    <Version>$(PackageVersion)</Version>
     <PackageId>LibVLCSharp</PackageId>
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -26,8 +26,7 @@
     <RootNamespace>LibVLCSharp</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>7.3</LangVersion>
-    <PackageVersion>3.0.0</PackageVersion>
-    <Version>$(PackageVersion)</Version>
+    <Version>3.0.0</Version>
     <PackageId>LibVLCSharp</PackageId>
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>

--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -80,7 +80,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         static void EnsureVersionsMatch()
         {
-            var libvlcMajorVersion = Native.LibVLCVersion().FromUtf8()[0].ToInt();
+            var libvlcMajorVersion = int.Parse(Native.LibVLCVersion().FromUtf8().Split('.').First());
             var libvlcsharpMajorVersion = Assembly.GetExecutingAssembly().GetName().Version.Major;
             if(libvlcMajorVersion != libvlcsharpMajorVersion)
                 throw new NotSupportedException($"Version mismatch between LibVLC {libvlcMajorVersion} and LibVLCSharp {libvlcsharpMajorVersion}. " +

--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -54,6 +54,8 @@ namespace LibVLCSharp.Shared
         /// Load the native libvlc library (if necessary, depending on platform)
         /// <para/> Ensure that you installed the VideoLAN.LibVLC.[YourPlatform] package in your target project
         /// <para/> This will throw a <see cref="VLCException"/> if the native libvlc libraries cannot be found or loaded.
+        /// <para/> It may also throw a <see cref="VLCException"/> if the LibVLC and LibVLCSharp major versions do not match.
+        /// See https://code.videolan.org/videolan/LibVLCSharp/blob/master/VERSIONING.md for more info about the versioning strategy.
         /// </summary>
         /// <param name="libvlcDirectoryPath">The path to the directory that contains libvlc and libvlccore
         /// No need to specify unless running netstandard 1.1, or using custom location for libvlc
@@ -83,7 +85,7 @@ namespace LibVLCSharp.Shared
             var libvlcMajorVersion = int.Parse(Native.LibVLCVersion().FromUtf8().Split('.').First());
             var libvlcsharpMajorVersion = Assembly.GetExecutingAssembly().GetName().Version.Major;
             if(libvlcMajorVersion != libvlcsharpMajorVersion)
-                throw new NotSupportedException($"Version mismatch between LibVLC {libvlcMajorVersion} and LibVLCSharp {libvlcsharpMajorVersion}. " +
+                throw new VLCException($"Version mismatch between LibVLC {libvlcMajorVersion} and LibVLCSharp {libvlcsharpMajorVersion}. " +
                     $"They must share the same major version number");
         }
 #endif

--- a/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -471,8 +471,6 @@ namespace LibVLCSharp.Shared.Helpers
             foreach (var ptr in ptrs)
                 Marshal.FreeHGlobal(ptr);
         }
-
-        internal static int ToInt(this char c) => c - '0';
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -471,6 +471,8 @@ namespace LibVLCSharp.Shared.Helpers
             foreach (var ptr in ptrs)
                 Marshal.FreeHGlobal(ptr);
         }
+
+        internal static int ToInt(this char c) => c - '0';
     }
 
     [AttributeUsage(AttributeTargets.Method)]


### PR DESCRIPTION
Closes https://code.videolan.org/videolan/LibVLCSharp/issues/152

Should be in both `3.x` and `master`