### PR TITLE
Extend Media Configuration API

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,13 +12,13 @@
     <DefineConstants>$(DefineConstants);NET471;NET</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS'))">
-    <DefineConstants>$(DefineConstants);MONO;IOS;COCOA</DefineConstants>
+    <DefineConstants>$(DefineConstants);MONO;IOS;APPLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.Mac'))">
-    <DefineConstants>$(DefineConstants);MONO;MAC;COCOA</DefineConstants>
+    <DefineConstants>$(DefineConstants);MONO;MAC;APPLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.TVOS'))">
-    <DefineConstants>$(DefineConstants);MONO;TVOS;COCOA</DefineConstants>
+    <DefineConstants>$(DefineConstants);MONO;TVOS;APPLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -309,8 +309,7 @@ namespace LibVLCSharp.Shared
 
             foreach(var option in mediaConfiguration.Build())
             {
-                if(!string.IsNullOrWhiteSpace(option))
-                    AddOption(option);
+                AddOption(option);
             }
         }
 

--- a/LibVLCSharp/Shared/Media.cs
+++ b/LibVLCSharp/Shared/Media.cs
@@ -307,7 +307,11 @@ namespace LibVLCSharp.Shared
         {
             if (mediaConfiguration == null) throw new ArgumentNullException(nameof(mediaConfiguration));
 
-            AddOption(mediaConfiguration.Build());
+            foreach(var option in mediaConfiguration.Build())
+            {
+                if(!string.IsNullOrWhiteSpace(option))
+                    AddOption(option);
+            }
         }
 
         /// <summary>Add an option to the media with configurable flags.</summary>
@@ -1082,23 +1086,5 @@ namespace LibVLCSharp.Shared
         Playlist = 5
     }
 
-    #endregion
-
-    /// <summary>
-    /// Small configuration helper
-    /// </summary>
-    public class MediaConfiguration
-    {
-        HashSet<string> _options = new HashSet<string>();
-
-        public MediaConfiguration EnableHardwareDecoding()
-        {
-#if ANDROID
-            _options.Add(":codec=mediacodec_ndk");
-#endif
-            return this;
-        }
-
-        public string Build() => string.Join(",", _options);
-    }
+#endregion
 }

--- a/LibVLCSharp/Shared/MediaConfiguration.cs
+++ b/LibVLCSharp/Shared/MediaConfiguration.cs
@@ -61,15 +61,12 @@ namespace LibVLCSharp.Shared
 #if ANDROID
         const string ENABLE_HW_ANDROID = ":codec=mediacodec_ndk";
         const string DISABLE_HW_ANDROID = "";
-#elif IOS || TVOS
-        const string ENABLE_HW_IOS = "codec";
-        const string DISABLE_HW_IOS = "";
 #endif
+        const string ENABLE_HW_APPLE = ":videotoolbox";
         const string ENABLE_HW_WINDOWS = ":avcodec-hw=d3d11va";
-        const string ENABLE_HW_MAC = ":videotoolbox";
 
-        const string DISABLE_HW_WINDOWS =":avcodec-hw=none";
-        const string DISABLE_HW_MAC = ":no-videotoolbox";
+        const string DISABLE_HW_APPLE = ":no-videotoolbox";
+        const string DISABLE_HW_WINDOWS = ":avcodec-hw=none";
 
         private string HardwareDecodingOptionString(bool enable)
         {
@@ -77,27 +74,29 @@ namespace LibVLCSharp.Shared
             {
 #if ANDROID
                 return ENABLE_HW_ANDROID;
-#elif IOS || TVOS
-                return ENABLE_HW_IOS;
-#endif
+#elif APPLE
+                return ENABLE_HW_APPLE;
+#else
                 if (PlatformHelper.IsWindows)
                     return ENABLE_HW_WINDOWS;
                 if (PlatformHelper.IsMac)
-                    return ENABLE_HW_MAC;
+                    return ENABLE_HW_APPLE;
                 return string.Empty;
+#endif
             }
             else
             {
 #if ANDROID
                 return DISABLE_HW_ANDROID;
-#elif IOS || TVOS
-                return DISABLE_HW_IOS;
-#endif
+#elif APPLE
+                return DISABLE_HW_APPLE;
+#else
                 if (PlatformHelper.IsWindows)
                     return DISABLE_HW_WINDOWS;
                 if (PlatformHelper.IsMac)
-                    return DISABLE_HW_MAC;
+                    return DISABLE_HW_APPLE;
                 return string.Empty;
+#endif
             }
 
         }

