### PR TITLE
Fix collected callbacks

### DIFF
--- a/LibVLCSharp/Shared/LibVLC.cs
+++ b/LibVLCSharp/Shared/LibVLC.cs
@@ -531,6 +531,14 @@ namespace LibVLCSharp.Shared
 
         #region DialogManagement
 
+        private static readonly DisplayErrorCallback InternalErrorCallback = Error;
+        private static readonly DisplayLoginCallback InternalLoginCallback = Login;
+        private static readonly DisplayQuestionCallback InternalQuestionCallback = Question;
+        private static readonly DisplayProgressCallback InternalDisplayProgressCallback = DisplayProgress;
+        private static readonly CancelCallback InternalCancelCallback = Cancel;
+        private static readonly UpdateProgressCallback InternalUpdateProgressCallback = UpdateProgress;
+        private static readonly DialogCallbacks DialogCbs = new DialogCallbacks(InternalErrorCallback, InternalLoginCallback, InternalQuestionCallback, InternalDisplayProgressCallback, InternalCancelCallback, InternalUpdateProgressCallback);
+
         /// <summary>
         /// Register callbacks in order to handle VLC dialogs. 
         /// LibVLC 3.0.0 and later.
@@ -551,8 +559,7 @@ namespace LibVLCSharp.Shared
             _displayProgress = displayProgress ?? throw new ArgumentNullException(nameof(displayProgress));
             _updateProgress = updateProgress ?? throw new ArgumentNullException(nameof(updateProgress));
 
-            _dialogCbs = new DialogCallbacks(Error, Login, Question, DisplayProgress, Cancel, UpdateProgress);
-            Native.LibVLCDialogSetCallbacks(NativeReference, _dialogCbs, IntPtr.Zero);
+            Native.LibVLCDialogSetCallbacks(NativeReference, DialogCbs, IntPtr.Zero);
         }
 
         /// <summary>
