### PR TITLE
MediaPlayerElement: Remove interface member modifier

### DIFF
--- a/LibVLCSharp/Shared/MediaPlayerElement/IDisplayInformation.cs
+++ b/LibVLCSharp/Shared/MediaPlayerElement/IDisplayInformation.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Gets the scale factor
         /// </summary>
-        public double ScalingFactor { get; }
+        double ScalingFactor { get; }
     }
 }


### PR DESCRIPTION
Unnecessary and breaks builds with older compilers (C#7 and under)