--- a/LibVLCSharp/Shared/MediaConfiguration.cs
+++ b/LibVLCSharp/Shared/MediaConfiguration.cs
@@ -4,7 +4,8 @@ using System.Linq;
 namespace LibVLCSharp.Shared
 {
     /// <summary>
-    /// Small configuration helper
+    /// Configuration helper designed to be used for advanced libvlc configuration
+    /// <para/> More info at https://wiki.videolan.org/VLC_command-line_help/
     /// </summary>
     public class MediaConfiguration
     {
@@ -16,6 +17,9 @@ namespace LibVLCSharp.Shared
         };
 
         bool _enableHardwareDecoding;
+        /// <summary>
+        /// Enable/disable hardware decoding in a crossplatform way.
+        /// </summary>
         public bool EnableHardwareDecoding
         {
             get => _enableHardwareDecoding;
@@ -26,18 +30,29 @@ namespace LibVLCSharp.Shared
                     _options[nameof(EnableHardwareDecoding)] = HardwareDecodingOptionString(_enableHardwareDecoding);
             }
         }
+
+        /// <summary>
+        /// Caching value for local files, in milliseconds [0 .. 60000ms]
+        /// </summary>
         public int FileCaching { get; set; } = -1;
+
+        /// <summary>
+        /// Caching value for network resources, in milliseconds [0 .. 60000ms]
+        /// </summary>
         public int NetworkCaching { get; set; } = -1;
 
 #if ANDROID
         const string ENABLE_HW_ANDROID = ":codec=mediacodec_ndk";
+        const string DISABLE_HW_ANDROID = "";
 #elif IOS || TVOS
-        const string ENABLE_HW_IOS = "";
+        const string ENABLE_HW_IOS = "codec";
+        const string DISABLE_HW_IOS = "";
 #endif
         const string ENABLE_HW_WINDOWS = ":avcodec-hw=d3d11va";
-        const string ENABLE_HW_MAC = "";
+        const string ENABLE_HW_MAC = ":videotoolbox";
 
-        const string DISABLE_HW_WINDOWS = ":avcodec-hw=none";
+        const string DISABLE_HW_WINDOWS =":avcodec-hw=none";
+        const string DISABLE_HW_MAC = ":no-videotoolbox";
 
         private string HardwareDecodingOptionString(bool enable)
         {
@@ -46,19 +61,26 @@ namespace LibVLCSharp.Shared
 #if ANDROID
                 return ENABLE_HW_ANDROID;
 #elif IOS || TVOS
-                
+                return ENABLE_HW_IOS;
 #endif
                 if (PlatformHelper.IsWindows)
                     return ENABLE_HW_WINDOWS;
                 if (PlatformHelper.IsMac)
                     return ENABLE_HW_MAC;
-                return "";
+                return string.Empty;
             }
             else
             {
+#if ANDROID
+                return DISABLE_HW_ANDROID;
+#elif IOS || TVOS
+                return DISABLE_HW_IOS;
+#endif
                 if (PlatformHelper.IsWindows)
                     return DISABLE_HW_WINDOWS;
-                return "";
+                if (PlatformHelper.IsMac)
+                    return DISABLE_HW_MAC;
+                return string.Empty;
             }
 
         }

--- a/LibVLCSharp/Shared/MediaConfiguration.cs
+++ b/LibVLCSharp/Shared/MediaConfiguration.cs
@@ -26,20 +26,37 @@ namespace LibVLCSharp.Shared
             set
             {
                 _enableHardwareDecoding = value;
-                if (_enableHardwareDecoding)
-                    _options[nameof(EnableHardwareDecoding)] = HardwareDecodingOptionString(_enableHardwareDecoding);
+                _options[nameof(EnableHardwareDecoding)] = HardwareDecodingOptionString(_enableHardwareDecoding);
             }
         }
 
+        int _fileCaching;
         /// <summary>
         /// Caching value for local files, in milliseconds [0 .. 60000ms]
         /// </summary>
-        public int FileCaching { get; set; } = -1;
+        public int FileCaching
+        {
+            get => _fileCaching;
+            set
+            {
+                _fileCaching = value;
+                _options[nameof(FileCaching)] = _fileCaching.ToString();
+            }
+        }
 
+        int _networkCaching;
         /// <summary>
         /// Caching value for network resources, in milliseconds [0 .. 60000ms]
         /// </summary>
-        public int NetworkCaching { get; set; } = -1;
+        public int NetworkCaching
+        {
+            get => _networkCaching;
+            set
+            {
+                _networkCaching = value;
+                _options[nameof(NetworkCaching)] = _networkCaching.ToString();
+            }
+        }
 
 #if ANDROID
         const string ENABLE_HW_ANDROID = ":codec=mediacodec_ndk";
@@ -85,6 +102,10 @@ namespace LibVLCSharp.Shared
 
         }
 
