### PR TITLE
Core: Fix size_t C# interop

### DIFF
--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -118,11 +118,11 @@ namespace LibVLCSharp.Shared
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_discoverer_list_get")]
-            internal static extern ulong LibVLCMediaDiscovererListGet(IntPtr libVLC, MediaDiscovererCategory category, out IntPtr pppServices);
+            internal static extern UIntPtr LibVLCMediaDiscovererListGet(IntPtr libVLC, MediaDiscovererCategory category, out IntPtr pppServices);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_discoverer_list_release")]
-            internal static extern void LibVLCMediaDiscovererListRelease(IntPtr ppServices, ulong count);
+            internal static extern void LibVLCMediaDiscovererListRelease(IntPtr ppServices, UIntPtr count);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_dialog_set_callbacks")]
@@ -130,11 +130,11 @@ namespace LibVLCSharp.Shared
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_renderer_discoverer_list_get")]
-            internal static extern ulong LibVLCRendererDiscovererGetList(IntPtr libVLC, out IntPtr discovererList);
+            internal static extern UIntPtr LibVLCRendererDiscovererGetList(IntPtr libVLC, out IntPtr discovererList);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_renderer_discoverer_list_release")]
-            internal static extern void LibVLCRendererDiscovererReleaseList(IntPtr discovererList, ulong count);
+            internal static extern void LibVLCRendererDiscovererReleaseList(IntPtr discovererList, UIntPtr count);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_retain")]


### PR DESCRIPTION
### Description of Change ###

ulong is not always correct for size_t marshaling. 

Use UIntPtr for P/Invoke and cast to uint or ulong depending on bitness.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/217

### API Changes ### 
 None

### Platforms Affected ### 

- Core (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Try running `_libVLC.RendererList.FirstOrDefault(r => r.Name.Equals("microdns_renderer"));` in release mode on device. Crashes in the `libvlc_renderer_discoverer_list_release` native call because of wrong count param.

With the fix, it works fine (release/debug/device/x86-sim). No public API change.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
