### PR TITLE
Fix libvlc logs bugs

### DIFF
--- a/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -120,30 +120,30 @@ namespace LibVLCSharp.Shared.Helpers
 
         static string UseStructurePointer<T>(T structure, Func<IntPtr, string> action)
         {
-            var listPointer = IntPtr.Zero;
+            var structurePointer = IntPtr.Zero;
             try
             {
-                listPointer = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
-                Marshal.StructureToPtr(structure, listPointer, false);
-                return action(listPointer);
+                structurePointer = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
+                Marshal.StructureToPtr(structure, structurePointer, false);
+                return action(structurePointer);
             }
             finally
             {
-                Marshal.FreeHGlobal(listPointer);
+                Marshal.FreeHGlobal(structurePointer);
             }
         }
 
         static void UseStructurePointer<T>(T structure, Action<IntPtr> action)
         {
-            var listPointer = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
+            var structurePointer = Marshal.AllocHGlobal(Marshal.SizeOf(structure));
             try
             {
-                Marshal.StructureToPtr(structure, listPointer, false);
-                action(listPointer);
+                Marshal.StructureToPtr(structure, structurePointer, false);
+                action(structurePointer);
             }
             finally
             {
-                Marshal.FreeHGlobal(listPointer);
+                Marshal.FreeHGlobal(structurePointer);
             }
         }
 

--- a/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -53,6 +53,32 @@ namespace LibVLCSharp.Shared.Helpers
 
             [DllImport(Constants.Msvcrt, EntryPoint = "vsprintf", CallingConvention = CallingConvention.Cdecl)]
             public static extern int vsprintf_windows(IntPtr buffer, IntPtr format, IntPtr args);
+
+            [DllImport(Constants.libSystem, EntryPoint = "vsnprintf", CallingConvention = CallingConvention.Cdecl)]
+            public static extern int vsnprintf_apple(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args);
+
+            [DllImport(Constants.Libc, EntryPoint = "vsnprintf", CallingConvention = CallingConvention.Cdecl)]
+            public static extern int vsnprintf_linux(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args);
+
+            [DllImport(Constants.Msvcrt, EntryPoint = "vsnprintf", CallingConvention = CallingConvention.Cdecl)]
+            public static extern int vsnprintf_windows(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args);
+        }
+
+        internal static int vsnprintf(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args)
+        {
+#if ANDROID
+            return Native.vsnprintf_linux(buffer, size, format, args);
+#elif APPLE
+            return Native.vsnprintf_apple(buffer, size, format, args);
+#else
+            if (PlatformHelper.IsWindows)
+                return Native.vsnprintf_windows(buffer, size, format, args);
+            else if (PlatformHelper.IsMac)
+                return Native.vsnprintf_apple(buffer, size, format, args);
+            else if (PlatformHelper.IsLinux)
+                return Native.vsnprintf_linux(buffer, size, format, args);
+            return -1;
+#endif
         }
 
         internal static int vsprintf(IntPtr buffer, IntPtr format, IntPtr args)

--- a/LibVLCSharp/Shared/Helpers/PlatformHelper.cs
+++ b/LibVLCSharp/Shared/Helpers/PlatformHelper.cs
@@ -27,6 +27,15 @@ namespace LibVLCSharp.Shared
 #endif
         }
 
+        public static bool IsLinuxDesktop
+        {
+#if ANDROID
+            get => false;
+#else
+            get => IsLinux;
+#endif
+        }
+
         public static bool IsMac
         {
 #if NET40 || UWP

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -634,7 +634,7 @@ namespace LibVLCSharp.Shared
 
             var gch = GCHandle.FromIntPtr(data);
 
-            if (!gch.IsAllocated || !(gch.Target is LibVLC libvlc))
+            if (!gch.IsAllocated || !(gch.Target is LibVLC libvlc) || libvlc.IsDisposed)
                 return;
 
             try
@@ -643,9 +643,9 @@ namespace LibVLCSharp.Shared
 
                 GetLogContext(ctx, out var module, out var file, out var line);
 #if NET40
-                Task.Factory.StartNew(() => libvlc?._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
+                Task.Factory.StartNew(() => libvlc._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
 #else
-                Task.Run(() => libvlc?._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
+                Task.Run(() => libvlc._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
 #endif
             }
             catch

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -648,6 +648,7 @@ namespace LibVLCSharp.Shared
                 Task.Run(() => libvlc._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
 #endif
             }
+            // Silently catching OOM exceptions and others as this is not critical if it fails
             catch
             {
             }

--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -643,9 +643,9 @@ namespace LibVLCSharp.Shared
 
                 GetLogContext(ctx, out var module, out var file, out var line);
 #if NET40
-                Task.Factory.StartNew(() => libvlc._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
+                Task.Factory.StartNew(() => libvlc?._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
 #else
-                Task.Run(() => libvlc._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
+                Task.Run(() => libvlc?._log?.Invoke(null, new LogEventArgs(level, message, module, file, line)));
 #endif
             }
             catch


### PR DESCRIPTION
### Description of Change ###

- Fix logging on all instances bug.
- Fix linux crash by allocating dynamically buffer size.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/213
- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/216

### API Changes ###

 None

### Platforms Affected ### 

- Core (all platforms)

### Testing Procedure ###

Try enabling/disabling logging on all supported platforms and devices and see if it works fine.

- [x] Windows
- [x] Android
- [ ] iOS
- [ ] macOS
- [x] Linux

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
