### PR TITLE
WinForms/WPF .NET Core 3 support for LibVLCSharp

### DIFF
--- a/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
+++ b/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
@@ -11,13 +11,14 @@ in a WPF app. It depends on LibVLCSharp.
 
 LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     </Description> 
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>LibVLCSharp.WPF</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>7.3</LangVersion>
     <Version>3.2.3</Version>
     <PackageId>LibVLCSharp.WPF</PackageId>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
@@ -31,7 +32,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <PackageReleaseNotes>https://code.videolan.org/videolan/LibVLCSharp/blob/master/NEWS</PackageReleaseNotes>
     <PackageTags>libvlc;vlc;videolan;native;c/c++;video;audio;player;media;mediaplayer;codec;ffmpeg;xamarin;graphics;ios;android;linux;windows;macos;cross-platform</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="WindowsFormsIntegration" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
@@ -50,6 +51,6 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     </Page>
     <Page Remove="**\App.xaml" />
     <ApplicationDefinition Include="**\App.xaml" />
-    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xaml" Condition="'$(TargetFramework)'=='net461'"/>
   </ItemGroup>
 </Project>

--- a/LibVLCSharp.WinForms/LibVLCSharp.WinForms.csproj
+++ b/LibVLCSharp.WinForms/LibVLCSharp.WinForms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <Title>LibVLCSharp.WinForms</Title>
     <Summary>WinForms integration for LibVLCSharp</Summary>
@@ -11,7 +11,8 @@ in a Windows Forms app. It depends on LibVLCSharp.
 
 LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     </Description>
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp3.0</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>LibVLCSharp.WinForms</RootNamespace>
     <Version>3.2.3</Version>
     <PackageId>LibVLCSharp.WinForms</PackageId>
@@ -31,7 +32,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
   <ItemGroup>
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 </Project>

--- a/Samples/LibVLCSharp.WinForms.Sample/LibVLCSharp.WinForms.Sample.csproj
+++ b/Samples/LibVLCSharp.WinForms.Sample/LibVLCSharp.WinForms.Sample.csproj
@@ -2,16 +2,19 @@
   <PropertyGroup>
     <Title>LibVLCSharp.WinForms.Sample</Title>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFrameworks>net40;netcoreapp3.0</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>LibVLCSharp.WinForms.Sample</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms> 
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.8" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\LibVLCSharp.WinForms\LibVLCSharp.WinForms.csproj" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Form1.cs">


### PR DESCRIPTION
### Description of Change ###

I apologize for not updating the existing PR. I had so many problems trying to rebase. I no longer have issues building w/ MSBuild.Sdk.Extras 2.0..54. 

You can run the winforms sample by running ```dotnet run -f netcoreapp3.0``` from sample directory. 

Add support for .net core 3.0 winforms and wpf. Update winforms sample to support netcoreapp3.0. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes #140

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

New platform added

- netcoreapp3.0

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