@@ -562,8 +569,7 @@ namespace LibVLCSharp.Shared
         {
             if (DialogHandlersSet)
             {
-                _dialogCbs = default;
-                Native.LibVLCDialogSetCallbacks(NativeReference, _dialogCbs, IntPtr.Zero);
+                Native.LibVLCDialogSetCallbacks(NativeReference, default, IntPtr.Zero);
                 _error = null;
                 _login = null;
                 _question = null;
@@ -575,9 +581,7 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// True if dialog handlers are set
         /// </summary>
-        public bool DialogHandlersSet => _dialogCbs.DisplayLogin != IntPtr.Zero;
-
-        DialogCallbacks _dialogCbs;
+        public bool DialogHandlersSet => _error != null;
         static DisplayError _error;
         static DisplayLogin _login;
         static DisplayQuestion _question;

--- a/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/LibVLCSharp/Shared/MediaPlayer.cs
@@ -994,6 +994,12 @@ namespace LibVLCSharp.Shared
         /// <returns>true on success, false otherwise.</returns>
         public bool UnsetEqualizer() => Native.LibVLCMediaPlayerSetEqualizer(NativeReference, IntPtr.Zero) == 0;
 
+        private LibVLCAudioPlayCb _audioPlayCb;
+        private LibVLCAudioPauseCb _audioPauseCb;
+        private LibVLCAudioResumeCb _audioResumeCb;
+        private LibVLCAudioFlushCb _audioFlushCb;
+        private LibVLCAudioDrainCb _audioDrainCb;
+
         /// <summary>
         /// Sets callbacks and private data for decoded audio. 
         /// Use libvlc_audio_set_format() or libvlc_audio_set_format_callbacks() to configure the decoded audio format.
@@ -1008,8 +1014,16 @@ namespace LibVLCSharp.Shared
             LibVLCAudioResumeCb resumeCb, LibVLCAudioFlushCb flushCb,
             LibVLCAudioDrainCb drainCb)
         {
+            _audioPlayCb = playCb;
+            _audioPauseCb = pauseCb;
+            _audioResumeCb = resumeCb;
+            _audioFlushCb = flushCb;
+            _audioDrainCb = drainCb;
+
             Native.LibVLCAudioSetCallbacks(NativeReference, playCb, pauseCb, resumeCb, flushCb, drainCb, IntPtr.Zero);
         }
+
+        private LibVLCVolumeCb _audioVolumeCb;
 
         /// <summary>
         /// Set callbacks and private data for decoded audio. 
@@ -1019,8 +1033,12 @@ namespace LibVLCSharp.Shared
         /// <param name="volumeCb">callback to apply audio volume, or NULL to apply volume in software</param>
         public void SetVolumeCallback(LibVLCVolumeCb volumeCb)
         {
+            _audioVolumeCb = volumeCb;
             Native.LibVLCAudioSetVolumeCallback(NativeReference, volumeCb);
         }
+
+        private LibVLCAudioSetupCb _setupCb;
+        private LibVLCAudioCleanupCb _cleanupCb;
 
         /// <summary>
         /// Sets decoded audio format via callbacks. 
@@ -1030,6 +1048,8 @@ namespace LibVLCSharp.Shared
         /// <param name="cleanupCb">callback to release any allocated resources (or NULL)</param>
         public void SetAudioFormatCallback(LibVLCAudioSetupCb setupCb, LibVLCAudioCleanupCb cleanupCb)
         {
+            _setupCb = setupCb;
+            _cleanupCb = cleanupCb;
             Native.LibVLCAudioSetFormatCallbacks(NativeReference, setupCb, cleanupCb);
         }
 
@@ -1224,6 +1244,10 @@ namespace LibVLCSharp.Shared
         /// <returns>true on success, false on error </returns>
         public bool SetAudioDelay(long delay) => Native.LibVLCAudioSetDelay(NativeReference, delay) == 0;
 
+        private LibVLCVideoLockCb _videoLockCb;
+        private LibVLCVideoUnlockCb _videoUnlockCb;
+        private LibVLCVideoDisplayCb _videoDisplayCb;
+
         /// <summary>
         /// Set callbacks and private data to render decoded video to a custom area in memory.
         /// Use libvlc_video_set_format() or libvlc_video_set_format_callbacks() to configure the decoded format.
@@ -1246,6 +1270,9 @@ namespace LibVLCSharp.Shared
         public void SetVideoCallbacks(LibVLCVideoLockCb lockCb, LibVLCVideoUnlockCb unlockCb,
             LibVLCVideoDisplayCb displayCb)
         {
+            _videoLockCb = lockCb;
+            _videoUnlockCb = unlockCb;
+            _videoDisplayCb = displayCb;
             Native.LibVLCVideoSetCallbacks(NativeReference, lockCb, unlockCb, displayCb, IntPtr.Zero);
         }
 
@@ -1267,6 +1294,9 @@ namespace LibVLCSharp.Shared
                 chromaUtf8);
         }
 
+        private LibVLCVideoFormatCb _videoFormatCb;
+        private LibVLCVideoCleanupCb _videoCleanupCb;
+
         /// <summary>
         /// Set decoded video chroma and dimensions. 
         /// This only works in combination with libvlc_video_set_callbacks().
@@ -1275,6 +1305,8 @@ namespace LibVLCSharp.Shared
         /// <param name="cleanupCb">callback to release any allocated resources (or NULL)</param>
         public void SetVideoFormatCallbacks(LibVLCVideoFormatCb formatCb, LibVLCVideoCleanupCb cleanupCb)
         {
+            _videoFormatCb = formatCb;
+            _videoCleanupCb = cleanupCb;
             Native.LibVLCVideoSetFormatCallbacks(NativeReference, formatCb, cleanupCb);
         }
 


### PR DESCRIPTION
### Description of Change ###
We have seen several issues related to libvlc callbacks that were called while the .net GC has collected the methods.

This fixes those kind of issues in the following APIs:
- Video callbacks
- Audio callbacks
- Dialog callbacks

### Issues Resolved ### 
- fixes #275

### API Changes ###
None, all changes are internal

### Platforms Affected ### 
- Core (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
https://github.com/sergiocapozzi77/SetDialogsCrash
https://github.com/jeremyVignelles/libvlcsharp-samples/commit/1ed62bd769ea16860f161dbc12911dae88c278f0

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
