### PR TITLE
Makes the UWP VideoView more MVVM friendly

### DIFF
--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -83,6 +83,9 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <Compile Include="Platforms\UWP\**\*.cs" />
+    <None Update="Themes\Generic.xaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
   </ItemGroup>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -56,7 +56,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <PropertyGroup Condition="$(NETSTANDARD_ONLY)=='true'">
     <TargetFrameworks>netstandard2.0;netstandard1.1</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <ItemGroup>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -48,7 +48,6 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>https://code.videolan.org/videolan/LibVLCSharp/blob/master/NEWS</PackageReleaseNotes>
     <PackageTags>libvlc;vlc;videolan;native;c/c++;video;audio;player;media;mediaplayer;codec;ffmpeg;xamarin;graphics;ios;android;linux;windows;macos;cross-platform</PackageTags>
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="$(UNITY_ANDROID)=='true'">
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -56,6 +56,9 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <PropertyGroup Condition="$(NETSTANDARD_ONLY)=='true'">
     <TargetFrameworks>netstandard2.0;netstandard1.1</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />

--- a/LibVLCSharp/LibVLCSharp.csproj
+++ b/LibVLCSharp/LibVLCSharp.csproj
@@ -48,6 +48,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>https://code.videolan.org/videolan/LibVLCSharp/blob/master/NEWS</PackageReleaseNotes>
     <PackageTags>libvlc;vlc;videolan;native;c/c++;video;audio;player;media;mediaplayer;codec;ffmpeg;xamarin;graphics;ios;android;linux;windows;macos;cross-platform</PackageTags>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="$(UNITY_ANDROID)=='true'">
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -83,9 +84,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <Compile Include="Platforms\UWP\**\*.cs" />
-    <None Update="Themes\Generic.xaml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Themes\Generic.xaml" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
   </ItemGroup>

--- a/LibVLCSharp/Platforms/UWP/InitializedEventArgs.cs
+++ b/LibVLCSharp/Platforms/UWP/InitializedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace LibVLCSharp.Platforms.UWP
+{
+    /// <summary>
+    /// Provides data for the <see cref="VideoView.Initialized"/> event.
+    /// </summary>
+    public class InitializedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="InitializedEventArgs"/> class
+        /// </summary>
+        /// <param name="swapChainOptions">swap chain parameters</param>
+        public InitializedEventArgs(string[] swapChainOptions) : base()
+        {
+            SwapChainOptions = swapChainOptions;
+        }
+
+        /// <summary>
+        /// Gets the swap chain parameters
+        /// </summary>
+        public string[] SwapChainOptions { get; }
+    }
+}

--- a/LibVLCSharp/Themes/Generic.xaml
+++ b/LibVLCSharp/Themes/Generic.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vlc="using:LibVLCSharp.Platforms.UWP">
+
+    <Style TargetType="vlc:VideoView">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="vlc:VideoView">
+                    <SwapChainPanel x:Name="SwapChainPanel" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/Samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
+++ b/Samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
@@ -123,6 +123,7 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="MainViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
+++ b/Samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
@@ -125,6 +125,7 @@
     </Compile>
     <Compile Include="MainViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RelayCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -155,6 +156,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
+      <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
       <Version>3.1.1</Version>

--- a/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml
+++ b/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml
@@ -8,8 +8,11 @@
     xmlns:lvs="using:LibVLCSharp.Platforms.UWP"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Page.DataContext>
+        <local:MainViewModel />
+    </Page.DataContext>
 
     <Grid>
-      <lvs:VideoView x:Name="VideoView"></lvs:VideoView>
+      <lvs:VideoView SwapChainOptions="{Binding SwapChainOptions, Mode=TwoWay}" MediaPlayer="{Binding MediaPlayer}"></lvs:VideoView>
     </Grid>
 </Page>

--- a/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml
+++ b/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml
@@ -5,6 +5,8 @@
     xmlns:local="using:LibVLCSharp.UWP.Sample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
     xmlns:lvs="using:LibVLCSharp.Platforms.UWP"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -13,6 +15,12 @@
     </Page.DataContext>
 
     <Grid>
-      <lvs:VideoView SwapChainOptions="{Binding SwapChainOptions, Mode=TwoWay}" MediaPlayer="{Binding MediaPlayer}"></lvs:VideoView>
+      <lvs:VideoView MediaPlayer="{Binding MediaPlayer}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:EventTriggerBehavior EventName="Initialized">
+                    <interactions:InvokeCommandAction Command="{Binding InitializedCommand}"/>
+                </interactions:EventTriggerBehavior>
+            </interactivity:Interaction.Behaviors>
+        </lvs:VideoView>
     </Grid>
 </Page>