+        /// <summary>
+        /// Builds the current MediaConfiguration for consumption by libvlc (or storage)
+        /// </summary>
+        /// <returns></returns>
         public string[] Build() => _options.Values.ToArray();
     }
 }

--- a/LibVLCSharp/Shared/MediaConfiguration.cs
+++ b/LibVLCSharp/Shared/MediaConfiguration.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace LibVLCSharp.Shared
+{
+    /// <summary>
+    /// Small configuration helper
+    /// </summary>
+    public class MediaConfiguration
+    {
+        readonly Dictionary<string, string> _options = new Dictionary<string, string>
+        {
+            { nameof(EnableHardwareDecoding), string.Empty },
+            { nameof(FileCaching), string.Empty },
+            { nameof(NetworkCaching), string.Empty },
+        };
+
+        bool _enableHardwareDecoding;
+        public bool EnableHardwareDecoding
+        {
+            get => _enableHardwareDecoding;
+            set
+            {
+                _enableHardwareDecoding = value;
+                if (_enableHardwareDecoding)
+                    _options[nameof(EnableHardwareDecoding)] = HardwareDecodingOptionString(_enableHardwareDecoding);
+            }
+        }
+        public int FileCaching { get; set; } = -1;
+        public int NetworkCaching { get; set; } = -1;
+
+#if ANDROID
+        const string ENABLE_HW_ANDROID = ":codec=mediacodec_ndk";
+#elif IOS || TVOS
+        const string ENABLE_HW_IOS = "";
+#endif
+        const string ENABLE_HW_WINDOWS = ":avcodec-hw=d3d11va";
+        const string ENABLE_HW_MAC = "";
+
+        const string DISABLE_HW_WINDOWS = ":avcodec-hw=none";
+
+        private string HardwareDecodingOptionString(bool enable)
+        {
+            if(enable)
+            {
+#if ANDROID
+                return ENABLE_HW_ANDROID;
+#elif IOS || TVOS
+                
+#endif
+                if (PlatformHelper.IsWindows)
+                    return ENABLE_HW_WINDOWS;
+                if (PlatformHelper.IsMac)
+                    return ENABLE_HW_MAC;
+                return "";
+            }
+            else
+            {
+                if (PlatformHelper.IsWindows)
+                    return DISABLE_HW_WINDOWS;
+                return "";
+            }
+
+        }
+
+        public string[] Build() => _options.Values.ToArray();
+    }
+}

--- a/LibVLCSharp/Shared/MediaConfiguration.cs
+++ b/LibVLCSharp/Shared/MediaConfiguration.cs
@@ -18,7 +18,7 @@ namespace LibVLCSharp.Shared
 
         bool _enableHardwareDecoding;
         /// <summary>
-        /// Enable/disable hardware decoding in a crossplatform way.
+        /// Enable/disable hardware decoding (crossplatform).
         /// </summary>
         public bool EnableHardwareDecoding
         {
@@ -104,7 +104,7 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Builds the current MediaConfiguration for consumption by libvlc (or storage)
         /// </summary>
-        /// <returns></returns>
-        public string[] Build() => _options.Values.ToArray();
+        /// <returns>Configured libvlc options as strings</returns>
+        public string[] Build() => _options.Values.Where(option => !string.IsNullOrEmpty(option)).ToArray();
     }
 }

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -664,7 +664,11 @@ namespace LibVLCSharp.Shared
         /// If playback was already started, this method has no effect
         /// </summary>
         /// <returns>true if successful</returns>
-        public bool Play() => Native.LibVLCMediaPlayerPlay(NativeReference) == 0;
+        public bool Play()
+        {
+            Media.AddOption(Configuration);
+            return Native.LibVLCMediaPlayerPlay(NativeReference) == 0;
+        }
 
         /// <summary>
         /// Set media and start playback
@@ -1662,6 +1666,26 @@ namespace LibVLCSharp.Shared
         /// <summary>Increments the native reference counter for this mediaplayer instance</summary>
         internal void Retain() => Native.LibVLCMediaPlayerRetain(NativeReference);
 
+        public bool EnableHardwareDecoding
+        {
+            get => Configuration.EnableHardwareDecoding;
+            set => Configuration.EnableHardwareDecoding = value;
+        }
+
+        public int FileCaching
+        {
+            get => Configuration.FileCaching;
+            set => Configuration.FileCaching = value;
+        }
+
+        public int NetworkCaching
+        {
+            get => Configuration.NetworkCaching;
+            set => Configuration.NetworkCaching = value;
+        }
+
+        MediaConfiguration Configuration = new MediaConfiguration();
+
 #if UNITY_ANDROID
         /// <summary>
         /// Retrieve a video frame from the Unity plugin.
