### PR TITLE
Refactored WPF DataContext passthrough

### DIFF
--- a/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -30,9 +30,17 @@ namespace LibVLCSharp.WPF
         {
             InitializeComponent();
 
+            this.DataContext = background.DataContext;
+
             _bckgnd = background;
+            _bckgnd.DataContextChanged += Background_DataContextChanged;
             _bckgnd.Loaded += Background_Loaded;
             _bckgnd.Unloaded += Background_Unloaded;
+        }
+
+        void Background_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            this.DataContext = e.NewValue;
         }
 
         void Background_Unloaded(object sender, RoutedEventArgs e)

--- a/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace LibVLCSharp.WPF
         {
             InitializeComponent();
 
-            this.DataContext = background.DataContext;
+            DataContext = background.DataContext;
 
             _bckgnd = background;
             _bckgnd.DataContextChanged += Background_DataContextChanged;
@@ -40,7 +40,7 @@ namespace LibVLCSharp.WPF
 
         void Background_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            this.DataContext = e.NewValue;
+            DataContext = e.NewValue;
         }
 
         void Background_Unloaded(object sender, RoutedEventArgs e)

--- a/LibVLCSharp.WPF/VideoView.cs
+++ b/LibVLCSharp.WPF/VideoView.cs
@@ -60,8 +60,7 @@ namespace LibVLCSharp.WPF
                 {
                     ForegroundWindow = new ForegroundWindow(windowsFormsHost)
                     {
-                        Content = ViewContent,
-                        DataContext = windowsFormsHost.DataContext
+                        Content = ViewContent
                     };
                 }
 


### PR DESCRIPTION
We now subscribe to the DataContextChanged event to make sure the
DataContext is always in sync with the outside

This is a follow-up of the discussion in #54 