### PR TITLE
Add VideoView's DataContext passthrough to Foreground window

### DIFF
--- a/LibVLCSharp.WPF/VideoView.cs
+++ b/LibVLCSharp.WPF/VideoView.cs
@@ -60,7 +60,8 @@ namespace LibVLCSharp.WPF
                 {
                     ForegroundWindow = new ForegroundWindow(windowsFormsHost)
                     {
-                        Content = ViewContent
+                        Content = ViewContent,
+                        DataContext = windowsFormsHost.DataContext
                     };
                 }
 


### PR DESCRIPTION
This allows video overlaying elements inside XAML \<VideoView\> tag to be data bound to viewmodel's properties in MVVM scenarios.