@@ -1676,7 +1700,7 @@ namespace LibVLCSharp.Shared
         }
 #endif
 
-#region Callbacks
+        #region Callbacks
 
         /// <summary>
         /// <para>A LibVLC media player plays one media (usually in a custom drawable).</para>
@@ -1879,7 +1903,8 @@ namespace LibVLCSharp.Shared
             }
         }
 
-#region events
+
+        #region events
 
         public event EventHandler<MediaPlayerMediaChangedEventArgs> MediaChanged
         {

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -666,7 +666,7 @@ namespace LibVLCSharp.Shared
         /// <returns>true if successful</returns>
         public bool Play()
         {
-            Media.AddOption(Configuration);
+            Media?.AddOption(Configuration);
             return Native.LibVLCMediaPlayerPlay(NativeReference) == 0;
         }
 

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1666,18 +1666,27 @@ namespace LibVLCSharp.Shared
         /// <summary>Increments the native reference counter for this mediaplayer instance</summary>
         internal void Retain() => Native.LibVLCMediaPlayerRetain(NativeReference);
 
+        /// <summary>
+        /// Enable/disable hardware decoding in a crossplatform way.
+        /// </summary>
         public bool EnableHardwareDecoding
         {
             get => Configuration.EnableHardwareDecoding;
             set => Configuration.EnableHardwareDecoding = value;
         }
 
+        /// <summary>
+        /// Caching value for local files, in milliseconds [0 .. 60000ms]
+        /// </summary>
         public int FileCaching
         {
             get => Configuration.FileCaching;
             set => Configuration.FileCaching = value;
         }
 
+        /// <summary>
+        /// Caching value for network resources, in milliseconds [0 .. 60000ms]
+        /// </summary>
         public int NetworkCaching
         {
             get => Configuration.NetworkCaching;

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -64,7 +64,7 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_media_player_stop")]
             internal static extern void LibVLCMediaPlayerStop(IntPtr mediaPlayer);
 
-#if COCOA || NET || NETSTANDARD
+#if APPLE || NET || NETSTANDARD
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_nsobject")]
             internal static extern void LibVLCMediaPlayerSetNsobject(IntPtr mediaPlayer, IntPtr drawable);
@@ -701,7 +701,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         public void Stop() => Native.LibVLCMediaPlayerStop(NativeReference);
 
-#if COCOA || NET || NETSTANDARD
+#if APPLE || NET || NETSTANDARD
         /// <summary>
         /// Get the NSView handler previously set
         /// return the NSView handler or 0 if none where set

--- a/Samples/LibVLCSharp.Android.Sample/MainActivity.cs
+++ b/Samples/LibVLCSharp.Android.Sample/MainActivity.cs
@@ -37,9 +37,6 @@ namespace LibVLCSharp.Android.Sample
             _videoView = new VideoView(this) { MediaPlayer = _mediaPlayer };
             AddContentView(_videoView, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent));
             var media = new Media(_libVLC, "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4", FromType.FromLocation);
-            //var configuration = new MediaConfiguration();
-            //configuration.EnableHardwareDecoding();
-            //media.AddOption(configuration);
             _videoView.MediaPlayer.Play(media);
         }
 

--- a/Samples/LibVLCSharp.Android.Sample/MainActivity.cs
+++ b/Samples/LibVLCSharp.Android.Sample/MainActivity.cs
@@ -29,14 +29,17 @@ namespace LibVLCSharp.Android.Sample
             Core.Initialize();
 
             _libVLC = new LibVLC();
-            _mediaPlayer = new MediaPlayer(_libVLC);
+            _mediaPlayer = new MediaPlayer(_libVLC)
+            {
+                EnableHardwareDecoding = true
+            };
 
             _videoView = new VideoView(this) { MediaPlayer = _mediaPlayer };
             AddContentView(_videoView, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent));
             var media = new Media(_libVLC, "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4", FromType.FromLocation);
-            var configuration = new MediaConfiguration();
-            configuration.EnableHardwareDecoding();
-            media.AddOption(configuration);
+            //var configuration = new MediaConfiguration();
+            //configuration.EnableHardwareDecoding();
+            //media.AddOption(configuration);
             _videoView.MediaPlayer.Play(media);
         }
 


### PR DESCRIPTION
Extend the media configuration helper:
- Works on both MediaPlayer and Media
- Add HW configuration support for more platforms (can be called from shared code)
Tested:
- [x] Android (existing) 
- [x] iOS
- [x] Windows
- [x] macOS (should be the same as iOS)
- Add network and file caching options

https://code.videolan.org/videolan/LibVLCSharp/issues/132

Will squash.