### PR TITLE
VolumeChanged event bug workaround

### DIFF
--- a/LibVLCSharp.Uno/PlaybackControlsBase.cs
+++ b/LibVLCSharp.Uno/PlaybackControlsBase.cs
@@ -74,7 +74,7 @@ namespace LibVLCSharp.Uno
             castRenderersDiscoverer.Enabled = IsCastButtonVisible;
             var volumeManager = Manager.Get<VolumeManager>();
             volumeManager.EnabledChanged += (sender, e) => VolumeMuteButtonAvailabilityCommand?.Update();
-            volumeManager.VolumeChanged += (sender, e) => UpdateVolumeSlider();
+            //volumeManager.VolumeChanged += (sender, e) => UpdateVolumeSlider();
             volumeManager.MuteChanged += (sender, e) => MuteStateCommand?.Update();
             var seekBarManager = Manager.Get<SeekBarManager>();
             seekBarManager.SeekableChanged += (sender, e) => SeekBarAvailabilityCommand?.Update();
@@ -584,6 +584,7 @@ namespace LibVLCSharp.Uno
             }
             if (GetTemplateChild("VolumeFlyout") is Flyout volumeFlyout)
             {
+                volumeFlyout.Opening += (sender, e) => UpdateVolumeSlider();
                 SubscribeFlyoutOpenedClosedEvents(volumeFlyout);
             }
             var audioTracksSelectionButton = Initialize("AudioTracksSelectionButton", "ShowAudioSelectionMenu") as Button;

--- a/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
+++ b/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
@@ -13,10 +13,10 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         public event EventHandler? EnabledChanged;
 
-        /// <summary>
-        /// Occurs when <see cref="Volume"/> property value changes
-        /// </summary>
-        public event EventHandler? VolumeChanged;
+        ///// <summary>
+        ///// Occurs when <see cref="Volume"/> property value changes
+        ///// </summary>
+        //public event EventHandler? VolumeChanged;
 
         /// <summary>
         /// Occurs when <see cref="Mute"/> property value changes
@@ -92,14 +92,14 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             {
                 Enabled = MediaPlayer != null;
                 MuteChanged?.Invoke(this, EventArgs.Empty);
-                VolumeChanged?.Invoke(this, EventArgs.Empty);
+                //VolumeChanged?.Invoke(this, EventArgs.Empty);
             });
         }
 
-        private async void MediaPlayer_VolumeChangedAsync(object sender, EventArgs e)
-        {
-            await DispatcherInvokeEventHandlerAsync(VolumeChanged);
-        }
+        //private async void MediaPlayer_VolumeChangedAsync(object sender, EventArgs e)
+        //{
+        //    await DispatcherInvokeEventHandlerAsync(VolumeChanged);
+        //}
 
         private async void MediaPlayer_MuteChangedAsync(object sender, EventArgs e)
         {
@@ -113,7 +113,8 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         protected override void SubscribeEvents(MediaPlayer mediaPlayer)
         {
             base.SubscribeEvents(mediaPlayer);
-            mediaPlayer.VolumeChanged += MediaPlayer_VolumeChangedAsync;
+            // Subscribe to the VolumeChanged event causes a bug when the media player is stopped
+            //mediaPlayer.VolumeChanged += MediaPlayer_VolumeChangedAsync;
             mediaPlayer.Muted += MediaPlayer_MuteChangedAsync;
             mediaPlayer.Unmuted += MediaPlayer_MuteChangedAsync;
         }
@@ -125,7 +126,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         protected override void UnsubscribeEvents(MediaPlayer mediaPlayer)
         {
             base.UnsubscribeEvents(mediaPlayer);
-            mediaPlayer.VolumeChanged -= MediaPlayer_VolumeChangedAsync;
+            //mediaPlayer.VolumeChanged -= MediaPlayer_VolumeChangedAsync;
             mediaPlayer.Muted -= MediaPlayer_MuteChangedAsync;
             mediaPlayer.Unmuted -= MediaPlayer_MuteChangedAsync;
         }


### PR DESCRIPTION
### Description of Change ###
Currently, on Android, if I subscribe to the MediaPlayer.VolumeChanged event, the application crashes when the media player is stopped (the problem must come from libVLC or Xamarin).
This pull request removes the subscription to the MediaPlayer.VolumeChanged event. It's just a workaround, idealy, it shouldn't crash when the media player is stopped.