### PR TITLE
Fix a memory leak with the foreground window (WPF)

### DIFF
--- a/LibVLCSharp.WPF/VideoView.cs
+++ b/LibVLCSharp.WPF/VideoView.cs
@@ -18,6 +18,8 @@ namespace LibVLCSharp.WPF
         private const string PART_PlayerHost = "PART_PlayerHost";
         private const string PART_PlayerView = "PART_PlayerView";
 
+        private WindowsFormsHost? WindowsFormsHost => Template.FindName(PART_PlayerHost, this) as WindowsFormsHost;
+
         /// <summary>
         /// WPF VideoView constructor
         /// </summary>
@@ -70,7 +72,7 @@ namespace LibVLCSharp.WPF
 
             if (!IsDesignMode)
             {
-                var windowsFormsHost = Template.FindName(PART_PlayerHost, this) as FrameworkElement;
+                var windowsFormsHost = WindowsFormsHost;
                 if (windowsFormsHost != null)
                 {
                     ForegroundWindow = new ForegroundWindow(windowsFormsHost)
@@ -144,11 +146,13 @@ namespace LibVLCSharp.WPF
                     {
                         MediaPlayer.Hwnd = IntPtr.Zero;
                     }
+
+                    WindowsFormsHost?.Dispose();
+                    ForegroundWindow?.Close();
                 }
 
                 ViewContent = null;
                 ForegroundWindow = null;
-
                 disposedValue = true;
             }
         }

--- a/Samples/LibVLCSharp.WPF.Sample/Example1.xaml.cs
+++ b/Samples/LibVLCSharp.WPF.Sample/Example1.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace LibVLCSharp.WPF.Sample
 {
@@ -12,6 +13,11 @@ namespace LibVLCSharp.WPF.Sample
 
             _controls = new Controls(this);
             VideoView.Content = _controls;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            VideoView.Dispose();
         }
     }
 }

--- a/Samples/LibVLCSharp.WPF.Sample/Example2.xaml.cs
+++ b/Samples/LibVLCSharp.WPF.Sample/Example2.xaml.cs
@@ -1,4 +1,5 @@
-﻿using LibVLCSharp.Shared;
+﻿using System;
+using LibVLCSharp.Shared;
 
 using System.Windows;
 using System.Windows.Controls;
@@ -47,6 +48,11 @@ namespace LibVLCSharp.WPF.Sample
                 VideoView.MediaPlayer.Play(new Media(_libVLC,
                     "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4", FromType.FromLocation));
             }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            VideoView.Dispose();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Fix a leak with the foreground window when the VideoView is disposed

In VideoView.Dispose()
- close the foreground window
- dispose the PlayerHost

In the WPF samples
- dispose the VideoView when the window is closed

### Issues Resolved ### 

None

### API Changes ###

 None

### Platforms Affected ### 

WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Start the WPF sample with a memory profiler
- Open Example 1 and close the window
- Open Example 2 and close the window
- Take a memory snapshot
- Check that no instance of ForeroundWindow or VideoView have survived

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard