### PR TITLE
Improvement/warnings as errors

### DIFF
--- a/LibVLCSharp.Forms.Platforms.GTK/LibVLCSharp.Forms.Platforms.GTK.csproj
+++ b/LibVLCSharp.Forms.Platforms.GTK/LibVLCSharp.Forms.Platforms.GTK.csproj
@@ -15,7 +15,8 @@ Xamarin.Forms support for other platforms are in different packages (namely LibV
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://code.videolan.org/videolan/LibVLCSharp</RepositoryUrl>

--- a/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms.Platforms.GTK/VideoViewRenderer.cs
@@ -7,10 +7,17 @@ using Xamarin.Forms.Platform.GTK;
 [assembly: ExportRenderer(typeof(LibVLCSharp.Forms.Shared.VideoView), typeof(VideoViewRenderer))]
 namespace LibVLCSharp.Forms.Platforms.GTK
 {
+    /// <summary>
+    /// Xamarin.Forms renderer for the VideoView on GTK
+    /// </summary>
     public class VideoViewRenderer : ViewRenderer<LibVLCSharp.Forms.Shared.VideoView, LibVLCSharp.GTK.VideoView>
     {
         LibVLCSharp.GTK.VideoView _videoView;
 
+        /// <summary>
+        /// Native control management during lifecycle events
+        /// </summary>
+        /// <param name="e">lifecycle event</param>
         protected override void OnElementChanged(ElementChangedEventArgs<VideoView> e)
         {
             base.OnElementChanged(e);
@@ -45,6 +52,10 @@ namespace LibVLCSharp.Forms.Platforms.GTK
             Control.MediaPlayer = e.NewMediaPlayer;
         }
 
+        /// <summary>
+        /// Dispose of the videoview, if any
+        /// </summary>
+        /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/LibVLCSharp.Forms.Platforms.WPF/LibVLCSharp.Forms.Platforms.WPF.csproj
+++ b/LibVLCSharp.Forms.Platforms.WPF/LibVLCSharp.Forms.Platforms.WPF.csproj
@@ -15,7 +15,8 @@ Xamarin.Forms support for other platforms are in different packages (namely LibV
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://code.videolan.org/videolan/LibVLCSharp</RepositoryUrl>

--- a/LibVLCSharp.Forms.Platforms.WPF/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms.Platforms.WPF/VideoViewRenderer.cs
@@ -6,8 +6,15 @@ using Xamarin.Forms.Platform.WPF;
 [assembly: ExportRenderer(typeof(VideoView), typeof(VideoViewRenderer))]
 namespace LibVLCSharp.Forms.Platforms.WPF
 {
+    /// <summary>
+    /// Xamarin.Forms renderer for the VideoView on WPF
+    /// </summary>
     public class VideoViewRenderer : ViewRenderer<VideoView, LibVLCSharp.WPF.VideoView>
     {
+        /// <summary>
+        /// Native control management during lifecycle events
+        /// </summary>
+        /// <param name="e">lifecycle event</param>
         protected override void OnElementChanged(ElementChangedEventArgs<VideoView> e)
         {
             base.OnElementChanged(e);

--- a/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
+++ b/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
@@ -21,7 +21,8 @@ Xamarin.Forms support for GTK and WPF are in separate packages. LibVLC needs to 
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>

--- a/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
@@ -10,12 +10,23 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ExportRenderer(typeof(VideoView), typeof(VideoViewRenderer))]
 namespace LibVLCSharp.Forms.Platforms.Android
 {
+    /// <summary>
+    /// Xamarin.Forms custom renderer for the Android VideoView
+    /// </summary>
     public class VideoViewRenderer : ViewRenderer<LibVLCSharp.Forms.Shared.VideoView, LibVLCSharp.Platforms.Android.VideoView>
     {
+        /// <summary>
+        /// Main constructor (empty)
+        /// </summary>
+        /// <param name="context">Android context</param>
         public VideoViewRenderer(Context context) : base(context)
         {
         }
 
+        /// <summary>
+        /// Native control management during lifecycle events
+        /// </summary>
+        /// <param name="e">lifecycle event</param>
         protected override void OnElementChanged(ElementChangedEventArgs<VideoView> e)
         {
             base.OnElementChanged(e);

--- a/LibVLCSharp.Forms/Platforms/Mac/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/Mac/VideoViewRenderer.cs
@@ -9,8 +9,15 @@ using Xamarin.Forms.Platform.MacOS;
 [assembly: ExportRenderer(typeof(VideoView), typeof(VideoViewRenderer))]
 namespace LibVLCSharp.Forms.Platforms.Mac
 {
+    /// <summary>
+    /// Xamarin.Forms custom renderer for the macOS VideoView
+    /// </summary>
     public class VideoViewRenderer : ViewRenderer<LibVLCSharp.Forms.Shared.VideoView, LibVLCSharp.Platforms.Mac.VideoView>
     {
+        /// <summary>
+        /// Native control management during lifecycle events
+        /// </summary>
+        /// <param name="e">lifecycle event</param>
         protected override void OnElementChanged(ElementChangedEventArgs<VideoView> e)
         {
             base.OnElementChanged(e);

--- a/LibVLCSharp.Forms/Platforms/iOS/VideoViewRenderer.cs
+++ b/LibVLCSharp.Forms/Platforms/iOS/VideoViewRenderer.cs
@@ -9,9 +9,16 @@ using Foundation;
 [assembly: ExportRenderer(typeof(LibVLCSharp.Forms.Shared.VideoView), typeof(VideoViewRenderer))]
 namespace LibVLCSharp.Forms.Platforms.iOS
 {
+    /// <summary>
+    /// Xamarin.Forms custom renderer for the iOS VideoView
+    /// </summary>
     [Preserve(AllMembers = true)]
     public class VideoViewRenderer : ViewRenderer<LibVLCSharp.Forms.Shared.VideoView, LibVLCSharp.Platforms.iOS.VideoView>
     {
+        /// <summary>
+        /// Native control management during lifecycle events
+        /// </summary>
+        /// <param name="e">lifecycle event</param>
         protected override void OnElementChanged(ElementChangedEventArgs<LibVLCSharp.Forms.Shared.VideoView> e)
         {
             base.OnElementChanged(e);

--- a/LibVLCSharp.Forms/Shared/VideoView.cs
+++ b/LibVLCSharp.Forms/Shared/VideoView.cs
@@ -5,6 +5,9 @@ using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Shared
 {
+    /// <summary>
+    /// Generic Xamarin.Forms VideoView
+    /// </summary>
     public class VideoView : View
     {
         /// <summary>
@@ -17,6 +20,9 @@ namespace LibVLCSharp.Forms.Shared
         /// </summary>
         public event EventHandler<MediaPlayerChangedEventArgs> MediaPlayerChanged;
 
+        /// <summary>
+        /// Xamarin.Forms MediaPlayer databinded property
+        /// </summary>
         public static readonly BindableProperty MediaPlayerProperty = BindableProperty.Create(nameof(MediaPlayer),
                 typeof(LibVLCSharp.Shared.MediaPlayer),
                 typeof(VideoView),

--- a/LibVLCSharp.GTK/LibVLCSharp.GTK.csproj
+++ b/LibVLCSharp.GTK/LibVLCSharp.GTK.csproj
@@ -19,7 +19,8 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>

--- a/LibVLCSharp.GTK/VideoView.cs
+++ b/LibVLCSharp.GTK/VideoView.cs
@@ -44,6 +44,9 @@ namespace LibVLCSharp.GTK
 
         private MediaPlayer _mediaPlayer;
 
+        /// <summary>
+        /// GTK VideoView constructor
+        /// </summary>
         public VideoView()
         {
             Color black = Color.Zero;
@@ -53,6 +56,9 @@ namespace LibVLCSharp.GTK
             Realized += (s, e) => Attach();
         }
 
+        /// <summary>
+        /// The MediaPlayer property for that GTK VideoView
+        /// </summary>
         public MediaPlayer MediaPlayer
         {
             get
@@ -122,6 +128,9 @@ namespace LibVLCSharp.GTK
             }
         }
 
+        /// <summary>
+        /// Detaches the MediaPlayer before disposing
+        /// </summary>
         public override void Dispose()
         {
             Detach();

--- a/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
+++ b/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
@@ -21,7 +21,8 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>

--- a/LibVLCSharp.WPF/VideoView.cs
+++ b/LibVLCSharp.WPF/VideoView.cs
@@ -8,6 +8,9 @@ using System.Windows.Forms.Integration;
 
 namespace LibVLCSharp.WPF
 {
+    /// <summary>
+    /// WPF VideoView with databinding for use with LibVLCSharp
+    /// </summary>
     [TemplatePart(Name = PART_PlayerHost, Type = typeof(WindowsFormsHost))]
     [TemplatePart(Name = PART_PlayerView, Type = typeof(System.Windows.Forms.Panel))]
     public class VideoView : ContentControl, IVideoView, IDisposable
@@ -15,16 +18,25 @@ namespace LibVLCSharp.WPF
         private const string PART_PlayerHost = "PART_PlayerHost";
         private const string PART_PlayerView = "PART_PlayerView";
 
+        /// <summary>
+        /// WPF VideoView constructor
+        /// </summary>
         public VideoView()
         {
             DefaultStyleKey = typeof(VideoView);
         }
 
+        /// <summary>
+        /// MediaPlayer WPF databinding property
+        /// </summary>
         public static readonly DependencyProperty MediaPlayerProperty = DependencyProperty.Register(nameof(MediaPlayer),
                 typeof(MediaPlayer),
                 typeof(VideoView),
                 new PropertyMetadata(null, OnMediaPlayerChanged));
 
+        /// <summary>
+        /// MediaPlayer property for this VideoView
+        /// </summary>
         public MediaPlayer MediaPlayer
         {
             get { return GetValue(MediaPlayerProperty) as MediaPlayer; }
@@ -49,6 +61,9 @@ namespace LibVLCSharp.WPF
         private UIElement ViewContent { get; set; }
         private IntPtr Hwnd { get; set; }
 
+        /// <summary>
+        /// ForegroundWindow management and MediaPlayer setup.
+        /// </summary>
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
@@ -81,6 +96,11 @@ namespace LibVLCSharp.WPF
             }
         }
 
+        /// <summary>
+        /// Override to update the foreground window content
+        /// </summary>
+        /// <param name="oldContent">old content</param>
+        /// <param name="newContent">new content</param>
         protected override void OnContentChanged(object oldContent, object newContent)
         {
             base.OnContentChanged(oldContent, newContent);
@@ -110,6 +130,10 @@ namespace LibVLCSharp.WPF
         #region IDisposable Support
 
         bool disposedValue;
+        /// <summary>
+        /// Unhook mediaplayer and dispose foreground window
+        /// </summary>
+        /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
             if (!disposedValue)
@@ -129,6 +153,9 @@ namespace LibVLCSharp.WPF
             }
         }
 
+        /// <summary>
+        /// Unhook mediaplayer and dispose foreground window
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/LibVLCSharp.WinForms/LibVLCSharp.WinForms.csproj
+++ b/LibVLCSharp.WinForms/LibVLCSharp.WinForms.csproj
@@ -18,7 +18,8 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>

--- a/LibVLCSharp.WinForms/VideoView.cs
+++ b/LibVLCSharp.WinForms/VideoView.cs
@@ -92,6 +92,11 @@ namespace LibVLCSharp.WinForms
         }
 
         bool disposedValue;
+
+        /// <summary>
+        /// Detaches the MediaPlayer from this VideoView
+        /// </summary>
+        /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
             if (!disposedValue)


### PR DESCRIPTION
### Description of Change ###

```
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
```

This will help enforce higher code documentation and quality by failing the build in case of warnings. Most current warnings are about missing documentation on public APIs. This will help enforce documentation in the future.

Only LibVLCSharp is left to fix (lots of comments need to be added).

### Platforms Affected ### 

- Core (all platforms)