### PR TITLE
WPF - ALT+F4 issue

### DIFF
--- a/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Windows;
+using System.Windows.Input;
 
 namespace LibVLCSharp.WPF
 {
@@ -107,6 +108,14 @@ namespace LibVLCSharp.WPF
         void Wndhost_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             Close();
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Key == Key.System && e.SystemKey == Key.F4)
+            {
+                _wndhost.Focus();
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Move the focus to the parent window when ALT+F4 is pressed to avoid closing only the Foreground window.

### Issues Resolved ### 

None

### API Changes ###

 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###

When the user hits ALT+F4, it closes the background window instead of the foreground window.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

With the WPF sample, (Example 1 and Example 2):
- click on the play button -> media starts playing
- hit Alt+f4 -> the background window is closed, not only the foreground window

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
