### PR TITLE
Core: Improve LibVLC loading error messages

### DIFF
--- a/LibVLCSharp/Shared/Core.cs
+++ b/LibVLCSharp/Shared/Core.cs
@@ -203,7 +203,9 @@ namespace LibVLCSharp.Shared
 
             if (!Loaded)
             {
-                throw new VLCException($"Failed to load required native libraries. Search paths include {string.Join("; ", paths.Select(p => $"{p.libvlc},{p.libvlccore}"))}");
+                throw new VLCException("Failed to load required native libraries. " +
+                    $"{Environment.NewLine}Have you installed the latest LibVLC package from nuget for your target platform?" +
+                    $"{Environment.NewLine}Search paths include {string.Join("; ", paths.Select(p => $"{p.libvlc},{p.libvlccore}"))}");
             }
 #endif
         }

--- a/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -199,7 +199,8 @@ namespace LibVLCSharp.Shared.Helpers
         /// </summary>
         /// <param name="options">libvlc options, an UTF16 string array turned to UTF8 string pointer array</param>
         /// <param name="create">the create function call</param>
-        /// <returns></returns>
+        /// <returns>the result of the create function</returns>
+        /// <exception cref="VLCException">Thrown when libvlc could not be created</exception>
         internal static IntPtr CreateWithOptions(string[] options, Func<int, IntPtr[], IntPtr> create)
         {
             var utf8Args = default(IntPtr[]);
@@ -207,6 +208,13 @@ namespace LibVLCSharp.Shared.Helpers
             {
                 utf8Args = options.ToUtf8();
                 return create(utf8Args.Length, utf8Args);
+            }
+            catch (DllNotFoundException ex)
+            {
+                throw new VLCException("LibVLC could not be created. Make sure that you have done the following:" +
+                    $"{Environment.NewLine}- Installed latest LibVLC from nuget for your target platform." +
+                    $"{Environment.NewLine}- Called LibVLCSharp.Shared.Core.Initialize() before creating any LibVLCSharp object." +
+                    $"{Environment.NewLine}{ex.Message} {ex.StackTrace}");
             }
             finally
             {


### PR DESCRIPTION
### Description of Change ###

Improve LibVLC loading error messages

A user could misuse the API in several ways:
- core.initialize is not called, libvlc is not installed.
- core.initialize is not called, libvlc is installed.
- core.initialize is called, libvlc is not installed.

These messages intend to help guide the user on which steps to take to initialize libvlc properly.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/issues/300

and probably a lot more.

### API Changes ###

 None

### Platforms Affected ### 

- Core (all platforms)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
