### PR TITLE
Fixed flawed logic in VolumeManager

### DIFF
--- a/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
+++ b/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
@@ -42,7 +42,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             get => _enabled;
             private set
             {
-                if (_enabled = value)
+                if (_enabled != value)
                 {
                     _enabled = value;
                     EnabledChanged?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
### Description of Change ###
An assignment was incorrectly used instead of a comparison with the value.

### Issues Resolved ### 
The IDE was complaining. 😁

Other than that, I suppose that incorrect behavior could have been observed when setting `Enabled = false`

### API Changes ###
 None

### Platforms Affected ### 

Core (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Try calling Enabled with different values, I guess?

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
