### PR TITLE
Fix libvlc loading on old android versions

### DIFF
--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -71,6 +71,9 @@ namespace LibVLCSharp.Shared
         public static void Initialize(string libvlcDirectoryPath = null)
         {
 #if ANDROID
+            if(Android.OS.Build.VERSION.SdkInt <= Android.OS.BuildVersionCodes.JellyBeanMr1)
+                LoadLibCpp();
+
             InitializeAndroid();
 #elif UWP
             InitializeUWP();
@@ -98,6 +101,17 @@ namespace LibVLCSharp.Shared
         }
 #endif
 #if ANDROID
+        static void LoadLibCpp()
+        {
+            try
+            {               
+                Java.Lang.JavaSystem.LoadLibrary("c++_shared");
+            }
+            catch(Java.Lang.UnsatisfiedLinkError exception)
+            {
+                throw new VLCException($"failed to load libc++_shared {nameof(exception)} {exception.Message}");
+            }
+        }
         static void InitializeAndroid()
         {
             var initLibvlc = Native.JniOnLoad(JniRuntime.CurrentRuntime.InvocationPointer);

--- a/Samples/LibVLCSharp.Android.Sample/Properties/AndroidManifest.xml
+++ b/Samples/LibVLCSharp.Android.Sample/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="LibVLCSharp.Android.Sample.LibVLCSharp.Android.Sample" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="LibVLCSharp.Android.Sample.LibVLCSharp.Android.Sample" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="17" android:targetSdkVersion="28" />
 	<application android:allowBackup="true" android:label="@string/app_name"></application>
 </manifest>


### PR DESCRIPTION
### Description of Change ###

Fix LibVLC loading on Android API 17 and older by explicitly loading libc++_shared.so
This patch should be located in the InitializeAndroid method, but it doesn't work if it is there. Must look at generated code.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/280

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Testing Procedure ###

Try running the Android sample on a Android API 17 simulator.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