--- a/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
+++ b/Samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Windows.UI.Xaml.Controls;
-using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.UWP.Sample
 {
@@ -8,27 +7,11 @@ namespace LibVLCSharp.UWP.Sample
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private LibVLC _libVLC;
-
-        private MediaPlayer _mediaPlayer;
-
+        /// <summary>
+        /// Initializes a new instance of <see cref="MainPage"/> class
         public MainPage()
         {
             InitializeComponent();
-            Loaded += (s, e) =>
-            {
-                _libVLC = new LibVLC(VideoView.SwapChainOptions);
-                _mediaPlayer = new MediaPlayer(_libVLC);
-                VideoView.MediaPlayer = _mediaPlayer;
-                this._mediaPlayer.Play(new Media(_libVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4", FromType.FromLocation));
-            };
-
-            Unloaded += (s, e) =>
-            {
-                VideoView.MediaPlayer = null;
-                this._mediaPlayer.Dispose();
-                this._libVLC.Dispose();
-            };
         }
     }
 }

--- a/Samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
+++ b/Samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.ComponentModel;
+using LibVLCSharp.Shared;
+
+namespace LibVLCSharp.UWP.Sample
+{
+    /// <summary>
+    /// Main view model
+    /// </summary>
+    public class MainViewModel : INotifyPropertyChanged, IDisposable
+    {
+        /// <summary>
+        /// Occurs when a property value changes
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Destructor
+        /// </summary>
+        ~MainViewModel()
+        {
+            Dispose();
+        }
+
+        private string[] _swapChainOptions;
+        /// <summary>
+        /// Sets the swap chain parameters
+        /// </summary>
+        public string[] SwapChainOptions
+        {
+            private get => _swapChainOptions;
+            set
+            {
+                if (_swapChainOptions != value)
+                {
+                    _swapChainOptions = value;
+                    LibVLC = new LibVLC(value);
+                    MediaPlayer = new MediaPlayer(LibVLC);
+                    MediaPlayer.Play(new Media(LibVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                        FromType.FromLocation));
+                }
+            }
+        }
+
+        private LibVLC LibVLC { get; set; }
+
+        private MediaPlayer _mediaPlayer;
+        /// <summary>
+        /// Gets the media player
+        /// </summary>
+        public MediaPlayer MediaPlayer
+        {
+            get => _mediaPlayer;
+            private set => Set(nameof(MediaPlayer), ref _mediaPlayer, value);
+        }
+
+        private void Set<T>(string propertyName, ref T field, T value)
+        {
+            if (field == null && value != null || field != null && !field.Equals(value))
+            {
+                field = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        /// <summary>
+        /// Cleaning
+        /// </summary>
+        public void Dispose()
+        {
+            var mediaPlayer = MediaPlayer;
+            MediaPlayer = null;
+            mediaPlayer?.Dispose();
+            LibVLC?.Dispose();
+            LibVLC = null;
+        }
+    }
+}

--- a/Samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
+++ b/Samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Windows.Input;
+using LibVLCSharp.Platforms.UWP;
 using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.UWP.Sample
@@ -15,6 +17,14 @@ namespace LibVLCSharp.UWP.Sample
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
+        /// Initialized a new instance of <see cref="MainViewModel"/> class
+        /// </summary>
+        public MainViewModel()
+        {
+            InitializedCommand = new RelayCommand<InitializedEventArgs>(Initialize);
+        }
+
+        /// <summary>
         /// Destructor
         /// </summary>
         ~MainViewModel()
@@ -22,25 +32,10 @@ namespace LibVLCSharp.UWP.Sample
             Dispose();
         }
 
-        private string[] _swapChainOptions;
         /// <summary>
-        /// Sets the swap chain parameters
+        /// Gets the command for the initialization
         /// </summary>
-        public string[] SwapChainOptions
-        {
-            private get => _swapChainOptions;
-            set
-            {
-                if (_swapChainOptions != value)
-                {
-                    _swapChainOptions = value;
-                    LibVLC = new LibVLC(value);
-                    MediaPlayer = new MediaPlayer(LibVLC);
-                    MediaPlayer.Play(new Media(LibVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
-                        FromType.FromLocation));
-                }
-            }
-        }
+        public ICommand InitializedCommand { get; }
 
         private LibVLC LibVLC { get; set; }
 
@@ -61,6 +56,14 @@ namespace LibVLCSharp.UWP.Sample
                 field = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             }
+        }
+
+        private void Initialize(InitializedEventArgs eventArgs)
+        {
+            LibVLC = new LibVLC(eventArgs.SwapChainOptions);
+            MediaPlayer = new MediaPlayer(LibVLC);
+            MediaPlayer.Play(new Media(LibVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                FromType.FromLocation));
         }
 
         /// <summary>

--- a/Samples/LibVLCSharp.UWP.Sample/RelayCommand.cs
+++ b/Samples/LibVLCSharp.UWP.Sample/RelayCommand.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace LibVLCSharp.UWP.Sample
+{
+    /// <summary>
+    /// A command whose sole purpose is to relay its functionality to other objects by invoking delegates
+    /// </summary>
+    public class RelayCommand<T> : ICommand
+    {
+        /// <summary>
+        /// Occurs when changes occur that affect whether or not the command should execute
+        /// </summary>
+        public event EventHandler CanExecuteChanged;
+
+        /// <summary>
+        /// Creates a new command
+        /// </summary>
+        /// <param name="executeAction">the execution logic</param>
+        public RelayCommand(Action<T> executeAction)
+        {
+            ExecuteAction = executeAction;
+        }
+
+        private Action<T> ExecuteAction { get; }
+
+        /// <summary>
+        /// Raises the <see cref="CanExecuteChanged" /> event
+        /// </summary>
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Determines whether the command can execute in its current state
+        /// </summary>
+        /// <param name="parameter">data used by the command.
+        /// If the command does not require data to be passed, this object can be set to null</param>
+        /// <returns>true</returns>
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Executes the <see cref="RelayCommand"/>
+        /// </summary>
+        /// <param name="parameter">data used by the command</param>
+        public void Execute(object parameter)
+        {
+            ExecuteAction?.Invoke((T)parameter);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
I replaced the SwapChainOptions and MediaPlayer properties to dependency properties. So It's easier to code in MVVM way with the UWP video view (I updated the sample to show the changes).
There is no breaking changes, property names stays the same.

Other change : the VideoView class inherits now from the Control class instead of UserControl. The developper can now updates the ControlTemplate if he wants. The default control template in Generic.xaml contains only the SwapChainPanel.

### Platforms Affected ### 
- UWP