### PR TITLE
Core: Always load libcpp on Android regardless of Android version

### DIFF
--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -71,9 +71,6 @@ namespace LibVLCSharp.Shared
         public static void Initialize(string libvlcDirectoryPath = null)
         {
 #if ANDROID
-            if(Android.OS.Build.VERSION.SdkInt <= Android.OS.BuildVersionCodes.JellyBeanMr1)
-                LoadLibCpp();
-
             InitializeAndroid();
 #elif UWP
             InitializeUWP();
@@ -114,6 +111,8 @@ namespace LibVLCSharp.Shared
         }
         static void InitializeAndroid()
         {
+            LoadLibCpp();
+
             var initLibvlc = Native.JniOnLoad(JniRuntime.CurrentRuntime.InvocationPointer);
             if(initLibvlc == 0)
                 throw new VLCException("failed to initialize libvlc with JniOnLoad " +


### PR DESCRIPTION
This was partly fixed in https://github.com/videolan/libvlcsharp/pull/88 but not entirely, according to https://code.videolan.org/videolan/LibVLCSharp/issues/283. This commit should fix it for good.

### Description of Change ###

Always load libcpp on Android regardless of Android version

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/283

### API Changes ###
 
 None

### Platforms Affected ### 

- Android