### PR TITLE
Fix video lock and format callback signatures to match libvlc

### DIFF
--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -1741,7 +1741,7 @@ namespace LibVLCSharp.Shared
         /// <para>planes must be aligned on 32-bytes boundaries.</para>
         /// </remarks>
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate IntPtr LibVLCVideoLockCb(IntPtr opaque, IntPtr planes);
+        public delegate IntPtr LibVLCVideoLockCb(IntPtr opaque, out IntPtr planes);
 
         /// <summary>Callback prototype to unlock a picture buffer.</summary>
         /// <param name="opaque">private pointer as passed to libvlc_video_set_callbacks() [IN]</param>
@@ -1799,8 +1799,8 @@ namespace LibVLCSharp.Shared
         /// <para>to not break assumptions that might be held by optimized code</para>
         /// <para>in the video decoders, video filters and/or video converters.</para>
         /// </remarks>
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate uint LibVLCVideoFormatCb(ref IntPtr userData, IntPtr chroma, ref uint width,
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public delegate uint LibVLCVideoFormatCb(ref IntPtr userData, ref uint chroma, ref uint width,
             ref uint height, ref uint pitches, ref uint lines);
 
         /// <summary>Callback prototype to configure picture buffers format.</summary>


### PR DESCRIPTION
### Description of Change ###

Fixed callback signatures of LibVLCVideoLockCb and LibVLCVideoFormatCb to match libvlc and the comment blocks above.

IntPtr planes -> out IntPtr planes as it is [OUT]
IntPtr chroma -> ref uint chroma as it is [IN/OUT] and always 4 bytes (not platform dependent)

### Issues Resolved ### 
Fixes #219 (https://code.videolan.org/videolan/LibVLCSharp/issues/219)

### API Changes ###
Changed signature of LibVLCVideoLockCb and LibVLCVideoFormatCb to match libvlc

### Platforms Affected ### 
- Core (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Tested callbacks now work by rendering an I420 video to a RV32 (RGBA) image in WPF
More testing not likely to be required as the signatures are being fixed to match libvlc

### PR Checklist ###

- [*] Rebased on top of the target branch at time of PR
- [*] Changes adhere to coding standard
