### PR TITLE
RendererDiscoverer: Make renderer name optional

### DIFF
--- a/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
+++ b/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
@@ -738,7 +738,7 @@ namespace LibVLCSharp.Forms.Shared
 
         private void ResetRendererDiscovery()
         {
-            ClearRenderers();
+            ClearRenderer();
 
             if(EnableRendererDiscovery)
                 FindRenderers();
@@ -838,7 +838,7 @@ namespace LibVLCSharp.Forms.Shared
                     {
                         _ = FadeInAsync();
 
-                        if(!RemoteRendering && RendererItems.Count == 1)
+                        if (!RemoteRendering && RendererItems.Count == 1)
                         {
                             mediaPlayer.SetRenderer(RendererItems.First());
                             RemoteRendering = true;
@@ -1484,28 +1484,17 @@ namespace LibVLCSharp.Forms.Shared
         }
 
         ObservableCollection<RendererItem> RendererItems = new ObservableCollection<RendererItem>();
-        List<RendererDiscoverer> RendererDiscoverers = new List<RendererDiscoverer>();
+        RendererDiscoverer RendererDiscoverer;
 
-        private void ClearRenderers()
+        private void ClearRenderer()
         {
-            if (RendererItems.Any())
+            if(RendererDiscoverer != null)
             {
-                foreach (var ri in RendererItems)
-                    ri.Dispose();
-            }
-            RendererItems.Clear();
-
-            if (RendererDiscoverers.Any())
-            {
-                foreach (var rd in RendererDiscoverers)
-                {
-                    rd.Stop();
-                    rd.ItemAdded -= RendererDiscoverer_ItemAdded;
-                    rd.ItemDeleted -= RendererDiscoverer_ItemDeleted;
-                    rd.Dispose();
-                }
-
-                RendererDiscoverers.Clear();
+                RendererDiscoverer.Stop();
+                RendererDiscoverer.ItemAdded -= RendererDiscoverer_ItemAdded;
+                RendererDiscoverer.ItemDeleted -= RendererDiscoverer_ItemDeleted;
+                RendererDiscoverer.Dispose();
+                RendererDiscoverer = null;
             }
         }
 
@@ -1517,15 +1506,10 @@ namespace LibVLCSharp.Forms.Shared
             if (!EnableRendererDiscovery)
                 return;
 
-            var renderers = LibVLC.RendererList;
-            foreach(var discoverer in renderers)
-            {
-                var rendererDiscoverer = new RendererDiscoverer(LibVLC, discoverer.Name);
-                rendererDiscoverer.ItemAdded += RendererDiscoverer_ItemAdded;
-                rendererDiscoverer.ItemDeleted += RendererDiscoverer_ItemDeleted;
-                rendererDiscoverer.Start();
-                RendererDiscoverers.Add(rendererDiscoverer);
-            }
+            var rendererDiscoverer = new RendererDiscoverer(LibVLC);
+            rendererDiscoverer.ItemAdded += RendererDiscoverer_ItemAdded;
+            rendererDiscoverer.ItemDeleted += RendererDiscoverer_ItemDeleted;
+            rendererDiscoverer.Start();
         }
 
         private void RendererDiscoverer_ItemDeleted(object sender, RendererDiscovererItemDeletedEventArgs e) => RendererItems.Remove(e.RendererItem);

--- a/LibVLCSharp/Shared/RendererDiscoverer.cs
+++ b/LibVLCSharp/Shared/RendererDiscoverer.cs
@@ -11,6 +11,8 @@ namespace LibVLCSharp.Shared
     public class RendererDiscoverer : Internal
     {
         RendererDiscovererEventManager _eventManager;
+        const string Bonjour = "Bonjour_renderer";
+        const string Mdns = "microdns_renderer";
 
         readonly struct Native
         {
@@ -39,10 +41,22 @@ namespace LibVLCSharp.Shared
         /// Create a new renderer discoverer with a LibVLC and protocol name depending on host platform
         /// </summary>
         /// <param name="libVLC">libvlc instance this will be connected to</param>
-        /// <param name="name">The service discovery protocol name depending on platform. Use <see cref="LibVLC.RendererList"/> to find the one for your platform</param>
-        public RendererDiscoverer(LibVLC libVLC, string name)
+        /// <param name="name">
+        /// The service discovery protocol name depending on platform. Use <see cref="LibVLC.RendererList"/> to find the one for your platform,
+        /// or let libvlcsharp find it for you
+        /// </param>
+        public RendererDiscoverer(LibVLC libVLC, string name = null)
             : base(() =>
             {
+                if(string.IsNullOrEmpty(name))
+                {
+#if APPLE
+                    name = Bonjour;
+#else
+                    name = Mdns;
+#endif
+                }
+
                 var nameUtf8 = name.ToUtf8();
                 return MarshalUtils.PerformInteropAndFree(() => 
                     Native.LibVLCRendererDiscovererNew(libVLC.NativeReference, nameUtf8), nameUtf8);


### PR DESCRIPTION
### Description of Change ###

As of libvlc 3, we can figure out the name internally so it makes sense to make that parameter optional. It is not an API breaking change. It is still possible to provide your own.
Moreover, mdns seems available on iOS and returns sometimes valid, sometimes invalid renderers.
The MediaElement now uses the new API which always uses only the bonjour protocol on Apple platforms.

### Issues Resolved ### 
- Incidentally fixes https://code.videolan.org/videolan/LibVLCSharp/issues/237

### API Changes ###
Changed:
 - `RendererDiscoverer(LibVLC libVLC, string name)` => `RendererDiscoverer(LibVLC libVLC, string name = null)`

### Platforms Affected ### 

- Core (all platforms)

### Testing Procedure ###

Try chromecasting on several platforms.

- [x] iOS
- [x] Android