### PR TITLE
Bring nullable back

### DIFF
--- a/buildsystem/azure-pipelines.yml
+++ b/buildsystem/azure-pipelines.yml
@@ -21,6 +21,6 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
   steps:
   - template: windows-build.yml

--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -7,6 +7,7 @@ var configuration = Argument("configuration", "Release");
 var solutionName = "LibVLCSharp";
 var solutionFile = IsRunningOnWindows() ? $"{solutionName}.sln" : $"{solutionName}.Mac.sln";
 var solutionPath = $"../src/{solutionFile}";
+var packagesDir = "../packages";
 
 //////////////////////////////////////////////////////////////////////
 // PREPARATION
@@ -24,6 +25,13 @@ Task("Clean")
 {
     DeleteFiles("./**/bin/Release/*.nupkg");
     CleanDirectory(buildDir);
+    if(DirectoryExists(packagesDir))
+    {
+        DeleteDirectory(packagesDir, new DeleteDirectorySettings 
+        {
+            Recursive = true,
+        });
+    }
 });
 
 Task("Restore-NuGet-Packages")
@@ -31,7 +39,7 @@ Task("Restore-NuGet-Packages")
     .Does(() =>
 {
     NuGetRestore(solutionPath);
-    MoveDirectory("../src/packages", "../packages");
+    MoveDirectory("../src/packages", packagesDir);
 });
 
 Task("Build")

--- a/src/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
+++ b/src/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
@@ -16,7 +16,8 @@ Xamarin.Forms support for GTK and WPF are in separate packages. LibVLC needs to 
     <RootNamespace>LibVLCSharp.Forms</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
     <Version>3.4.3</Version>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageId>LibVLCSharp.Forms</PackageId>
     <Authors>VideoLAN</Authors>
     <Owners>VideoLAN</Owners>

--- a/src/LibVLCSharp.Forms/Platforms/Android/Platform.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Android/Platform.cs
@@ -12,12 +12,12 @@ namespace LibVLCSharp.Forms.Platforms.Android
     {
         private class ActivityLifecycleContextListener : Java.Lang.Object, IActivityLifecycleCallbacks
         {
-            private WeakReference<Activity> CurrentActivity { get; } = new WeakReference<Activity>(null);
+            private WeakReference<Activity?> CurrentActivity { get; } = new WeakReference<Activity?>(null);
 
             /// <summary>
             /// Gets or sets the current activity
             /// </summary>
-            public Activity Activity
+            public Activity? Activity
             {
                 get => CurrentActivity.TryGetTarget(out var a) ? a : null;
                 set => CurrentActivity.SetTarget(value);
@@ -55,12 +55,12 @@ namespace LibVLCSharp.Forms.Platforms.Android
             }
         }
 
-        private static ActivityLifecycleContextListener LifecycleListener { get; set; }
+        private static ActivityLifecycleContextListener? LifecycleListener { get; set; }
 
         /// <summary>
         /// Gets the current activity.
         /// </summary>
-        internal static Activity Activity => LifecycleListener?.Activity;
+        internal static Activity? Activity => LifecycleListener?.Activity;
 
         /// <summary>
         /// Sets the activity.

--- a/src/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
@@ -38,9 +38,9 @@ namespace LibVLCSharp.Forms.Platforms.Android
                     SetNativeControl(new LibVLCSharp.Platforms.Android.VideoView(Context));
 
                     e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
-                    if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                    if (Control!.MediaPlayer != e.NewElement.MediaPlayer)
                     {
-                        OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                        OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control!.MediaPlayer, e.NewElement.MediaPlayer));
                     }
                 }
             }

--- a/src/LibVLCSharp.Forms/Platforms/Apple/VideoViewRenderer.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Apple/VideoViewRenderer.cs
@@ -46,9 +46,9 @@ namespace LibVLCSharp.Forms.Platforms.Mac
                     SetNativeControl(new LibVLCSharp.Platforms.Mac.VideoView());
 #endif
                     e.NewElement.MediaPlayerChanging += OnMediaPlayerChanging;
-                    if (Control.MediaPlayer != e.NewElement.MediaPlayer)
+                    if (Control!.MediaPlayer != e.NewElement.MediaPlayer)
                     {
-                        OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control.MediaPlayer, e.NewElement.MediaPlayer));
+                        OnMediaPlayerChanging(this, new MediaPlayerChangingEventArgs(Control!.MediaPlayer, e.NewElement.MediaPlayer));
                     }
                 }
             }

--- a/src/LibVLCSharp.Forms/Shared/MediaPlayerElement.xaml.cs
+++ b/src/LibVLCSharp.Forms/Shared/MediaPlayerElement.xaml.cs
@@ -68,7 +68,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the video view.
         /// </summary>
-        public VideoView VideoView
+        public VideoView? VideoView
         {
             get => (VideoView)GetValue(VideoViewProperty);
             private set => SetValue(VideoViewProperty, value);
@@ -199,7 +199,7 @@ namespace LibVLCSharp.Forms.Shared
 
         private void PageAppearing(object sender, Page e)
         {
-            if (e == this.FindAncestor<Page>())
+            if (e == this.FindAncestor<Page?>())
             {
                 MessagingCenter.Subscribe<LifecycleMessage>(this, "OnSleep", m =>
                 {
@@ -233,7 +233,7 @@ namespace LibVLCSharp.Forms.Shared
 
         private void PageDisappearing(object sender, Page e)
         {
-            if (e == this.FindAncestor<Page>())
+            if (e == this.FindAncestor<Page?>())
             {
                 MessagingCenter.Unsubscribe<LifecycleMessage>(this, "OnSleep");
                 MessagingCenter.Unsubscribe<LifecycleMessage>(this, "OnResume");

--- a/src/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
+++ b/src/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
@@ -95,19 +95,19 @@ namespace LibVLCSharp.Forms.Shared
         }
 
         private MediaPlayerElementManager Manager { get; }
-        private Button AudioTracksSelectionButton { get; set; }
-        private Button CastButton { get; set; }
-        private Button ClosedCaptionsSelectionButton { get; set; }
-        private VisualElement ControlsPanel { get; set; }
-        private Button PlayPauseButton { get; set; }
-        private Label RemainingTimeLabel { get; set; }
-        private Label ElapsedTimeLabel { get; set; }
-        private Label AspectRatioLabel { get; set; }
+        private Button? AudioTracksSelectionButton { get; set; }
+        private Button? CastButton { get; set; }
+        private Button? ClosedCaptionsSelectionButton { get; set; }
+        private VisualElement? ControlsPanel { get; set; }
+        private Button? PlayPauseButton { get; set; }
+        private Label? RemainingTimeLabel { get; set; }
+        private Label? ElapsedTimeLabel { get; set; }
+        private Label? AspectRatioLabel { get; set; }
 
-        private Slider SeekBar { get; set; }
+        private Slider? SeekBar { get; set; }
 
         private bool Initialized { get; set; }
-        private ISystemUI SystemUI => DependencyService.Get<ISystemUI>();
+        private ISystemUI? SystemUI => DependencyService.Get<ISystemUI>();
 
         private const int SEEK_OFFSET = 2000;
         private bool RemoteRendering { get; set; } = false;
@@ -164,7 +164,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the audio tracks selection button style.
         /// </summary>
-        public Style AudioTracksSelectionButtonStyle
+        public Style? AudioTracksSelectionButtonStyle
         {
             get => (Style)GetValue(AudioTracksSelectionButtonStyleProperty);
             set => SetValue(AudioTracksSelectionButtonStyleProperty, value);
@@ -178,7 +178,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the controls panel style.
         /// </summary>
-        public Style BufferingProgressBarStyle
+        public Style? BufferingProgressBarStyle
         {
             get => (Style)GetValue(BufferingProgressBarStyleProperty);
             set => SetValue(BufferingProgressBarStyleProperty, value);
@@ -192,7 +192,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the button bar style.
         /// </summary>
-        public Style ButtonBarStyle
+        public Style? ButtonBarStyle
         {
             get => (Style)GetValue(ButtonBarStyleProperty);
             set => SetValue(ButtonBarStyleProperty, value);
@@ -206,7 +206,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the cast button style.
         /// </summary>
-        public Style CastButtonStyle
+        public Style? CastButtonStyle
         {
             get => (Style)GetValue(CastButtonStyleProperty);
             set => SetValue(CastButtonStyleProperty, value);
@@ -220,7 +220,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the closed captions selection button style.
         /// </summary>
-        public Style ClosedCaptionsSelectionButtonStyle
+        public Style? ClosedCaptionsSelectionButtonStyle
         {
             get => (Style)GetValue(ClosedCaptionsSelectionButtonStyleProperty);
             set => SetValue(ClosedCaptionsSelectionButtonStyleProperty, value);
@@ -234,7 +234,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the controls panel style.
         /// </summary>
-        public Style ControlsPanelStyle
+        public Style? ControlsPanelStyle
         {
             get => (Style)GetValue(ControlsPanelStyleProperty);
             set => SetValue(ControlsPanelStyleProperty, value);
@@ -248,7 +248,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the message style.
         /// </summary>
-        public Style MessageStyle
+        public Style? MessageStyle
         {
             get => (Style)GetValue(MessageStyleProperty);
             set => SetValue(MessageStyleProperty, value);
@@ -262,7 +262,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the play/pause button style.
         /// </summary>
-        public Style PlayPauseButtonStyle
+        public Style? PlayPauseButtonStyle
         {
             get => (Style)GetValue(PlayPauseButtonStyleProperty);
             set => SetValue(PlayPauseButtonStyleProperty, value);
@@ -276,7 +276,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the remaining time label style.
         /// </summary>
-        public Style RemainingTimeLabelStyle
+        public Style? RemainingTimeLabelStyle
         {
             get => (Style)GetValue(RemainingTimeLabelStyleProperty);
             set => SetValue(RemainingTimeLabelStyleProperty, value);
@@ -290,7 +290,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the elapsed time label style.
         /// </summary>
-        public Style ElapsedTimeLabelStyle
+        public Style? ElapsedTimeLabelStyle
         {
             get => (Style)GetValue(ElapsedTimeLabelStyleProperty);
             set => SetValue(ElapsedTimeLabelStyleProperty, value);
@@ -304,7 +304,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the seek bar style.
         /// </summary>
-        public Style SeekBarStyle
+        public Style? SeekBarStyle
         {
             get => (Style)GetValue(SeekBarStyleProperty);
             set => SetValue(SeekBarStyleProperty, value);
@@ -318,7 +318,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the stop button style.
         /// </summary>
-        public Style StopButtonStyle
+        public Style? StopButtonStyle
         {
             get => (Style)GetValue(StopButtonStyleProperty);
             set => SetValue(StopButtonStyleProperty, value);
@@ -335,7 +335,7 @@ namespace LibVLCSharp.Forms.Shared
         /// Gets or sets the associated <see cref="VideoView"/>.
         /// </summary>
         /// <remarks>It is only useful to set this property for the aspect ratio feature.</remarks>
-        public VideoView VideoView
+        public VideoView? VideoView
         {
             get => (VideoView)GetValue(VideoViewProperty);
             set => SetValue(VideoViewProperty, value);
@@ -349,7 +349,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the aspect ratio button style.
         /// </summary>
-        public Style AspectRatioButtonStyle
+        public Style? AspectRatioButtonStyle
         {
             get => (Style)GetValue(AspectRatioButtonStyleProperty);
             set => SetValue(AspectRatioButtonStyleProperty, value);
@@ -363,7 +363,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the rewind button style.
         /// </summary>
-        public Style RewindButtonStyle
+        public Style? RewindButtonStyle
         {
             get => (Style)GetValue(RewindButtonStyleProperty);
             set => SetValue(RewindButtonStyleProperty, value);
@@ -377,7 +377,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets or sets the rewind button style.
         /// </summary>
-        public Style SeekButtonStyle
+        public Style? SeekButtonStyle
         {
             get => (Style)GetValue(SeekButtonStyleProperty);
             set => SetValue(SeekButtonStyleProperty, value);
@@ -461,7 +461,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Gets the last error message.
         /// </summary>
-        public string ErrorMessage
+        public string? ErrorMessage
         {
             get => (string)GetValue(ErrorMessageProperty);
             private set => SetValue(ErrorMessageProperty, value);
@@ -687,11 +687,11 @@ namespace LibVLCSharp.Forms.Shared
             PlayPauseButton = SetClickEventHandler(nameof(PlayPauseButton), PlayPauseButton_Clicked);
             SetClickEventHandler("StopButton", StopButton_Clicked);
             SetClickEventHandler("AspectRatioButton", AspectRatioButton_ClickedAsync);
-            ControlsPanel = this.FindChild<VisualElement>(nameof(ControlsPanel));
-            SeekBar = this.FindChild<Slider>(nameof(SeekBar));
-            RemainingTimeLabel = this.FindChild<Label>(nameof(RemainingTimeLabel));
-            ElapsedTimeLabel = this.FindChild<Label>(nameof(ElapsedTimeLabel));
-            AspectRatioLabel = this.FindChild<Label>(nameof(AspectRatioLabel));
+            ControlsPanel = this.FindChild<VisualElement?>(nameof(ControlsPanel));
+            SeekBar = this.FindChild<Slider?>(nameof(SeekBar));
+            RemainingTimeLabel = this.FindChild<Label?>(nameof(RemainingTimeLabel));
+            ElapsedTimeLabel = this.FindChild<Label?>(nameof(ElapsedTimeLabel));
+            AspectRatioLabel = this.FindChild<Label?>(nameof(AspectRatioLabel));
             SetClickEventHandler("RewindButton", RewindButton_Clicked);
             SetClickEventHandler("SeekButton", SeekButton_Clicked);
 
@@ -781,8 +781,13 @@ namespace LibVLCSharp.Forms.Shared
                 }
                 else
                 {
-                    var result = await this.FindAncestor<Page>()?.DisplayActionSheet(ResourceManager.GetString(nameof(Strings.CastTo)),
+                    var page = this.FindAncestor<Page>();
+                    if (page == null)
+                        return;
+
+                    var result = await page.DisplayActionSheet(ResourceManager.GetString(nameof(Strings.CastTo)),
                         Cancel, Disconnect, renderers.Select(r => r.Name).OrderBy(r => r).ToArray());
+
                     if (result != null)
                     {
                         var rendererName = renderers.FirstOrDefault(r => r.Name == result);
@@ -808,6 +813,9 @@ namespace LibVLCSharp.Forms.Shared
                 OnShowAndHideAutomaticallyPropertyChanged();
             }
             Show();
+
+
+
         }
 
         private async void ClosedCaptionsSelectionButton_ClickedAsync(object sender, EventArgs e)
@@ -833,6 +841,9 @@ namespace LibVLCSharp.Forms.Shared
                 aspectRatioManager.AspectRatio = aspectRatioManager.AspectRatio == AspectRatio.Original ? AspectRatio.BestFit :
                     aspectRatioManager.AspectRatio + 1;
 
+                if (AspectRatioLabel == null)
+                    return;
+
                 AspectRatioLabel.Text = Strings.ResourceManager.GetString($"{nameof(AspectRatio)}{aspectRatioManager.AspectRatio}");
                 await AspectRatioLabel.FadeTo(1);
                 await AspectRatioLabel.FadeTo(0, 2000);
@@ -841,6 +852,7 @@ namespace LibVLCSharp.Forms.Shared
             {
                 ShowErrorMessageBox(ex);
             }
+
         }
 
         private void RewindButton_Clicked(object sender, EventArgs e)
@@ -865,9 +877,9 @@ namespace LibVLCSharp.Forms.Shared
             mediaPlayer.Time += SEEK_OFFSET;
         }
 
-        private Button SetClickEventHandler(string name, EventHandler eventHandler)
+        private Button? SetClickEventHandler(string name, EventHandler eventHandler, bool fadeIn = false)
         {
-            var button = this.FindChild<Button>(name);
+            var button = this.FindChild<Button?>(name);
             if (button != null)
             {
                 button.Clicked += (sender, e) => OnButtonClicked(sender, e, eventHandler);
@@ -899,7 +911,7 @@ namespace LibVLCSharp.Forms.Shared
             VisualStateManager.GoToState(PlayPauseButton, PlayState);
         }
 
-        private string GetTrackName(string trackName, int trackId, int currentTrackId)
+        private string? GetTrackName(string? trackName, int trackId, int currentTrackId)
         {
             return trackId == currentTrackId ? $"{trackName} *" : trackName;
         }
@@ -916,7 +928,7 @@ namespace LibVLCSharp.Forms.Shared
             {
                 var currentTrackId = manager.CurrentTrackId;
                 var index = 0;
-                IEnumerable<string> tracksNames = tracks.Select(t =>
+                IEnumerable<string?> tracksNames = tracks.Select(t =>
                 {
                     index += 1;
                     return GetTrackName(t.Name, currentTrackId, index);
@@ -927,7 +939,10 @@ namespace LibVLCSharp.Forms.Shared
                         .Union(tracksNames);
                 }
 
-                var trackName = await this.FindAncestor<Page>()?.DisplayActionSheet(popupTitle, null, null, tracksNames.ToArray());
+                var page = this.FindAncestor<Page>();
+                if (page == null) return;
+
+                var trackName = await page.DisplayActionSheet(popupTitle, null, null, tracksNames.ToArray());
                 if (trackName != null)
                 {
                     var found = false;
@@ -954,7 +969,7 @@ namespace LibVLCSharp.Forms.Shared
             }
         }
 
-        private void UpdateTracksSelectionButtonAvailability(Button tracksSelectionButton, string state)
+        private void UpdateTracksSelectionButtonAvailability(Button? tracksSelectionButton, string state)
         {
             if (tracksSelectionButton != null)
             {
@@ -962,7 +977,7 @@ namespace LibVLCSharp.Forms.Shared
             }
         }
 
-        private void UpdateTracksSelectionAvailability(TracksManager tracksManager, Button tracksSelectionButton,
+        private void UpdateTracksSelectionAvailability(TracksManager tracksManager, Button? tracksSelectionButton,
             bool isTracksSelectionButtonVisible, string availableState, string unavailableState, int count)
         {
             if (tracksSelectionButton != null)
@@ -987,7 +1002,7 @@ namespace LibVLCSharp.Forms.Shared
 
         private void ShowError()
         {
-            ErrorMessage = string.Format(ResourceManager.GetString(nameof(Strings.ErrorWithMedia)), Manager.Get<StateManager>().MediaResourceLocator);
+            Device.BeginInvokeOnMainThread(() => ErrorMessage = string.Format(ResourceManager.GetString(nameof(Strings.ErrorWithMedia)), Manager.Get<StateManager>().MediaResourceLocator));
         }
 
         private void UpdateKeepScreenOn(bool keepScreenOn)
@@ -1070,7 +1085,7 @@ namespace LibVLCSharp.Forms.Shared
         protected virtual void ShowErrorMessageBox(Exception ex)
         {
             var error = ResourceManager.GetString(nameof(Strings.Error));
-            Device.BeginInvokeOnMainThread(() => this.FindAncestor<Page>().DisplayAlert(error, ex?.GetBaseException().Message ?? error,
+            Device.BeginInvokeOnMainThread(() => this.FindAncestor<Page?>()?.DisplayAlert(error, ex?.GetBaseException().Message ?? error,
                 ResourceManager.GetString(nameof(Strings.OK))));
         }
 

--- a/src/LibVLCSharp.Forms/Shared/VideoView.cs
+++ b/src/LibVLCSharp.Forms/Shared/VideoView.cs
@@ -14,12 +14,12 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// Raised when a new MediaPlayer is set and will be attached to the view
         /// </summary>
-        public event EventHandler<MediaPlayerChangingEventArgs> MediaPlayerChanging;
+        public event EventHandler<MediaPlayerChangingEventArgs>? MediaPlayerChanging;
 
         /// <summary>
         /// Raised when a new MediaPlayer is set and attached to the view
         /// </summary>
-        public event EventHandler<MediaPlayerChangedEventArgs> MediaPlayerChanged;
+        public event EventHandler<MediaPlayerChangedEventArgs>? MediaPlayerChanged;
 
         /// <summary>
         /// Xamarin.Forms MediaPlayer databinded property
@@ -33,7 +33,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <summary>
         /// The MediaPlayer object attached to this view
         /// </summary>
-        public LibVLCSharp.Shared.MediaPlayer MediaPlayer
+        public LibVLCSharp.Shared.MediaPlayer? MediaPlayer
         {
             get { return GetValue(MediaPlayerProperty) as LibVLCSharp.Shared.MediaPlayer; }
             set { SetValue(MediaPlayerProperty, value); }

--- a/src/LibVLCSharp.Forms/Shared/VisualTreeHelper.cs
+++ b/src/LibVLCSharp.Forms/Shared/VisualTreeHelper.cs
@@ -15,7 +15,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <typeparam name="T">Element type to find.</typeparam>
         /// <param name="parent">The parent element.</param>
         /// <returns>The child element, or null if not found.</returns>
-        internal static T FindChild<T>(this Element parent) where T : Element
+        internal static T FindChild<T>(this Element parent) where T : Element?
         {
             if (parent is Layout layout)
             {
@@ -25,15 +25,15 @@ namespace LibVLCSharp.Forms.Shared
                     {
                         return result;
                     }
-                    result = child.FindChild<T>();
-                    if (result != null)
+                    var childResult = child.FindChild<T>();
+                    if (childResult != null)
                     {
-                        return result;
+                        return childResult;
                     }
                 }
             }
 
-            return null;
+            return default!;
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <param name="parent">The parent element.</param>
         /// <param name="name">The searched name</param>
         /// <returns>The child element, or null if not found.</returns>
-        internal static T FindChild<T>(this Element parent, string name) where T : Element
+        internal static T FindChild<T>(this Element parent, string name) where T : Element?
         {
             var result = parent.FindByName<T>(name);
             if (result != null)
@@ -63,7 +63,7 @@ namespace LibVLCSharp.Forms.Shared
                 }
             }
 
-            return null;
+            return default!;
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace LibVLCSharp.Forms.Shared
         /// <typeparam name="T">Ancestor element type.</typeparam>
         /// <param name="element">The element.</param>
         /// <returns>The ancestor element of the given type, or null if not found.</returns>
-        internal static T FindAncestor<T>(this Element element) where T : Element
+        internal static T FindAncestor<T>(this Element element) where T : Element?
         {
             if (element != null)
             {
@@ -86,7 +86,7 @@ namespace LibVLCSharp.Forms.Shared
                     element = element.Parent;
                 }
             }
-            return null;
+            return default!;
         }
     }
 }

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -28,13 +28,14 @@ This package also contains the views for the following platforms:
 If you need Xamarin.Forms support, see LibVLCSharp.Forms. 
 
 LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard1.1;net40;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.1;net40;net471</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0;uap10.0.16299</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAWindow</TargetsForTfmSpecificBuildOutput>
     <RootNamespace>LibVLCSharp</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <Version>3.4.3</Version>
     <PackageId>LibVLCSharp</PackageId>
     <Authors>VideoLAN</Authors>

--- a/src/LibVLCSharp/Platforms/Android/VideoView.cs
+++ b/src/LibVLCSharp/Platforms/Android/VideoView.cs
@@ -16,9 +16,9 @@ namespace LibVLCSharp.Platforms.Android
     /// </summary>
     public class VideoView : SurfaceView, IVLCVoutCallback, IVideoView, AWindow.ISurfaceCallback
     {
-        MediaPlayer _mediaPlayer;
-        AWindow _awindow;
-        LayoutChangeListener _layoutListener;
+        MediaPlayer? _mediaPlayer;
+        AWindow? _awindow;
+        LayoutChangeListener? _layoutListener;
 
         #region ctors
 
@@ -75,7 +75,7 @@ namespace LibVLCSharp.Platforms.Android
         /// <summary>
         /// The MediaPlayer object attached to this VideoView. Use this to manage playback and more
         /// </summary>
-        public MediaPlayer MediaPlayer
+        public MediaPlayer? MediaPlayer
         {
             get => _mediaPlayer;
             set

--- a/src/LibVLCSharp/Platforms/Apple/VideoView.cs
+++ b/src/LibVLCSharp/Platforms/Apple/VideoView.cs
@@ -25,12 +25,12 @@ namespace LibVLCSharp.Platforms.Mac
     public class VideoView : NSView, IVideoView
 #endif
     {
-        Shared.MediaPlayer _mediaPlayer;
+        Shared.MediaPlayer? _mediaPlayer;
 
         /// <summary>
         /// The MediaPlayer object attached to this VideoView. Use this to manage playback and more
         /// </summary>
-        public Shared.MediaPlayer MediaPlayer
+        public Shared.MediaPlayer? MediaPlayer
         {
             get => _mediaPlayer;
             set

--- a/src/LibVLCSharp/Platforms/UWP/VideoViewBase.cs
+++ b/src/LibVLCSharp/Platforms/UWP/VideoViewBase.cs
@@ -19,12 +19,12 @@ namespace LibVLCSharp.Platforms.UWP
     {
         private const string PartSwapChainPanelName = "SwapChainPanel";
 
-        SwapChainPanel _panel;
-        SharpDX.Direct3D11.Device _d3D11Device;
-        SharpDX.DXGI.Device1 _device;
-        SharpDX.DXGI.Device3 _device3;
-        SwapChain2 _swapChain2;
-        SwapChain1 _swapChain;
+        SwapChainPanel? _panel;
+        SharpDX.Direct3D11.Device? _d3D11Device;
+        SharpDX.DXGI.Device1? _device;
+        SharpDX.DXGI.Device3? _device3;
+        SwapChain2? _swapChain2;
+        SwapChain1? _swapChain;
         const string Mobile = "Windows.Mobile";
         bool _loaded;
 
@@ -98,8 +98,8 @@ namespace LibVLCSharp.Platforms.UWP
 
                 return new string[]
                 {
-                    $"--winrt-d3dcontext=0x{_d3D11Device.ImmediateContext.NativePointer.ToString("x")}",
-                    $"--winrt-swapchain=0x{_swapChain.NativePointer.ToString("x")}"
+                    $"--winrt-d3dcontext=0x{_d3D11Device!.ImmediateContext.NativePointer.ToString("x")}",
+                    $"--winrt-swapchain=0x{_swapChain!.NativePointer.ToString("x")}"
                 };
             }
         }
@@ -118,7 +118,8 @@ namespace LibVLCSharp.Platforms.UWP
             if (_panel == null || _panel.ActualHeight == 0)
                 return;
 
-            SharpDX.DXGI.Factory2 dxgiFactory = null;
+
+            SharpDX.DXGI.Factory2? dxgiFactory = null;
             try
             {
                 var deviceCreationFlags =
@@ -252,7 +253,7 @@ namespace LibVLCSharp.Platforms.UWP
         /// </summary>
         void UpdateSize()
         {
-            if (_swapChain == null || _swapChain.IsDisposed)
+            if (_panel is null || _swapChain is null || _swapChain.IsDisposed)
                 return;
 
             var width = IntPtr.Zero;
@@ -284,7 +285,8 @@ namespace LibVLCSharp.Platforms.UWP
         /// </summary>
         void UpdateScale()
         {
-            _swapChain2.MatrixTransform = new RawMatrix3x2 { M11 = 1.0f / _panel.CompositionScaleX, M22 = 1.0f / _panel.CompositionScaleY };
+            if (_panel is null) return;
+            _swapChain2!.MatrixTransform = new RawMatrix3x2 { M11 = 1.0f / _panel.CompositionScaleX, M22 = 1.0f / _panel.CompositionScaleY };
         }
 
         /// <summary>
@@ -318,9 +320,9 @@ namespace LibVLCSharp.Platforms.UWP
         /// <summary>
         /// MediaPlayer object connected to the view
         /// </summary>
-        public MediaPlayer MediaPlayer
+        public MediaPlayer? MediaPlayer
         {
-            get => (MediaPlayer)GetValue(MediaPlayerProperty);
+            get => (MediaPlayer?)GetValue(MediaPlayerProperty);
             set => SetValue(MediaPlayerProperty, value);
         }
 

--- a/src/LibVLCSharp/Platforms/UWP/VideoViewOfTInitializedEventArgs.cs
+++ b/src/LibVLCSharp/Platforms/UWP/VideoViewOfTInitializedEventArgs.cs
@@ -10,7 +10,7 @@ namespace LibVLCSharp.Platforms.UWP
         /// <summary>
         /// Occurs when the <see cref="VideoView"/> is fully loaded and the <see cref="VideoViewBase.SwapChainOptions"/> property is set
         /// </summary>
-        public event EventHandler<TInitializedEventArgs> Initialized;
+        public event EventHandler<TInitializedEventArgs>? Initialized;
 
         /// <summary>
         /// Creates args for <see cref="Initialized"/> event

--- a/src/LibVLCSharp/Shared/Dialog.cs
+++ b/src/LibVLCSharp/Shared/Dialog.cs
@@ -28,7 +28,7 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_dialog_dismiss")]
             internal static extern int LibVLCDialogDismiss(IntPtr dialogId);
         }
-        
+
         Dialog(IntPtr id)
         {
             if(id == IntPtr.Zero)
@@ -48,28 +48,26 @@ namespace LibVLCSharp.Shared
         /// <param name="password">valid string</param>
         /// <param name="store">if true stores the credentials</param>
         /// <returns></returns>
-        public bool PostLogin(string username, string password, bool store)
+        public bool PostLogin(string? username, string? password, bool store)
         {
             if (_id == IntPtr.Zero)
                 throw new VLCException("Calling method on dismissed Dialog instance");
 
-            if (username == null)
-                username = string.Empty;
-            if (password == null)
-                password = string.Empty;
+            username ??= string.Empty;
+            password ??= string.Empty;
 
             var usernamePtr = username.ToUtf8();
             var passwordPtr = password.ToUtf8();
 
             var result = MarshalUtils.PerformInteropAndFree(
-                () => Native.LibVLCDialogPostLogin(_id, usernamePtr, passwordPtr, store), 
+                () => Native.LibVLCDialogPostLogin(_id, usernamePtr, passwordPtr, store),
                 usernamePtr, passwordPtr) == 0;
 
             _id = IntPtr.Zero;
 
             return result;
         }
-        
+
         /// <summary>
         /// Post a question answer.
         /// After this call, this instance won't be valid anymore
@@ -135,14 +133,14 @@ namespace LibVLCSharp.Shared
     }
 
     /// <summary>
-    /// Called when an error message needs to be displayed. 
+    /// Called when an error message needs to be displayed.
     /// </summary>
     /// <param name="title">title of the dialog </param>
     /// <param name="text">text of the dialog </param>
-    public delegate Task DisplayError(string title, string text);
+    public delegate Task DisplayError(string? title, string? text);
 
     /// <summary>
-    /// Called when a login dialog needs to be displayed. 
+    /// Called when a login dialog needs to be displayed.
     /// You can interact with this dialog by calling PostLogin() to post an answer or Dismiss() to cancel this dialog.
     /// </summary>
     /// <param name="dialog">id used to interact with the dialog </param>
@@ -151,10 +149,10 @@ namespace LibVLCSharp.Shared
     /// <param name="defaultUsername">user name that should be set on the user form</param>
     /// <param name="askStore">if true, ask the user if he wants to save the credentials</param>
     /// <param name="token">Use token to cancel operation</param>
-    public delegate Task DisplayLogin(Dialog dialog, string title, string text, string defaultUsername, bool askStore, CancellationToken token);
+    public delegate Task DisplayLogin(Dialog dialog, string? title, string? text, string? defaultUsername, bool askStore, CancellationToken token);
 
     /// <summary>
-    /// Called when a question dialog needs to be displayed. 
+    /// Called when a question dialog needs to be displayed.
     /// You can interact with this dialog by calling PostAction() to post an answer or Dismiss() to cancel this dialog.
     /// </summary>
     /// <param name="dialog">id used to interact with the dialog</param>
@@ -165,11 +163,11 @@ namespace LibVLCSharp.Shared
     /// <param name="firstActionText">text of the first button, if NULL, don't display this button</param>
     /// <param name="secondActionText">text of the second button, if NULL, don't display this button</param>
     /// <param name="token">Use token to cancel operation</param>
-    public delegate Task DisplayQuestion(Dialog dialog, string title, string text, DialogQuestionType type, string cancelText,
-        string firstActionText, string secondActionText, CancellationToken token);
+    public delegate Task DisplayQuestion(Dialog dialog, string? title, string? text, DialogQuestionType type, string? cancelText,
+        string? firstActionText, string? secondActionText, CancellationToken token);
 
     /// <summary>
-    /// Called when a progress dialog needs to be displayed. 
+    /// Called when a progress dialog needs to be displayed.
     /// If cancellable cancelText is not NULL, you can cancel this dialog by calling libvlc_dialog_dismiss()
     /// </summary>
     /// <param name="dialog">id used to interact with the dialog</param>
@@ -179,13 +177,13 @@ namespace LibVLCSharp.Shared
     /// <param name="position">initial position of the progress bar (between 0.0 and 1.0)</param>
     /// <param name="cancelText">text of the cancel button, if NULL the dialog is not cancellable</param>
     /// <param name="token">Use token to cancel operation</param>
-    public delegate Task DisplayProgress(Dialog dialog, string title, string text, bool indeterminate, float position, string cancelText, CancellationToken token);
+    public delegate Task DisplayProgress(Dialog dialog, string? title, string? text, bool indeterminate, float position, string? cancelText, CancellationToken token);
 
     /// <summary>
-    /// Called when a progress dialog needs to be updated. 
+    /// Called when a progress dialog needs to be updated.
     /// </summary>
     /// <param name="dialog">id of the dialog</param>
     /// <param name="position">position of the progress bar (between 0.0 and 1.0)</param>
     /// <param name="text">new text of the progress dialog </param>
-    public delegate Task UpdateProgress(Dialog dialog, float position, string text);
+    public delegate Task UpdateProgress(Dialog dialog, float position, string? text);
 }

--- a/src/LibVLCSharp/Shared/Equalizer.cs
+++ b/src/LibVLCSharp/Shared/Equalizer.cs
@@ -126,7 +126,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="index">index of the preset, counting from zero</param>
         /// <returns>preset name, or empty string if there is no such preset</returns>
-        public string PresetName(uint index) => Native.LibVLCAudioEqualizerGetPresetName(index).FromUtf8();
+        public string? PresetName(uint index) => Native.LibVLCAudioEqualizerGetPresetName(index).FromUtf8();
 
         /// <summary>
         /// Get the number of distinct frequency bands for an equalizer.
@@ -145,7 +145,7 @@ namespace LibVLCSharp.Shared
         public float BandFrequency(uint index) => Native.LibVLCAudioEqualizerGetBandFrequency(index);
 
         /// <summary>
-        /// Dipose for equalizer
+        /// Dispose for equalizer
         /// </summary>
         /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)

--- a/src/LibVLCSharp/Shared/Events/MediaDiscovererEventManager.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaDiscovererEventManager.cs
@@ -4,8 +4,8 @@ namespace LibVLCSharp.Shared
 {
     internal class MediaDiscovererEventManager : EventManager
     {
-        EventHandler<EventArgs> _mediaDiscovererStarted;
-        EventHandler<EventArgs> _mediaDiscovererStopped;
+        EventHandler<EventArgs>? _mediaDiscovererStarted;
+        EventHandler<EventArgs>? _mediaDiscovererStopped;
 
         public MediaDiscovererEventManager(IntPtr ptr) : base(ptr)
         {

--- a/src/LibVLCSharp/Shared/Events/MediaEventManager.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaEventManager.cs
@@ -4,13 +4,13 @@ namespace LibVLCSharp.Shared
 {
     internal class MediaEventManager : EventManager
     {
-        EventHandler<MediaMetaChangedEventArgs> _mediaMetaChanged;
-        EventHandler<MediaParsedChangedEventArgs> _mediaParsedChanged;
-        EventHandler<MediaSubItemAddedEventArgs> _mediaSubItemAdded;
-        EventHandler<MediaDurationChangedEventArgs> _mediaDurationChanged;
-        EventHandler<MediaFreedEventArgs> _mediaFreed;
-        EventHandler<MediaStateChangedEventArgs> _mediaStateChanged;
-        EventHandler<MediaSubItemTreeAddedEventArgs> _mediaSubItemTreeAdded;
+        EventHandler<MediaMetaChangedEventArgs>? _mediaMetaChanged;
+        EventHandler<MediaParsedChangedEventArgs>? _mediaParsedChanged;
+        EventHandler<MediaSubItemAddedEventArgs>? _mediaSubItemAdded;
+        EventHandler<MediaDurationChangedEventArgs>? _mediaDurationChanged;
+        EventHandler<MediaFreedEventArgs>? _mediaFreed;
+        EventHandler<MediaStateChangedEventArgs>? _mediaStateChanged;
+        EventHandler<MediaSubItemTreeAddedEventArgs>? _mediaSubItemTreeAdded;
 
         public MediaEventManager(IntPtr ptr) : base(ptr)
         {
@@ -101,23 +101,23 @@ namespace LibVLCSharp.Shared
         void OnMediaStateChanged(IntPtr ptr)
         {
             _mediaStateChanged?.Invoke(this,
-                new MediaStateChangedEventArgs(RetrieveEvent(ptr).Union.MediaStateChanged.NewState));    
+                new MediaStateChangedEventArgs(RetrieveEvent(ptr).Union.MediaStateChanged.NewState));
         }
-        
+
         void OnMediaFreed(IntPtr ptr)
         {
-            _mediaFreed?.Invoke(this, new MediaFreedEventArgs(RetrieveEvent(ptr).Union.MediaFreed.MediaInstance));    
+            _mediaFreed?.Invoke(this, new MediaFreedEventArgs(RetrieveEvent(ptr).Union.MediaFreed.MediaInstance));
         }
 
         void OnDurationChanged(IntPtr ptr)
         {
-            _mediaDurationChanged?.Invoke(this, 
-                new MediaDurationChangedEventArgs(RetrieveEvent(ptr).Union.MediaDurationChanged.NewDuration));    
+            _mediaDurationChanged?.Invoke(this,
+                new MediaDurationChangedEventArgs(RetrieveEvent(ptr).Union.MediaDurationChanged.NewDuration));
         }
 
         void OnSubItemAdded(IntPtr ptr)
         {
-            _mediaSubItemAdded?.Invoke(this, 
+            _mediaSubItemAdded?.Invoke(this,
                 new MediaSubItemAddedEventArgs(RetrieveEvent(ptr).Union.MediaSubItemAdded.NewChild));
         }
 

--- a/src/LibVLCSharp/Shared/Events/MediaListEventManager.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaListEventManager.cs
@@ -5,11 +5,11 @@ namespace LibVLCSharp.Shared
 {
     internal class MediaListEventManager : EventManager
     {
-        EventHandler<MediaListItemAddedEventArgs> _mediaListItemAdded;
-        EventHandler<MediaListWillAddItemEventArgs> _mediaListWillAddItem;
-        EventHandler<MediaListItemDeletedEventArgs> _mediaListItemDeleted;
-        EventHandler<MediaListWillDeleteItemEventArgs> _mediaListWillDeleteItem;
-        EventHandler<EventArgs> _mediaListEndReached;
+        EventHandler<MediaListItemAddedEventArgs>? _mediaListItemAdded;
+        EventHandler<MediaListWillAddItemEventArgs>? _mediaListWillAddItem;
+        EventHandler<MediaListItemDeletedEventArgs>? _mediaListItemDeleted;
+        EventHandler<MediaListWillDeleteItemEventArgs>? _mediaListWillDeleteItem;
+        EventHandler<EventArgs>? _mediaListEndReached;
 
         public MediaListEventManager(IntPtr ptr) : base(ptr)
         {

--- a/src/LibVLCSharp/Shared/Events/MediaPlayerChangedEventArgs.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaPlayerChangedEventArgs.cs
@@ -13,7 +13,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="oldMediaPlayer">The previous mediaplayer (if any)</param>
         /// <param name="newMediaPlayer">The new mediaplayer (if any)</param>
-        public MediaPlayerChangedEventArgs(MediaPlayer oldMediaPlayer, MediaPlayer newMediaPlayer)
+        public MediaPlayerChangedEventArgs(MediaPlayer? oldMediaPlayer, MediaPlayer? newMediaPlayer)
         {
             OldMediaPlayer = oldMediaPlayer;
             NewMediaPlayer = newMediaPlayer;
@@ -22,11 +22,11 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// The previous mediaplayer (if any)
         /// </summary>
-        public MediaPlayer OldMediaPlayer { get; }
+        public MediaPlayer? OldMediaPlayer { get; }
 
         /// <summary>
         /// The new mediaplayer (if any)
         /// </summary>
-        public MediaPlayer NewMediaPlayer { get; }
+        public MediaPlayer? NewMediaPlayer { get; }
     }
 }

--- a/src/LibVLCSharp/Shared/Events/MediaPlayerChangingEventArgs.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaPlayerChangingEventArgs.cs
@@ -12,7 +12,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="oldMediaPlayer">The previous mediaplayer (if any)</param>
         /// <param name="newMediaPlayer">The new mediaplayer (if any)</param>
-        public MediaPlayerChangingEventArgs(MediaPlayer oldMediaPlayer, MediaPlayer newMediaPlayer)
+        public MediaPlayerChangingEventArgs(MediaPlayer? oldMediaPlayer, MediaPlayer? newMediaPlayer)
         {
             OldMediaPlayer = oldMediaPlayer;
             NewMediaPlayer = newMediaPlayer;
@@ -21,11 +21,11 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// The previous mediaplayer (if any)
         /// </summary>
-        public MediaPlayer OldMediaPlayer { get; }
+        public MediaPlayer? OldMediaPlayer { get; }
 
         /// <summary>
         /// The new mediaplayer (if any)
         /// </summary>
-        public MediaPlayer NewMediaPlayer { get; }
+        public MediaPlayer? NewMediaPlayer { get; }
     }
 }

--- a/src/LibVLCSharp/Shared/Events/MediaPlayerEventManager.cs
+++ b/src/LibVLCSharp/Shared/Events/MediaPlayerEventManager.cs
@@ -5,36 +5,36 @@ namespace LibVLCSharp.Shared
 {
     internal class MediaPlayerEventManager : EventManager
     {
-        EventHandler<MediaPlayerPositionChangedEventArgs> _mediaPlayerPositionChanged;
-        EventHandler<MediaPlayerMediaChangedEventArgs> _mediaPlayerMediaChanged;
-        EventHandler<EventArgs> _mediaPlayerNothingSpecial;
-        EventHandler<EventArgs> _mediaPlayerOpening;
-        EventHandler<MediaPlayerBufferingEventArgs> _mediaPlayerBuffering;
-        EventHandler<EventArgs> _mediaPlayerPlaying;
-        EventHandler<EventArgs> _mediaPlayerPaused;
-        EventHandler<EventArgs> _mediaPlayerStopped;
-        EventHandler<EventArgs> _mediaPlayerForward;
-        EventHandler<EventArgs> _mediaPlayerBackward;
-        EventHandler<EventArgs> _mediaPlayerEndReached;
-        EventHandler<EventArgs> _mediaPlayerEncounteredError;
-        EventHandler<MediaPlayerTimeChangedEventArgs> _mediaPlayerTimeChanged;
-        EventHandler<MediaPlayerSeekableChangedEventArgs> _mediaPlayerSeekableChanged;
-        EventHandler<MediaPlayerPausableChangedEventArgs> _mediaPlayerPausableChanged;
-        EventHandler<MediaPlayerTitleChangedEventArgs> _mediaPlayerTitleChanged;
-        EventHandler<MediaPlayerChapterChangedEventArgs> _mediaPlayerChapterChanged; //vlc 3
-        EventHandler<MediaPlayerSnapshotTakenEventArgs> _mediaPlayerSnapshotTaken;
-        EventHandler<MediaPlayerLengthChangedEventArgs> _mediaPlayerLengthChanged;
-        EventHandler<MediaPlayerVoutEventArgs> _mediaPlayerVout;
-        EventHandler<MediaPlayerScrambledChangedEventArgs> _mediaPlayerScrambledChanged;
-        EventHandler<MediaPlayerESAddedEventArgs> _mediaPlayerESAdded; // vlc 3
-        EventHandler<MediaPlayerESDeletedEventArgs> _mediaPlayerESDeleted; // vlc 3
-        EventHandler<MediaPlayerESSelectedEventArgs> _mediaPlayerESSelected; // vlc 3
-        EventHandler<MediaPlayerAudioDeviceEventArgs> _mediaPlayerAudioDevice; // vlc 3
-        EventHandler<EventArgs> _mediaPlayerCorked; // vlc 2.2
-        EventHandler<EventArgs> _mediaPlayerUncorked; // vlc 2.2
-        EventHandler<EventArgs> _mediaPlayerMuted; // vlc 2.2
-        EventHandler<EventArgs> _mediaPlayerUnmuted; // vlc 2.2
-        EventHandler<MediaPlayerVolumeChangedEventArgs> _mediaPlayerVolumeChanged; // vlc 2.2
+        EventHandler<MediaPlayerPositionChangedEventArgs>? _mediaPlayerPositionChanged;
+        EventHandler<MediaPlayerMediaChangedEventArgs>? _mediaPlayerMediaChanged;
+        EventHandler<EventArgs>? _mediaPlayerNothingSpecial;
+        EventHandler<EventArgs>? _mediaPlayerOpening;
+        EventHandler<MediaPlayerBufferingEventArgs>? _mediaPlayerBuffering;
+        EventHandler<EventArgs>? _mediaPlayerPlaying;
+        EventHandler<EventArgs>? _mediaPlayerPaused;
+        EventHandler<EventArgs>? _mediaPlayerStopped;
+        EventHandler<EventArgs>? _mediaPlayerForward;
+        EventHandler<EventArgs>? _mediaPlayerBackward;
+        EventHandler<EventArgs>? _mediaPlayerEndReached;
+        EventHandler<EventArgs>? _mediaPlayerEncounteredError;
+        EventHandler<MediaPlayerTimeChangedEventArgs>? _mediaPlayerTimeChanged;
+        EventHandler<MediaPlayerSeekableChangedEventArgs>? _mediaPlayerSeekableChanged;
+        EventHandler<MediaPlayerPausableChangedEventArgs>? _mediaPlayerPausableChanged;
+        EventHandler<MediaPlayerTitleChangedEventArgs>? _mediaPlayerTitleChanged;
+        EventHandler<MediaPlayerChapterChangedEventArgs>? _mediaPlayerChapterChanged; //vlc 3
+        EventHandler<MediaPlayerSnapshotTakenEventArgs>? _mediaPlayerSnapshotTaken;
+        EventHandler<MediaPlayerLengthChangedEventArgs>? _mediaPlayerLengthChanged;
+        EventHandler<MediaPlayerVoutEventArgs>? _mediaPlayerVout;
+        EventHandler<MediaPlayerScrambledChangedEventArgs>? _mediaPlayerScrambledChanged;
+        EventHandler<MediaPlayerESAddedEventArgs>? _mediaPlayerESAdded; // vlc 3
+        EventHandler<MediaPlayerESDeletedEventArgs>? _mediaPlayerESDeleted; // vlc 3
+        EventHandler<MediaPlayerESSelectedEventArgs>? _mediaPlayerESSelected; // vlc 3
+        EventHandler<MediaPlayerAudioDeviceEventArgs>? _mediaPlayerAudioDevice; // vlc 3
+        EventHandler<EventArgs>? _mediaPlayerCorked; // vlc 2.2
+        EventHandler<EventArgs>? _mediaPlayerUncorked; // vlc 2.2
+        EventHandler<EventArgs>? _mediaPlayerMuted; // vlc 2.2
+        EventHandler<EventArgs>? _mediaPlayerUnmuted; // vlc 2.2
+        EventHandler<MediaPlayerVolumeChangedEventArgs>? _mediaPlayerVolumeChanged; // vlc 2.2
         public MediaPlayerEventManager(IntPtr ptr) : base(ptr)
         {
         }
@@ -395,8 +395,7 @@ namespace LibVLCSharp.Shared
         void OnSnapshotTaken(IntPtr ptr)
         {
             var filenamePtr = RetrieveEvent(ptr).Union.MediaPlayerSnapshotTaken.Filename;
-            var filename = filenamePtr.FromUtf8();
-            _mediaPlayerSnapshotTaken?.Invoke(this, new MediaPlayerSnapshotTakenEventArgs(filename));
+            _mediaPlayerSnapshotTaken?.Invoke(this, new MediaPlayerSnapshotTakenEventArgs(filenamePtr.FromUtf8()!));
         }
 
         void OnLengthChanged(IntPtr ptr)
@@ -443,8 +442,7 @@ namespace LibVLCSharp.Shared
         void OnAudioDevice(IntPtr ptr)
         {
             var deviceNamePtr = RetrieveEvent(ptr).Union.AudioDeviceChanged.Device;
-            var deviceName = deviceNamePtr.FromUtf8();
-            _mediaPlayerAudioDevice?.Invoke(this, new MediaPlayerAudioDeviceEventArgs(deviceName));
+            _mediaPlayerAudioDevice?.Invoke(this, new MediaPlayerAudioDeviceEventArgs(deviceNamePtr.FromUtf8()!));
         }
 
         void OnCorked(IntPtr ptr)

--- a/src/LibVLCSharp/Shared/Events/RendererDiscovererEventManager.cs
+++ b/src/LibVLCSharp/Shared/Events/RendererDiscovererEventManager.cs
@@ -4,8 +4,8 @@ namespace LibVLCSharp.Shared
 {
     internal class RendererDiscovererEventManager : EventManager
     {
-        EventHandler<RendererDiscovererItemAddedEventArgs> _itemAdded;
-        EventHandler<RendererDiscovererItemDeletedEventArgs> _itemDeleted;
+        EventHandler<RendererDiscovererItemAddedEventArgs>? _itemAdded;
+        EventHandler<RendererDiscovererItemDeletedEventArgs>? _itemDeleted;
 
         internal RendererDiscovererEventManager(IntPtr ptr) : base(ptr)
         {
@@ -55,7 +55,7 @@ namespace LibVLCSharp.Shared
 
         void OnItemAdded(IntPtr args)
         {
-            var rendererItem = RetrieveEvent(args).Union.RendererDiscovererItemAdded;           
+            var rendererItem = RetrieveEvent(args).Union.RendererDiscovererItemAdded;
             _itemAdded?.Invoke(this, new RendererDiscovererItemAddedEventArgs(new RendererItem(rendererItem.item)));
         }
     }

--- a/src/LibVLCSharp/Shared/Helpers/MarshalExtensions.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalExtensions.cs
@@ -14,7 +14,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="s">AudioOutputDescriptionStructure from interop</param>
         /// <returns>public AudioOutputDescription to be consumed by the user</returns>
         internal static AudioOutputDescription Build(this AudioOutputDescriptionStructure s) => 
-            new AudioOutputDescription(s.Name.FromUtf8(), s.Description.FromUtf8());
+            new AudioOutputDescription(s.Name.FromUtf8()!, s.Description.FromUtf8()!);
 
         /// <summary>
         /// Helper method that creates a user friendly type from the internal interop structure.
@@ -22,7 +22,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="s">AudioOutputDeviceStructure from interop</param>
         /// <returns>public AudioOutputDevice to be consumed by the user</returns>
         internal static AudioOutputDevice Build(this AudioOutputDeviceStructure s) =>
-            new AudioOutputDevice(s.DeviceIdentifier.FromUtf8(), s.Description.FromUtf8());
+            new AudioOutputDevice(s.DeviceIdentifier.FromUtf8()!, s.Description.FromUtf8()!);
 
         /// <summary>
         /// Helper method that creates a user friendly type from the internal interop structure.
@@ -38,7 +38,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="s">TrackDescriptionStructure from interop</param>
         /// <returns>public TrackDescription to be consumed by the user</returns>
         internal static TrackDescription Build(this TrackDescriptionStructure s) =>
-            new TrackDescription(s.Id, s.Name.FromUtf8());
+            new TrackDescription(s.Id, s.Name.FromUtf8()!);
 
         /// <summary>
         /// Helper method that creates a user friendly type from the internal interop structure.
@@ -46,7 +46,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="s">MediaSlaveStructure from interop</param>
         /// <returns>public MediaSlave to be consumed by the user</returns>
         internal static MediaSlave Build(this MediaSlaveStructure s) => 
-            new MediaSlave(s.Uri.FromUtf8(), s.Type, s.Priority);
+            new MediaSlave(s.Uri.FromUtf8()!, s.Type, s.Priority);
 
         /// <summary>
         /// Helper method that creates a user friendly type from the internal interop structure.
@@ -113,12 +113,12 @@ namespace LibVLCSharp.Shared.Helpers
         /// </summary>
         /// <param name="str">the managed string to marshal to native</param>
         /// <returns>a ptr to the UTF8 string that needs to be freed after use</returns>
-        internal static IntPtr ToUtf8(this string str)
+        internal static IntPtr ToUtf8(this string? str)
         {
             if (str == null)
                 return IntPtr.Zero;
 
-            byte[] bytes = Encoding.UTF8.GetBytes(str);
+            var bytes = Encoding.UTF8.GetBytes(str);
             var nativeString = Marshal.AllocHGlobal(bytes.Length + 1);
             try
             {
@@ -141,7 +141,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="nativeString">the native string to marshal to managed</param>
         /// <param name="libvlcFree">frees the native pointer of the libvlc string (use only for char*)</param>
         /// <returns>a managed UTF16 string</returns>
-        internal static string FromUtf8(this IntPtr nativeString, bool libvlcFree = false)
+        internal static string? FromUtf8(this IntPtr nativeString, bool libvlcFree = false)
         {
             if (nativeString == IntPtr.Zero)
                 return null;
@@ -153,7 +153,7 @@ namespace LibVLCSharp.Shared.Helpers
                 length++;
             }
 
-            byte[] buffer = new byte[length];
+            var buffer = new byte[length];
             Marshal.Copy(nativeString, buffer, 0, buffer.Length);
             if (libvlcFree)
                 MarshalUtils.LibVLCFree(ref nativeString);

--- a/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -83,7 +83,7 @@ namespace LibVLCSharp.Shared.Helpers
             {
                 buffer = Marshal.AllocHGlobal(byteLength);
                 vsprintf(buffer, format, args);
-                return buffer.FromUtf8();
+                return buffer.FromUtf8()!;
             }
             finally
             {
@@ -102,7 +102,7 @@ namespace LibVLCSharp.Shared.Helpers
                 if (count == -1)
                     return string.Empty;
 
-                return buffer.FromUtf8();
+                return buffer.FromUtf8() ?? string.Empty;
             }
             finally
             {
@@ -128,7 +128,7 @@ namespace LibVLCSharp.Shared.Helpers
                 return UseStructurePointer(listStructure, listPointer =>
                 {
                     Native.vsprintf_linux(utf8Buffer, format, listPointer);
-                    return utf8Buffer.FromUtf8();
+                    return utf8Buffer.FromUtf8()!;
                 });
             }
             finally
@@ -191,7 +191,7 @@ namespace LibVLCSharp.Shared.Helpers
             return -1;
 #endif
         }
-        
+
 #endregion
 
         /// <summary>
@@ -218,11 +218,14 @@ namespace LibVLCSharp.Shared.Helpers
             }
             finally
             {
-                foreach (var arg in utf8Args)
+                if (!(utf8Args is null))
                 {
-                    if (arg != IntPtr.Zero)
+                    foreach (var arg in utf8Args)
                     {
-                        Marshal.FreeHGlobal(arg);
+                        if (arg != IntPtr.Zero)
+                        {
+                            Marshal.FreeHGlobal(arg);
+                        }
                     }
                 }
             }
@@ -416,7 +419,7 @@ namespace LibVLCSharp.Shared.Helpers
         /// <param name="releaseRef">Native libvlc call: release the array allocated with the getRef call with the given element count</param>
         /// <returns>An array of publicly facing struct types</returns>
         internal static TU[] Retrieve<T, TU, TE>(IntPtr nativeRef, TE extraParam, CategoryArrayOut<TE> getRef, Func<IntPtr, T> retrieve,
-            Func<T, TU> create, Action<IntPtr, UIntPtr> releaseRef) 
+            Func<T, TU> create, Action<IntPtr, UIntPtr> releaseRef)
             where T : struct
             where TU : struct
             where TE : Enum
@@ -479,13 +482,13 @@ namespace LibVLCSharp.Shared.Helpers
         /// </summary>
         /// <param name="args"></param>
         /// <returns>Array of pointer you need to release when you're done with Marshal.FreeHGlobal</returns>
-        internal static IntPtr[] ToUtf8(this string[] args)
+        internal static IntPtr[] ToUtf8(this string[]? args)
         {
             var utf8Args = new IntPtr[args?.Length ?? 0];
-            
+
             for (var i = 0; i < utf8Args.Length; i++)
             {
-                utf8Args[i] = args[i].ToUtf8();
+                utf8Args[i] = args![i].ToUtf8();
             }
 
             return utf8Args;
@@ -648,12 +651,12 @@ namespace LibVLCSharp.Shared.Helpers
         {
             if (handle == IntPtr.Zero)
             {
-                return null;
+                return default!;
             }
 
             var gch = GCHandle.FromIntPtr(handle);
             if (!gch.IsAllocated || !(gch.Target is T instance))
-                return null;
+                return default!;
 
             return instance;
         }

--- a/src/LibVLCSharp/Shared/IVideoView.cs
+++ b/src/LibVLCSharp/Shared/IVideoView.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// MediaPlayer object connected to the view
         /// </summary>
-        MediaPlayer MediaPlayer { get; set; }
+        MediaPlayer? MediaPlayer { get; set; }
     }
 }

--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -10,13 +10,13 @@ using LibVLCSharp.Shared.Structures;
 namespace LibVLCSharp.Shared
 {
     /// <summary>
-    /// Main LibVLC API object representing a libvlc instance in native code. 
+    /// Main LibVLC API object representing a libvlc instance in native code.
     /// Note: You may create multiple mediaplayers from a single LibVLC instance
     /// </summary>
     public class LibVLC : Internal
     {
         /// <summary>
-        /// Determines whether two object instances are equal. 
+        /// Determines whether two object instances are equal.
         /// </summary>
         /// <param name="other">other libvlc instance to compare with</param>
         /// <returns>true if same instance, false otherwise</returns>
@@ -26,11 +26,11 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Determines whether two object instances are equal. 
+        /// Determines whether two object instances are equal.
         /// </summary>
         /// <param name="obj">other libvlc instance to compare with</param>
         /// <returns>true if same instance, false otherwise</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -43,12 +43,12 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// The real log event handlers.
         /// </summary>
-        EventHandler<LogEventArgs> _log;
+        EventHandler<LogEventArgs>? _log;
 
 #if NETFRAMEWORK || NETSTANDARD
         IntPtr _logFileHandle;
 #endif
-        
+
         /// <summary>
         /// The GCHandle to be passed to callbacks as userData
         /// </summary>
@@ -246,7 +246,7 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Dipose of this libvlc instance
+        /// Dispose of this libvlc instance
         /// </summary>
         /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
@@ -272,7 +272,7 @@ namespace LibVLCSharp.Shared
         /// <param name="libvlc1">1st instance of libvlc</param>
         /// <param name="libvlc2">2nd instance of libvlc</param>
         /// <returns></returns>
-        public static bool operator ==(LibVLC libvlc1, LibVLC libvlc2)
+        public static bool operator ==(LibVLC? libvlc1, LibVLC? libvlc2)
         {
             return libvlc1?.NativeReference == libvlc2?.NativeReference;
         }
@@ -283,7 +283,7 @@ namespace LibVLCSharp.Shared
         /// <param name="libvlc1">1st instance of libvlc</param>
         /// <param name="libvlc2">2nd instance of libvlc</param>
         /// <returns></returns>
-        public static bool operator !=(LibVLC libvlc1, LibVLC libvlc2)
+        public static bool operator !=(LibVLC? libvlc1, LibVLC? libvlc2)
         {
             return libvlc1?.NativeReference != libvlc2?.NativeReference;
         }
@@ -292,16 +292,16 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Try to start a user interface for the libvlc instance.
         /// </summary>
-        /// <param name="name">interface name, or empty string for default</param>
+        /// <param name="name">interface name, or null for default</param>
         /// <returns>True if successful, false otherwise</returns>
-        public bool AddInterface(string name)
+        public bool AddInterface(string? name)
         {
             var namePtr = name.ToUtf8();
             return MarshalUtils.PerformInteropAndFree(() => Native.LibVLCAddInterface(NativeReference, namePtr) == 0, namePtr);
         }
 #endif
 
-        internal ExitCallback _exitCallback;
+        internal ExitCallback? _exitCallback;
 
         /// <summary>
         /// <para>Registers a callback for the LibVLC exit event. This is mostly useful if</para>
@@ -359,7 +359,7 @@ namespace LibVLCSharp.Shared
         /// <param name="version">application version numbers, e.g. &quot;1.2.3&quot;</param>
         /// <param name="icon">application icon name, e.g. &quot;foobar&quot;</param>
         /// <remarks>LibVLC 2.1.0 or later.</remarks>
-        public void SetAppId(string id, string version, string icon)
+        public void SetAppId(string? id, string? version, string? icon)
         {
             var idUtf8 = id.ToUtf8();
             var versionUtf8 = version.ToUtf8();
@@ -458,7 +458,7 @@ namespace LibVLCSharp.Shared
         public ModuleDescription[] AudioFilters => MarshalUtils.Retrieve(() => Native.LibVLCAudioFilterListGet(NativeReference),
             MarshalUtils.PtrToStructure<ModuleDescriptionStructure>,
             s => s.Build(),
-            module => module.Next, 
+            module => module.Next,
             Native.LibVLCModuleDescriptionListRelease);
 
         /// <summary>Returns a list of video filters that are available.</summary>
@@ -473,7 +473,7 @@ namespace LibVLCSharp.Shared
         public ModuleDescription[] VideoFilters => MarshalUtils.Retrieve(() => Native.LibVLCVideoFilterListGet(NativeReference),
             MarshalUtils.PtrToStructure<ModuleDescriptionStructure>,
             s => s.Build(),
-            module => module.Next, 
+            module => module.Next,
             Native.LibVLCModuleDescriptionListRelease);
 
         /// <summary>Gets the list of available audio output modules.</summary>
@@ -483,10 +483,10 @@ namespace LibVLCSharp.Shared
         /// <para>libvlc_audio_output_t .</para>
         /// <para>In case of error, NULL is returned.</para>
         /// </remarks>
-        public AudioOutputDescription[] AudioOutputs => MarshalUtils.Retrieve(() => Native.LibVLCAudioOutputListGet(NativeReference), 
+        public AudioOutputDescription[] AudioOutputs => MarshalUtils.Retrieve(() => Native.LibVLCAudioOutputListGet(NativeReference),
             ptr => MarshalUtils.PtrToStructure<AudioOutputDescriptionStructure>(ptr),
-            s => s.Build(), 
-            s => s.Next, 
+            s => s.Build(),
+            s => s.Next,
             Native.LibVLCAudioOutputListRelease);
 
         /// <summary>Gets a list of audio output devices for a given audio output module,</summary>
@@ -509,24 +509,24 @@ namespace LibVLCSharp.Shared
         /// <para>explicit audio device.</para>
         /// <para>LibVLC 2.1.0 or later.</para>
         /// </remarks>
-        public AudioOutputDevice[] AudioOutputDevices(string audioOutputName) => 
-            MarshalUtils.Retrieve(() => 
+        public AudioOutputDevice[] AudioOutputDevices(string audioOutputName) =>
+            MarshalUtils.Retrieve(() =>
             {
                 var audioOutputNameUtf8 = audioOutputName.ToUtf8();
-                return MarshalUtils.PerformInteropAndFree(() => 
+                return MarshalUtils.PerformInteropAndFree(() =>
                     Native.LibVLCAudioOutputDeviceListGet(NativeReference, audioOutputNameUtf8), audioOutputNameUtf8);
-            }, 
+            },
             MarshalUtils.PtrToStructure<AudioOutputDeviceStructure>,
-            s => s.Build(), 
-            device => device.Next, 
+            s => s.Build(),
+            device => device.Next,
             Native.LibVLCAudioOutputDeviceListRelease);
-        
+
         /// <summary>Get media discoverer services by category</summary>
         /// <param name="discovererCategory">category of services to fetch</param>
         /// <returns>the number of media discoverer services (0 on error)</returns>
         /// <remarks>LibVLC 3.0.0 and later.</remarks>
         public MediaDiscovererDescription[] MediaDiscoverers(MediaDiscovererCategory discovererCategory) =>
-            MarshalUtils.Retrieve(NativeReference, discovererCategory, 
+            MarshalUtils.Retrieve(NativeReference, discovererCategory,
                 (IntPtr nativeRef, MediaDiscovererCategory enumType, out IntPtr array) => Native.LibVLCMediaDiscovererListGet(nativeRef, enumType, out array),
             MarshalUtils.PtrToStructure<MediaDiscovererDescriptionStructure>,
             m => m.Build(),
@@ -536,7 +536,7 @@ namespace LibVLCSharp.Shared
 
 
         /// <summary>
-        /// Register callbacks in order to handle VLC dialogs. 
+        /// Register callbacks in order to handle VLC dialogs.
         /// LibVLC 3.0.0 and later.
         /// </summary>
         /// <param name="error">Called when an error message needs to be displayed.</param>
@@ -578,19 +578,19 @@ namespace LibVLCSharp.Shared
         /// True if dialog handlers are set
         /// </summary>
         public bool DialogHandlersSet => _error != null;
-        DisplayError _error;
-        DisplayLogin _login;
-        DisplayQuestion _question;
-        DisplayProgress _displayProgress;
-        UpdateProgress _updateProgress;
+        DisplayError? _error;
+        DisplayLogin? _login;
+        DisplayQuestion? _question;
+        DisplayProgress? _displayProgress;
+        UpdateProgress? _updateProgress;
         readonly Dictionary<IntPtr, CancellationTokenSource> _cts = new Dictionary<IntPtr, CancellationTokenSource>();
 
-        void OnDisplayError(string title, string text)
+        void OnDisplayError(string? title, string? text)
         {
             _error?.Invoke(title, text);
         }
 
-        void OnDisplayLogin(IntPtr dialogId, string title, string text, string defaultUsername, bool askStore)
+        void OnDisplayLogin(IntPtr dialogId, string? title, string? text, string? defaultUsername, bool askStore)
         {
             if (_login == null) return;
 
@@ -599,9 +599,9 @@ namespace LibVLCSharp.Shared
             _cts[dialogId] = cts;
             _login(dlg, title, text, defaultUsername, askStore, cts.Token);
         }
-        
-        void OnDisplayQuestion(IntPtr dialogId, string title, string text, DialogQuestionType type, 
-            string cancelText, string firstActionText, string secondActionText)
+
+        void OnDisplayQuestion(IntPtr dialogId, string? title, string? text, DialogQuestionType type,
+            string? cancelText, string? firstActionText, string? secondActionText)
         {
             if (_question == null) return;
 
@@ -611,7 +611,7 @@ namespace LibVLCSharp.Shared
             _question(dlg, title, text, type, cancelText, firstActionText, secondActionText, cts.Token);
         }
 
-        void OnDisplayProgress(IntPtr dialogId, string title, string text, bool indeterminate, float position, string cancelText)
+        void OnDisplayProgress(IntPtr dialogId, string? title, string? text, bool indeterminate, float position, string? cancelText)
         {
             if (_displayProgress == null) return;
 
@@ -630,7 +630,7 @@ namespace LibVLCSharp.Shared
             }
         }
 
-        void OnUpdateProgress(IntPtr dialogId, float position, string text)
+        void OnUpdateProgress(IntPtr dialogId, float position, string? text)
         {
             if (_updateProgress == null) return;
 
@@ -639,12 +639,12 @@ namespace LibVLCSharp.Shared
         }
 
         #endregion
-        
+
         /// <summary>
         /// List of available renderers used to create RendererDiscoverer objects
         /// Note: LibVLC 3.0.0 and later
-        /// </summary>       
-        public RendererDescription[] RendererList => MarshalUtils.Retrieve(NativeReference, 
+        /// </summary>
+        public RendererDescription[] RendererList => MarshalUtils.Retrieve(NativeReference,
             (IntPtr nativeRef, out IntPtr array) => Native.LibVLCRendererDiscovererGetList(nativeRef, out array),
             MarshalUtils.PtrToStructure<RendererDescriptionStructure>,
             m => m.Build(),
@@ -665,7 +665,7 @@ namespace LibVLCSharp.Shared
         /// <param name="module">The module name storage.</param>
         /// <param name="file">The source code file name storage.</param>
         /// <param name="line">The source code file line number storage.</param>
-        static void GetLogContext(IntPtr logContext, out string module, out string file, out uint? line)
+        static void GetLogContext(IntPtr logContext, out string? module, out string? file, out uint? line)
         {
             Native.LibVLCLogGetContext(logContext, out var modulePtr, out var filePtr, out var linePtr);
 
@@ -678,18 +678,18 @@ namespace LibVLCSharp.Shared
         internal void Retain() => Native.LibVLCRetain(NativeReference);
 
         /// <summary>The version of the LibVLC engine currently used by LibVLCSharp</summary>
-        public string Version => Native.LibVLCVersion().FromUtf8();
+        public string Version => Native.LibVLCVersion().FromUtf8()!;
 
         /// <summary>The changeset of the LibVLC engine currently used by LibVLCSharp</summary>
-        public string Changeset => Native.LibVLCChangeset().FromUtf8();
+        public string Changeset => Native.LibVLCChangeset().FromUtf8()!;
 
         /// <summary>
         /// A human-readable error message for the last LibVLC error in the calling
         /// thread. The resulting string is valid until another error occurs (at least
-        /// until the next LibVLC call). 
+        /// until the next LibVLC call).
         /// <para/> Null if no error.
         /// </summary>
-        public string LastLibVLCError => Native.LibVLCErrorMessage().FromUtf8();
+        public string? LastLibVLCError => Native.LibVLCErrorMessage().FromUtf8();
 
         /// <summary>
         /// Clears the LibVLC error status for the current thread. This is optional.
@@ -702,7 +702,7 @@ namespace LibVLCSharp.Shared
         /// Retrieve the libvlc compiler version.
         /// Example: "gcc version 4.2.3 (Ubuntu 4.2.3-2ubuntu6)"
         /// </summary>
-        public string LibVLCCompiler => Native.LibVLCGetCompiler().FromUtf8();
+        public string LibVLCCompiler => Native.LibVLCGetCompiler().FromUtf8()!;
 
         #region Exit
 
@@ -730,7 +730,7 @@ namespace LibVLCSharp.Shared
 
                 GetLogContext(logContext, out var module, out var file, out var line);
 
-                void logAction() => libVLC._log?.Invoke(null, new LogEventArgs(logLevel, message, module, file, line));
+                void logAction() => libVLC?._log?.Invoke(null, new LogEventArgs(logLevel, message, module, file, line));
 #if NET40
                 Task.Factory.StartNew(logAction);
 #else
@@ -808,8 +808,8 @@ namespace LibVLCSharp.Shared
         #region internal callbacks
 
         /// <summary>
-        /// Registers a callback for the LibVLC exit event. 
-        /// This is mostly useful if the VLC playlist and/or at least one interface are started with libvlc_playlist_play() 
+        /// Registers a callback for the LibVLC exit event.
+        /// This is mostly useful if the VLC playlist and/or at least one interface are started with libvlc_playlist_play()
         /// or AddInterface() respectively. Typically, this function will wake up your application main loop (from another thread).
         /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -889,10 +889,10 @@ namespace LibVLCSharp.Shared
 
     #region Callbacks
 
-    
+
     /// <summary>
-    /// Registers a callback for the LibVLC exit event. 
-    /// This is mostly useful if the VLC playlist and/or at least one interface are started with libvlc_playlist_play() 
+    /// Registers a callback for the LibVLC exit event.
+    /// This is mostly useful if the VLC playlist and/or at least one interface are started with libvlc_playlist_play()
     /// or AddInterface() respectively. Typically, this function will wake up your application main loop (from another thread).
     /// </summary>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/LibVLCSharp/Shared/LibVLCEvents.cs
+++ b/src/LibVLCSharp/Shared/LibVLCEvents.cs
@@ -959,7 +959,7 @@ namespace LibVLCSharp.Shared
     /// </summary>
     public sealed class LogEventArgs : EventArgs
     {
-        internal LogEventArgs(LogLevel level, string message, string module, string sourceFile, uint? sourceLine)
+        internal LogEventArgs(LogLevel level, string message, string? module, string? sourceFile, uint? sourceLine)
         {
             Level = level;
             Message = message;
@@ -982,13 +982,13 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// The name of the module that emitted the message
         /// </summary>
-        public string Module { get; }
+        public string? Module { get; }
 
         /// <summary>
         /// The source file that emitted the message.
         /// This may be <see langword="null"/> if that info is not available, i.e. always if you are using a release version of VLC.
         /// </summary>
-        public string SourceFile { get; }
+        public string? SourceFile { get; }
 
         /// <summary>
         /// The line in the <see cref="SourceFile"/> at which the message was emitted.

--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -324,7 +324,7 @@ namespace LibVLCSharp.Shared
             MarshalUtils.PerformInteropAndFree(() => Native.LibVLCMediaAddOptionFlag(NativeReference, optionUtf8, flags), optionUtf8);
         }
 
-        string _mrl;
+        string? _mrl;
         /// <summary>Get the media resource locator (mrl) from a media descriptor object</summary>
         public string Mrl
         {
@@ -335,7 +335,7 @@ namespace LibVLCSharp.Shared
                     var mrlPtr = Native.LibVLCMediaGetMrl(NativeReference);
                     _mrl = mrlPtr.FromUtf8(libvlcFree: true);
                 }
-                return _mrl;
+                return _mrl!;
             }
         }
 
@@ -353,7 +353,7 @@ namespace LibVLCSharp.Shared
         /// <remarks>
         /// If the media has not yet been parsed this will return NULL.
         /// </remarks>
-        public string Meta(MetadataType metadataType)
+        public string? Meta(MetadataType metadataType)
         {
             var metaPtr = Native.LibVLCMediaGetMeta(NativeReference, metadataType);
             return metaPtr.FromUtf8(libvlcFree: true);
@@ -388,7 +388,7 @@ namespace LibVLCSharp.Shared
         public MediaStats Statistics => Native.LibVLCMediaGetStats(NativeReference, out var mediaStats) == 0 
             ? default : mediaStats;
 
-        MediaEventManager _eventManager;
+        MediaEventManager? _eventManager;
         /// <summary>
         /// <para>Get event manager from media descriptor object.</para>
         /// <para>NOTE: this function doesn't increment reference counting.</para>
@@ -425,21 +425,19 @@ namespace LibVLCSharp.Shared
         {
             cancellationToken.ThrowIfCancellationRequested();
             
-            TaskCompletionSource<MediaParsedStatus> tcs = null;
+            var tcs = new TaskCompletionSource<MediaParsedStatus>();
             var cancellationTokenRegistration = cancellationToken.Register(() =>
             {
                 ParsedChanged -= OnParsedChanged;
                 Native.LibVLCMediaParseStop(NativeReference);
-                tcs?.TrySetCanceled();
+                tcs.TrySetCanceled();
             });
 
             void OnParsedChanged(object sender, MediaParsedChangedEventArgs mediaParsedChangedEventArgs) 
-                => tcs?.TrySetResult(mediaParsedChangedEventArgs.ParsedStatus);
+                => tcs.TrySetResult(mediaParsedChangedEventArgs.ParsedStatus);
 
             try
             {
-                tcs = new TaskCompletionSource<MediaParsedStatus>();
-                        
                 ParsedChanged += OnParsedChanged;
 
                 var result = Native.LibVLCMediaParseWithOptions(NativeReference, options, timeout);
@@ -555,7 +553,7 @@ namespace LibVLCSharp.Shared
         /// <param name="type">The type of the track</param>
         /// <param name="codec">the codec or fourcc</param>
         /// <returns>the codec description</returns>
-        public string CodecDescription(TrackType type, uint codec) => Native.LibvlcMediaGetCodecDescription(type, codec).FromUtf8();
+        public string CodecDescription(TrackType type, uint codec) => Native.LibvlcMediaGetCodecDescription(type, codec).FromUtf8()!;
 
         /// <summary>
         /// Equality override for this media instance

--- a/src/LibVLCSharp/Shared/MediaDiscoverer.cs
+++ b/src/LibVLCSharp/Shared/MediaDiscoverer.cs
@@ -9,8 +9,8 @@ namespace LibVLCSharp.Shared
     /// </summary>
     public class MediaDiscoverer : Internal
     {
-        MediaDiscovererEventManager _eventManager;
-        MediaList _mediaList;
+        MediaDiscovererEventManager? _eventManager;
+        MediaList? _mediaList;
 
         readonly struct Native
         {
@@ -78,13 +78,13 @@ namespace LibVLCSharp.Shared
         /// Get media service discover object its localized name.
         /// under v3 only
         /// </summary>
-        public string LocalizedName => Native.LibVLCMediaDiscovererLocalizedName(NativeReference).FromUtf8();
+        public string? LocalizedName => Native.LibVLCMediaDiscovererLocalizedName(NativeReference).FromUtf8();
 
         /// <summary>
         /// Get event manager from media service discover object.
         /// under v3 only
         /// </summary>
-        MediaDiscovererEventManager EventManager
+        MediaDiscovererEventManager? EventManager
         {
             get
             {
@@ -101,14 +101,12 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Query if media service discover object is running.
         /// </summary>
-        public bool IsRunning => NativeReference != IntPtr.Zero ? 
-            Native.LibVLCMediaDiscovererIsRunning(NativeReference) != 0 
-            : false;
+        public bool IsRunning => NativeReference != IntPtr.Zero && Native.LibVLCMediaDiscovererIsRunning(NativeReference) != 0;
 
         /// <summary>
         /// The MediaList attached to this MediaDiscoverer
         /// </summary>
-        public MediaList MediaList
+        public MediaList? MediaList
         {
             get
             {
@@ -131,8 +129,8 @@ namespace LibVLCSharp.Shared
         /// </summary>
         public event EventHandler<EventArgs> Started
         {
-            add => EventManager.AttachEvent(EventType.MediaDiscovererStarted, value);
-            remove => EventManager.DetachEvent(EventType.MediaDiscovererStarted, value);
+            add => EventManager?.AttachEvent(EventType.MediaDiscovererStarted, value);
+            remove => EventManager?.DetachEvent(EventType.MediaDiscovererStarted, value);
         }
 
         /// <summary>
@@ -140,8 +138,8 @@ namespace LibVLCSharp.Shared
         /// </summary>
         public event EventHandler<EventArgs> Stopped
         {
-            add => EventManager.AttachEvent(EventType.MediaDiscovererStopped, value);
-            remove => EventManager.DetachEvent(EventType.MediaDiscovererStopped, value);
+            add => EventManager?.AttachEvent(EventType.MediaDiscovererStopped, value);
+            remove => EventManager?.DetachEvent(EventType.MediaDiscovererStopped, value);
         }
 
         #endregion

--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -246,21 +246,18 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_media_player_set_equalizer")]
             internal static extern int LibVLCMediaPlayerSetEqualizer(IntPtr mediaPlayer, IntPtr equalizer);
 
-
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_audio_set_callbacks")]
-            internal static extern void LibVLCAudioSetCallbacks(IntPtr mediaPlayer, LibVLCAudioPlayCb play, LibVLCAudioPauseCb pause,
-                LibVLCAudioResumeCb resume, LibVLCAudioFlushCb flush, LibVLCAudioDrainCb drain, IntPtr opaque);
-
+            internal static extern void LibVLCAudioSetCallbacks(IntPtr mediaPlayer, LibVLCAudioPlayCb play, LibVLCAudioPauseCb? pause,
+                LibVLCAudioResumeCb? resume, LibVLCAudioFlushCb? flush, LibVLCAudioDrainCb? drain, IntPtr opaque);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_audio_set_volume_callback")]
-            internal static extern void LibVLCAudioSetVolumeCallback(IntPtr mediaPlayer, LibVLCVolumeCb volumeCallback);
-
+            internal static extern void LibVLCAudioSetVolumeCallback(IntPtr mediaPlayer, LibVLCVolumeCb? volumeCallback);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_audio_set_format_callbacks")]
-            internal static extern void LibVLCAudioSetFormatCallbacks(IntPtr mediaPlayer, LibVLCAudioSetupCb setup, LibVLCAudioCleanupCb cleanup);
+            internal static extern void LibVLCAudioSetFormatCallbacks(IntPtr mediaPlayer, LibVLCAudioSetupCb setup, LibVLCAudioCleanupCb? cleanup);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_audio_set_format")]
@@ -348,22 +345,20 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_audio_set_delay")]
             internal static extern int LibVLCAudioSetDelay(IntPtr mediaPlayer, long delay);
 
-
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_set_callbacks")]
             internal static extern void LibVLCVideoSetCallbacks(IntPtr mediaPlayer, LibVLCVideoLockCb lockCallback,
-                LibVLCVideoUnlockCb unlock, LibVLCVideoDisplayCb display, IntPtr opaque);
+                LibVLCVideoUnlockCb? unlock, LibVLCVideoDisplayCb? display, IntPtr opaque);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_set_format")]
             internal static extern void LibVLCVideoSetFormat(IntPtr mediaPlayer, IntPtr chroma,
                 uint width, uint height, uint pitch);
 
-
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_set_format_callbacks")]
             internal static extern void LibVLCVideoSetFormatCallbacks(IntPtr mediaPlayer, LibVLCVideoFormatCb setup,
-                LibVLCVideoCleanupCb cleanup);
+                LibVLCVideoCleanupCb? cleanup);
 
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
@@ -557,7 +552,7 @@ namespace LibVLCSharp.Shared
             internal static extern int LibVLCMediaPlayerAddSlave(IntPtr mediaPlayer, MediaSlaveType mediaSlaveType,
                 IntPtr uri, bool selectWhenloaded);
 
-            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl, 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_new_viewpoint")]
             internal static extern IntPtr LibVLCVideoNewViewpoint();
 
@@ -599,7 +594,7 @@ namespace LibVLCSharp.Shared
 #endif
         }
 
-        MediaPlayerEventManager _eventManager;
+        MediaPlayerEventManager? _eventManager;
 
         /// <summary>
         /// The GCHandle to be passed to callbacks as userData
@@ -632,11 +627,11 @@ namespace LibVLCSharp.Shared
 
         /// <summary>
         /// Get the media used by the media_player.
-        /// Set the media that will be used by the media_player. 
+        /// Set the media that will be used by the media_player.
         /// If any, previous md will be released.
         /// Note: It is safe to release the Media on the C# side after it's been set on the MediaPlayer successfully
         /// </summary>
-        public Media Media
+        public Media? Media
         {
             get
             {
@@ -721,16 +716,16 @@ namespace LibVLCSharp.Shared
 
 #if NETFRAMEWORK || NETSTANDARD
         /// <summary>
-        /// Set an X Window System drawable where the media player should render its video output. 
-        /// The call takes effect when the playback starts. If it is already started, it might need to be stopped before changes apply. 
+        /// Set an X Window System drawable where the media player should render its video output.
+        /// The call takes effect when the playback starts. If it is already started, it might need to be stopped before changes apply.
         /// If LibVLC was built without X11 output support, then this function has no effects.
-        /// By default, LibVLC will capture input events on the video rendering area. 
-        /// Use libvlc_video_set_mouse_input() and libvlc_video_set_key_input() to disable that and deliver events to the parent window / to the application instead. 
+        /// By default, LibVLC will capture input events on the video rendering area.
+        /// Use libvlc_video_set_mouse_input() and libvlc_video_set_key_input() to disable that and deliver events to the parent window / to the application instead.
         /// By design, the X11 protocol delivers input events to only one recipient.
         /// <para></para>
         /// Warning:
         /// The application must call the XInitThreads() function from Xlib before libvlc_new(), and before any call to XOpenDisplay() directly
-        /// or via any other library.Failure to call XInitThreads() will seriously impede LibVLC performance. 
+        /// or via any other library.Failure to call XInitThreads() will seriously impede LibVLC performance.
         /// Calling XOpenDisplay() before XInitThreads() will eventually crash the process. That is a limitation of Xlib.
         /// uint: X11 window ID
         /// </summary>
@@ -846,7 +841,7 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Get the requested movie play rate.
         /// warning
-        /// <para></para> 
+        /// <para></para>
         /// Depending on the underlying media, the requested rate may be
         /// different from the real playback rate.
         /// </summary>
@@ -880,7 +875,7 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Get the number of video outputs 
+        /// Get the number of video outputs
         /// </summary>
         public uint VoutCount => Native.LibVLCMediaPlayerHasVout(NativeReference);
 
@@ -941,10 +936,10 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Enable or disable fullscreen. 
+        /// Enable or disable fullscreen.
         /// Warning
         /// With most window managers, only a top-level windows can be in full-screen mode.
-        /// Hence, this function will not operate properly if libvlc_media_player_set_xwindow() was used to embed the video in a non-top-level window. 
+        /// Hence, this function will not operate properly if libvlc_media_player_set_xwindow() was used to embed the video in a non-top-level window.
         /// In that case, the embedding window must be reparented to the root window before fullscreen mode is enabled.
         /// You will want to reparent it back to its normal parent when disabling fullscreen.
         /// <para></para>
@@ -983,15 +978,15 @@ namespace LibVLCSharp.Shared
         /// <returns>true on success, false otherwise.</returns>
         public bool UnsetEqualizer() => Native.LibVLCMediaPlayerSetEqualizer(NativeReference, IntPtr.Zero) == 0;
 
-        LibVLCAudioPlayCb _audioPlayCb;
-        LibVLCAudioPauseCb _audioPauseCb;
-        LibVLCAudioResumeCb _audioResumeCb;
-        LibVLCAudioFlushCb _audioFlushCb;
-        LibVLCAudioDrainCb _audioDrainCb;
+        LibVLCAudioPlayCb? _audioPlayCb;
+        LibVLCAudioPauseCb? _audioPauseCb;
+        LibVLCAudioResumeCb? _audioResumeCb;
+        LibVLCAudioFlushCb? _audioFlushCb;
+        LibVLCAudioDrainCb? _audioDrainCb;
         IntPtr _audioUserData = IntPtr.Zero;
 
         /// <summary>
-        /// Sets callbacks and private data for decoded audio. 
+        /// Sets callbacks and private data for decoded audio.
         /// Use libvlc_audio_set_format() or libvlc_audio_set_format_callbacks() to configure the decoded audio format.
         /// Note: The audio callbacks override any other audio output mechanism. If the callbacks are set, LibVLC will not output audio in any way.
         /// </summary>
@@ -1000,11 +995,11 @@ namespace LibVLCSharp.Shared
         /// <param name="resumeCb">callback to resume playback (or NULL to ignore) </param>
         /// <param name="flushCb">callback to flush audio buffers (or NULL to ignore) </param>
         /// <param name="drainCb">callback to drain audio buffers (or NULL to ignore) </param>
-        public void SetAudioCallbacks(LibVLCAudioPlayCb playCb, LibVLCAudioPauseCb pauseCb,
-            LibVLCAudioResumeCb resumeCb, LibVLCAudioFlushCb flushCb,
-            LibVLCAudioDrainCb drainCb)
+        public void SetAudioCallbacks(LibVLCAudioPlayCb playCb, LibVLCAudioPauseCb? pauseCb,
+            LibVLCAudioResumeCb? resumeCb, LibVLCAudioFlushCb? flushCb,
+            LibVLCAudioDrainCb? drainCb)
         {
-            _audioPlayCb = playCb;
+            _audioPlayCb = playCb ?? throw new ArgumentNullException(nameof(playCb));
             _audioPauseCb = pauseCb;
             _audioResumeCb = resumeCb;
             _audioFlushCb = flushCb;
@@ -1020,11 +1015,11 @@ namespace LibVLCSharp.Shared
                 GCHandle.ToIntPtr(_gcHandle));
         }
 
-        LibVLCVolumeCb _audioVolumeCb;
+        LibVLCVolumeCb? _audioVolumeCb;
 
         /// <summary>
-        /// Set callbacks and private data for decoded audio. 
-        /// This only works in combination with libvlc_audio_set_callbacks(). 
+        /// Set callbacks and private data for decoded audio.
+        /// This only works in combination with libvlc_audio_set_callbacks().
         /// Use libvlc_audio_set_format() or libvlc_audio_set_format_callbacks() to configure the decoded audio format.
         /// </summary>
         /// <param name="volumeCb">callback to apply audio volume, or NULL to apply volume in software</param>
@@ -1034,26 +1029,24 @@ namespace LibVLCSharp.Shared
             Native.LibVLCAudioSetVolumeCallback(NativeReference, (volumeCb == null) ? null : AudioVolumeCallbackHandle);
         }
 
-        LibVLCAudioSetupCb _setupCb;
-        LibVLCAudioCleanupCb _cleanupCb;
+        LibVLCAudioSetupCb? _setupCb;
+        LibVLCAudioCleanupCb? _cleanupCb;
 
         /// <summary>
-        /// Sets decoded audio format via callbacks. 
+        /// Sets decoded audio format via callbacks.
         /// This only works in combination with libvlc_audio_set_callbacks().
         /// </summary>
         /// <param name="setupCb">callback to select the audio format (cannot be NULL)</param>
         /// <param name="cleanupCb">callback to release any allocated resources (or NULL)</param>
         public void SetAudioFormatCallback(LibVLCAudioSetupCb setupCb, LibVLCAudioCleanupCb cleanupCb)
         {
-            _setupCb = setupCb;
+            _setupCb = setupCb ?? throw new ArgumentNullException(nameof(setupCb));
             _cleanupCb = cleanupCb;
-            Native.LibVLCAudioSetFormatCallbacks(NativeReference,
-                                                 (setupCb == null) ? null : AudioSetupCallbackHandle,
-                                                 (cleanupCb == null) ? null : AudioCleanupCallbackHandle);
+            Native.LibVLCAudioSetFormatCallbacks(NativeReference, AudioSetupCallbackHandle, (cleanupCb == null) ? null : AudioCleanupCallbackHandle);
         }
 
         /// <summary>
-        /// Sets a fixed decoded audio format. 
+        /// Sets a fixed decoded audio format.
         /// This only works in combination with libvlc_audio_set_callbacks(), and is mutually exclusive with libvlc_audio_set_format_callbacks().
         /// </summary>
         /// <param name="format">a four-characters string identifying the sample format (e.g. "S16N" or "FL32")</param>
@@ -1067,7 +1060,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>
         /// Selects an audio output module.
-        /// Note: 
+        /// Note:
         /// Any change will take effect only after playback is stopped and restarted. Audio output cannot be changed while playing.
         /// </summary>
         /// <param name="name">name of audio output, use psz_name of</param>
@@ -1094,7 +1087,7 @@ namespace LibVLCSharp.Shared
         ///
         /// </summary>
         /// <returns>the current audio output device identifier, or NULL if no device is selected or in case of error.</returns>
-        public string OutputDevice => Native.LibVLCAudioOutputDeviceGet(NativeReference).FromUtf8(libvlcFree: true);
+        public string? OutputDevice => Native.LibVLCAudioOutputDeviceGet(NativeReference).FromUtf8(libvlcFree: true);
 
         /// <summary>
         /// Configures an explicit audio output device.
@@ -1108,18 +1101,18 @@ namespace LibVLCSharp.Shared
         /// parameter was NULL.
         /// If the module parameter is not NULL, the device parameter of the
         /// corresponding audio output, if it exists, will be set to the specified
-        /// string. 
+        /// string.
         /// A list of adequate potential device strings can be obtained with
         /// <see cref="LibVLC.AudioOutputDevices"/>
         /// </summary>
         /// <param name="deviceId">device identifier string</param>
         /// <param name="module">If NULL, current audio output module. if non-NULL, name of audio output module</param>
-        public void SetOutputDevice(string deviceId, string module = null)
+        public void SetOutputDevice(string deviceId, string? module = null)
         {
             var deviceIdUtf8 = deviceId.ToUtf8();
             var moduleUtf8 = module.ToUtf8();
-            MarshalUtils.PerformInteropAndFree(() => 
-                Native.LibVLCAudioOutputDeviceSet(NativeReference, moduleUtf8, deviceIdUtf8), 
+            MarshalUtils.PerformInteropAndFree(() =>
+                Native.LibVLCAudioOutputDeviceSet(NativeReference, moduleUtf8, deviceIdUtf8),
                 moduleUtf8, deviceIdUtf8);
         }
 
@@ -1137,15 +1130,15 @@ namespace LibVLCSharp.Shared
            Native.LibVLCAudioOutputDeviceListRelease);
 
         /// <summary>
-        /// Toggle mute status. 
+        /// Toggle mute status.
         /// Warning
-        /// Toggling mute atomically is not always possible: On some platforms, other processes can mute the VLC audio playback 
+        /// Toggling mute atomically is not always possible: On some platforms, other processes can mute the VLC audio playback
         /// stream asynchronously.
         /// Thus, there is a small race condition where toggling will not work.
-        /// See also the limitations of libvlc_audio_set_mute(). 
+        /// See also the limitations of libvlc_audio_set_mute().
         /// </summary>
         public void ToggleMute() => Native.LibVLCAudioToggleMute(NativeReference);
-        
+
         /// <summary>
         /// Get current mute status.
         /// Set mute status.
@@ -1155,7 +1148,7 @@ namespace LibVLCSharp.Shared
         /// If digital pass-through (S/PDIF, HDMI...) is in use, muting may be unapplicable.
         /// Also some audio output plugins do not support muting at all.
         /// Note
-        /// To force silent playback, disable all audio tracks. This is more efficient and reliable than mute. 
+        /// To force silent playback, disable all audio tracks. This is more efficient and reliable than mute.
         /// </summary>
         public bool Mute
         {
@@ -1243,17 +1236,17 @@ namespace LibVLCSharp.Shared
         /// <returns>true on success, false on error </returns>
         public bool SetAudioDelay(long delay) => Native.LibVLCAudioSetDelay(NativeReference, delay) == 0;
 
-        LibVLCVideoLockCb _videoLockCb;
-        LibVLCVideoUnlockCb _videoUnlockCb;
-        LibVLCVideoDisplayCb _videoDisplayCb;
+        LibVLCVideoLockCb? _videoLockCb;
+        LibVLCVideoUnlockCb? _videoUnlockCb;
+        LibVLCVideoDisplayCb? _videoDisplayCb;
 
         /// <summary>
         /// Set callbacks and private data to render decoded video to a custom area in memory.
         /// Use libvlc_video_set_format() or libvlc_video_set_format_callbacks() to configure the decoded format.
         /// Warning
         /// Rendering video into custom memory buffers is considerably less efficient than rendering in a custom window as normal.
-        /// For optimal perfomances, VLC media player renders into a custom window, and does not use this function and associated callbacks. 
-        /// It is highly recommended that other LibVLC-based application do likewise. 
+        /// For optimal perfomances, VLC media player renders into a custom window, and does not use this function and associated callbacks.
+        /// It is highly recommended that other LibVLC-based application do likewise.
         /// To embed video in a window, use libvlc_media_player_set_xid() or equivalent depending on the operating system.
         /// If window embedding does not fit the application use case, then a custom LibVLC video output display plugin is required to maintain optimal video rendering performances.
         /// The following limitations affect performance:
@@ -1266,10 +1259,10 @@ namespace LibVLCSharp.Shared
         /// <param name="lockCb">callback to lock video memory (must not be NULL)</param>
         /// <param name="unlockCb">callback to unlock video memory (or NULL if not needed)</param>
         /// <param name="displayCb">callback to display video (or NULL if not needed)</param>
-        public void SetVideoCallbacks(LibVLCVideoLockCb lockCb, LibVLCVideoUnlockCb unlockCb,
-            LibVLCVideoDisplayCb displayCb)
+        public void SetVideoCallbacks(LibVLCVideoLockCb lockCb, LibVLCVideoUnlockCb? unlockCb,
+            LibVLCVideoDisplayCb? displayCb)
         {
-            _videoLockCb = lockCb;
+            _videoLockCb = lockCb ?? throw new ArgumentNullException(nameof(lockCb));
             _videoUnlockCb = unlockCb;
             _videoDisplayCb = displayCb;
             Native.LibVLCVideoSetCallbacks(NativeReference,
@@ -1292,39 +1285,39 @@ namespace LibVLCSharp.Shared
         {
             var chromaUtf8 = chroma.ToUtf8();
 
-            MarshalUtils.PerformInteropAndFree(() => 
+            MarshalUtils.PerformInteropAndFree(() =>
                 Native.LibVLCVideoSetFormat(NativeReference, chromaUtf8, width, height, pitch),
                 chromaUtf8);
         }
 
-        LibVLCVideoFormatCb _videoFormatCb;
-        LibVLCVideoCleanupCb _videoCleanupCb;
+        LibVLCVideoFormatCb? _videoFormatCb;
+        LibVLCVideoCleanupCb? _videoCleanupCb;
         IntPtr _videoUserData = IntPtr.Zero;
 
         /// <summary>
-        /// Set decoded video chroma and dimensions. 
+        /// Set decoded video chroma and dimensions.
         /// This only works in combination with libvlc_video_set_callbacks().
         /// </summary>
         /// <param name="formatCb">callback to select the video format (cannot be NULL)</param>
         /// <param name="cleanupCb">callback to release any allocated resources (or NULL)</param>
-        public void SetVideoFormatCallbacks(LibVLCVideoFormatCb formatCb, LibVLCVideoCleanupCb cleanupCb)
+        public void SetVideoFormatCallbacks(LibVLCVideoFormatCb formatCb, LibVLCVideoCleanupCb? cleanupCb)
         {
-            _videoFormatCb = formatCb;
+            _videoFormatCb = formatCb ?? throw new ArgumentNullException(nameof(formatCb));
             _videoCleanupCb = cleanupCb;
             Native.LibVLCVideoSetFormatCallbacks(NativeReference, VideoFormatCallbackHandle,
                 (cleanupCb == null)? null : VideoCleanupCallbackHandle);
         }
 
         /// <summary>
-        /// Enable or disable key press events handling, according to the LibVLC hotkeys configuration. 
+        /// Enable or disable key press events handling, according to the LibVLC hotkeys configuration.
         /// By default and for historical reasons, keyboard events are handled by the LibVLC video widget.
         /// Note
         /// On X11, there can be only one subscriber for key press and mouse click events per window.
-        /// If your application has subscribed to those events for the X window ID of the video widget, 
+        /// If your application has subscribed to those events for the X window ID of the video widget,
         /// then LibVLC will not be able to handle key presses and mouse clicks in any case.
         /// Warning
         /// This function is only implemented for X11 and Win32 at the moment.
-        /// true to handle key press events, false to ignore them. 
+        /// true to handle key press events, false to ignore them.
         /// </summary>
         public bool EnableKeyInput
         {
@@ -1332,11 +1325,11 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Enable or disable mouse click events handling. 
+        /// Enable or disable mouse click events handling.
         /// By default, those events are handled. This is needed for DVD menus to work, as well as a few video filters such as "puzzle".
         /// Warning
         /// This function is only implemented for X11 and Win32 at the moment.
-        /// true to handle mouse click events, false to ignore them. 
+        /// true to handle mouse click events, false to ignore them.
         /// </summary>
         public bool EnableMouseInput
         {
@@ -1356,10 +1349,10 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
-        /// Get the mouse pointer coordinates over a video. 
+        /// Get the mouse pointer coordinates over a video.
         /// Coordinates are expressed in terms of the decoded video resolution, not in terms of pixels on the screen/viewport
         /// (to get the latter, you can query your windowing system directly).
-        /// Either of the coordinates may be negative or larger than the corresponding dimension of the video, 
+        /// Either of the coordinates may be negative or larger than the corresponding dimension of the video,
         /// if the cursor is outside the rendering area.
         /// Warning
         /// The coordinates may be out-of-date if the pointer is not located on the video rendering area.
@@ -1392,10 +1385,10 @@ namespace LibVLCSharp.Shared
 
         /// <summary>
         /// Get/set current video aspect ratio.
-        /// Set empty string to reset to default
+        /// Set to null to reset to default
         /// Invalid aspect ratios are ignored.
         /// </summary>
-        public string AspectRatio
+        public string? AspectRatio
         {
             get => Native.LibVLCVideoGetAspectRatio(NativeReference).FromUtf8(libvlcFree: true);
             set
@@ -1432,13 +1425,13 @@ namespace LibVLCSharp.Shared
             Native.LibVLCTrackDescriptionListRelease);
 
         /// <summary>
-        /// Get the current subtitle delay. 
+        /// Get the current subtitle delay.
         /// </summary>
         public long SpuDelay => Native.LibVLCVideoGetSpuDelay(NativeReference);
 
         /// <summary>
-        /// Set the subtitle delay. 
-        /// This affects the timing of when the subtitle will be displayed. 
+        /// Set the subtitle delay.
+        /// This affects the timing of when the subtitle will be displayed.
         /// Positive values result in subtitles being displayed later, while negative values will result in subtitles being displayed earlier.
         /// The subtitle delay will be reset to zero each time the media changes.
         /// </summary>
@@ -1470,7 +1463,7 @@ namespace LibVLCSharp.Shared
         /// Get/Set current crop filter geometry.
         /// Empty string to unset
         /// </summary>
-        public string CropGeometry
+        public string? CropGeometry
         {
             get => Native.LibVLCVideoGetCropGeometry(NativeReference).FromUtf8(libvlcFree: true);
             set
@@ -1526,7 +1519,7 @@ namespace LibVLCSharp.Shared
         /// <param name="width">the snapshot's width</param>
         /// <param name="height">the snapshot's height</param>
         /// <returns>true on success</returns>
-        public bool TakeSnapshot(uint num, string filePath, uint width, uint height)
+        public bool TakeSnapshot(uint num, string? filePath, uint width, uint height)
         {
             var filePathUtf8 = filePath.ToUtf8();
             return MarshalUtils.PerformInteropAndFree(() =>
@@ -1537,12 +1530,12 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Enable or disable deinterlace filter
         /// </summary>
-        /// <param name="deinterlaceMode">type of deinterlace filter, empty string to disable</param>
-        public void SetDeinterlace(string deinterlaceMode)
+        /// <param name="deinterlaceMode">type of deinterlace filter, null to disable</param>
+        public void SetDeinterlace(string? deinterlaceMode)
         {
             var deinterlaceModeUtf8 = deinterlaceMode.ToUtf8();
 
-            MarshalUtils.PerformInteropAndFree(() => 
+            MarshalUtils.PerformInteropAndFree(() =>
                 Native.LibVLCVideoSetDeinterlace(NativeReference, deinterlaceModeUtf8),
                 deinterlaceModeUtf8);
         }
@@ -1559,7 +1552,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="option">marq option to get</param>
         /// <returns></returns>
-        public string MarqueeString(VideoMarqueeOption option)
+        public string? MarqueeString(VideoMarqueeOption option)
         {
             var marqueeStrPtr = Native.LibVLCVideoGetMarqueeString(NativeReference, option);
             return marqueeStrPtr.FromUtf8(libvlcFree: true);
@@ -1580,14 +1573,14 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="option">marq option to set</param>
         /// <param name="marqueeValue">marq option value</param>
-        public void SetMarqueeString(VideoMarqueeOption option, string marqueeValue)
+        public void SetMarqueeString(VideoMarqueeOption option, string? marqueeValue)
         {
             var marqueeValueUtf8 = marqueeValue.ToUtf8();
             MarshalUtils.PerformInteropAndFree(() =>
                 Native.LibVLCVideoSetMarqueeString(NativeReference, option, marqueeValueUtf8),
                 marqueeValueUtf8);
         }
-        
+
 
         /// <summary>
         /// Get integer logo option.
@@ -1610,7 +1603,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="option">logo option to set, values of libvlc_video_logo_option_t</param>
         /// <param name="logoValue">logo option value</param>
-        public void SetLogoString(VideoLogoOption option, string logoValue)
+        public void SetLogoString(VideoLogoOption option, string? logoValue)
         {
             var logoValueUtf8 = logoValue.ToUtf8();
 
@@ -1682,7 +1675,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>
         /// Update the video viewpoint information.
-        /// The values are set asynchronously, it will be used by the next frame displayed. 
+        /// The values are set asynchronously, it will be used by the next frame displayed.
         /// It is safe to call this function before the media player is started.
         /// LibVLC 3.0.0 and later
         /// </summary>
@@ -1699,7 +1692,7 @@ namespace LibVLCSharp.Shared
 
             Viewpoint = new VideoViewpoint(yaw, pitch, roll, fov);
             Marshal.StructureToPtr(Viewpoint, vpPtr, false);
-            
+
             var result = Native.LibVLCVideoUpdateViewpoint(NativeReference, vpPtr, absolute) == 0;
             MarshalUtils.LibVLCFree(ref vpPtr);
 
@@ -1711,14 +1704,14 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="rendererItem">discovered renderer item or null to fallback on local rendering</param>
         /// <returns>true on success, false otherwise</returns>
-        public bool SetRenderer(RendererItem rendererItem) =>
+        public bool SetRenderer(RendererItem? rendererItem) =>
             Native.LibVLCMediaPlayerSetRenderer(NativeReference, rendererItem?.NativeReference ?? IntPtr.Zero) == 0;
 
         /// <summary>Gets the media role.
         /// <para/> version LibVLC 3.0.0 and later.
         /// </summary>
         public MediaPlayerRole Role => Native.LibVLCMediaPlayerGetRole(NativeReference);
-        
+
         /// <summary>Sets the media role.
         /// <para/> version LibVLC 3.0.0 and later.
         /// </summary>
@@ -2092,7 +2085,7 @@ namespace LibVLCSharp.Shared
         public delegate void LibVLCVolumeCb(IntPtr data, float volume, [MarshalAs(UnmanagedType.I1)] bool mute);
 
 #endregion
-        
+
         /// <summary>
         /// Get the Event Manager from which the media player send event.
         /// </summary>
@@ -2401,14 +2394,9 @@ namespace LibVLCSharp.Shared
                     Stop();
                 }
 
-                if(Media != null)
-                {
-                    Media.Dispose();
-                }
-
-                _gcHandle.Free();
+                Media?.Dispose();
             }
-            
+
             base.Dispose(disposing);
         }
     }
@@ -2740,11 +2728,11 @@ namespace LibVLCSharp.Shared
         LiblvcRoleNotification = 5,
         /// <summary>Embedded animation (e.g. in web page)</summary>
         Animation = 6,
-        /// <summary>Audio editting/production</summary>
+        /// <summary>Audio editing/production</summary>
         Production = 7,
         /// <summary>Accessibility</summary>
         Accessibility = 8,
         /// <summary>Testing</summary>
         Test = 9
-    }    
+    }
 }

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/AspectRatioManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/AspectRatioManager.cs
@@ -13,14 +13,14 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="AspectRatio"/> property value changes
         /// </summary>
-        public event EventHandler AspectRatioChanged;
+        public event EventHandler? AspectRatioChanged;
 
         /// <summary>
         /// Initializes a new instance of <see cref="AspectRatioManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
         /// <param name="displayInformation">display information</param>
-        public AspectRatioManager(IDispatcher dispatcher, IDisplayInformation displayInformation) : base(dispatcher)
+        public AspectRatioManager(IDispatcher? dispatcher, IDisplayInformation displayInformation) : base(dispatcher)
         {
             DisplayInformation = displayInformation;
         }
@@ -42,7 +42,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="oldValue">old value</param>
         /// <param name="newValue">new value</param>
-        protected override void OnVideoViewChanged(IVideoControl oldValue, IVideoControl newValue)
+        protected override void OnVideoViewChanged(IVideoControl? oldValue, IVideoControl? newValue)
         {
             base.OnVideoViewChanged(oldValue, newValue);
             if (oldValue != null)
@@ -114,7 +114,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             return orientation == VideoOrientation.LeftBottom || orientation == VideoOrientation.RightTop;
         }
 
-        private AspectRatio GetAspectRatio(Shared.MediaPlayer mediaPlayer)
+        private AspectRatio GetAspectRatio(Shared.MediaPlayer? mediaPlayer)
         {
             if (mediaPlayer == null)
             {

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/AudioTracksManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/AudioTracksManager.cs
@@ -13,7 +13,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// Initialized a new instance of <see cref="AudioTracksManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public AudioTracksManager(IDispatcher dispatcher) : base(dispatcher, TrackType.Audio)
+        public AudioTracksManager(IDispatcher? dispatcher) : base(dispatcher, TrackType.Audio)
         {
         }
 
@@ -30,6 +30,6 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Gets the tracks descriptions
         /// </summary>
-        public override IEnumerable<TrackDescription> Tracks => MediaPlayer?.AudioTrackDescription;
+        public override IEnumerable<TrackDescription>? Tracks => MediaPlayer?.AudioTrackDescription;
     }
 }

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/AutoHideNotifier.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/AutoHideNotifier.cs
@@ -13,17 +13,17 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs whenever the playback controls should be shown
         /// </summary>
-        public event EventHandler Shown;
+        public event EventHandler? Shown;
         /// <summary>
         /// Occurs whenever the playback controls should be hidden
         /// </summary>
-        public event EventHandler Hidden;
+        public event EventHandler? Hidden;
 
         /// <summary>
         /// Initializes a new instance of <see cref="AutoHideNotifier"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public AutoHideNotifier(IDispatcher dispatcher) : base(dispatcher)
+        public AutoHideNotifier(IDispatcher? dispatcher) : base(dispatcher)
         {
             MediaPlayerChanged += async (sender, e) => await ShowAsync();
             Timer = new Timer(async obj => await HideAsync(), null, Timeout.Infinite, Timeout.Infinite);

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/BufferingProgressNotifier.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/BufferingProgressNotifier.cs
@@ -11,17 +11,17 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="IsBuffering"/> property value changes
         /// </summary>
-        public event EventHandler IsBufferingChanged;
+        public event EventHandler? IsBufferingChanged;
         /// <summary>
         /// Occurs when buffering
         /// </summary>
-        public event EventHandler Buffering;
+        public event EventHandler? Buffering;
 
         /// <summary>
         /// Initializes a new instance of <see cref="BufferingProgressNotifier"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public BufferingProgressNotifier(IDispatcher dispatcher) : base(dispatcher)
+        public BufferingProgressNotifier(IDispatcher? dispatcher) : base(dispatcher)
         {
         }
 

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/CastRenderersDiscoverer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/CastRenderersDiscoverer.cs
@@ -16,19 +16,19 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="CastAvailable"/> property value changes
         /// </summary>
-        public event EventHandler CastAvailableChanged;
+        public event EventHandler? CastAvailableChanged;
 
         /// <summary>
         /// Initializes a new instance of <see cref="CastRenderersDiscoverer"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public CastRenderersDiscoverer(IDispatcher dispatcher) : base(dispatcher)
+        public CastRenderersDiscoverer(IDispatcher? dispatcher) : base(dispatcher)
         {
             MediaPlayerChanged += async (sender, e) => await UpdateHasRenderersPropertyValueAsync();
             LibVLCChanged += async (sender, e) => await OnLibVLCChangedAsync();
         }
 
-        private RendererDiscoverer RendererDiscoverer { get; set; }
+        private RendererDiscoverer? RendererDiscoverer { get; set; }
 
         private bool _castAvailable;
         /// <summary>
@@ -78,7 +78,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
 
         private IList<RendererItem> RenderersList { get; } = new List<RendererItem>();
 
-        private IEnumerable<RendererItem> _renderers;
+        private IEnumerable<RendererItem>? _renderers;
         /// <summary>
         /// Gets the renderers list
         /// </summary>

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/DeviceAwakeningManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/DeviceAwakeningManager.cs
@@ -13,7 +13,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
         /// <param name="displayRequest">display request object</param>
-        public DeviceAwakeningManager(IDispatcher dispatcher, IDisplayRequest displayRequest) : base(dispatcher)
+        public DeviceAwakeningManager(IDispatcher? dispatcher, IDisplayRequest displayRequest) : base(dispatcher)
         {
             DisplayRequest = displayRequest;
             MediaPlayerChanged += OnStateChangedAsync;

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/MediaPlayerElementManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/MediaPlayerElementManager.cs
@@ -18,7 +18,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <param name="dispatcher">dispatcher</param>
         /// <param name="displayInformation">display information</param>
         /// <param name="displayRequest">display request object</param>
-        public MediaPlayerElementManager(IDispatcher dispatcher, IDisplayInformation displayInformation, IDisplayRequest displayRequest)
+        public MediaPlayerElementManager(IDispatcher? dispatcher, IDisplayInformation displayInformation, IDisplayRequest displayRequest)
             : base(dispatcher)
         {
             SubManagers = new MediaPlayerElementManagerBase[] {
@@ -42,7 +42,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="oldValue">old value</param>
         /// <param name="newValue">new value</param>
-        protected override void OnVideoViewChanged(IVideoControl oldValue, IVideoControl newValue)
+        protected override void OnVideoViewChanged(IVideoControl? oldValue, IVideoControl? newValue)
         {
             base.OnVideoViewChanged(oldValue, newValue);
             foreach (var subManager in SubManagers)
@@ -56,7 +56,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="oldValue">old value</param>
         /// <param name="newValue">new value</param>
-        protected override void OnLibVLCChanged(LibVLC oldValue, LibVLC newValue)
+        protected override void OnLibVLCChanged(LibVLC? oldValue, LibVLC? newValue)
         {
             base.OnLibVLCChanged(oldValue, newValue);
             foreach (var subManager in SubManagers)
@@ -68,7 +68,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Called when <see cref="MediaPlayer"/> property value changes
         /// </summary>
-        protected override void OnMediaPlayerChanged(MediaPlayer oldValue, MediaPlayer newValue)
+        protected override void OnMediaPlayerChanged(MediaPlayer? oldValue, MediaPlayer? newValue)
         {
             base.OnMediaPlayerChanged(oldValue, newValue);
             foreach (var subManager in SubManagers)

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/MediaPlayerElementManagerBase.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/MediaPlayerElementManagerBase.cs
@@ -11,23 +11,23 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="VideoView"/> property changed
         /// </summary>
-        protected EventHandler VideoViewChanged;
+        protected EventHandler? VideoViewChanged;
 
         /// <summary>
         /// Occurs when <see cref="LibVLC"/> property changed
         /// </summary>
-        protected EventHandler LibVLCChanged;
+        protected EventHandler? LibVLCChanged;
 
         /// <summary>
         /// Occurs when <see cref="MediaPlayer"/> property changed
         /// </summary>
-        protected EventHandler MediaPlayerChanged;
+        protected EventHandler? MediaPlayerChanged;
 
         /// <summary>
         /// Initializes a new instance of <see cref="MediaPlayerElementManagerBase"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public MediaPlayerElementManagerBase(IDispatcher dispatcher)
+        public MediaPlayerElementManagerBase(IDispatcher? dispatcher)
         {
             Dispatcher = dispatcher;
         }
@@ -40,13 +40,13 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             Dispose();
         }
 
-        private IDispatcher Dispatcher { get; }
+        private IDispatcher? Dispatcher { get; }
 
-        private IVideoControl _videoView;
+        private IVideoControl? _videoView;
         /// <summary>
         /// Gets or sets the video view
         /// </summary>
-        public IVideoControl VideoView
+        public IVideoControl? VideoView
         {
             get => _videoView;
             set
@@ -60,11 +60,11 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             }
         }
 
-        private LibVLC _libVLC;
+        private LibVLC? _libVLC;
         /// <summary>
         /// Gets or sets the <see cref="LibVLC"/> instance
         /// </summary>
-        public LibVLC LibVLC
+        public LibVLC? LibVLC
         {
             get => _libVLC;
             set
@@ -78,11 +78,11 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             }
         }
 
-        private Shared.MediaPlayer _mediaPlayer;
+        private Shared.MediaPlayer? _mediaPlayer;
         /// <summary>
         /// Gets or sets the media player
         /// </summary>
-        public Shared.MediaPlayer MediaPlayer
+        public Shared.MediaPlayer? MediaPlayer
         {
             get => _mediaPlayer;
             set
@@ -101,7 +101,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="oldValue">old value</param>
         /// <param name="newValue">new value</param>
-        protected virtual void OnVideoViewChanged(IVideoControl oldValue, IVideoControl newValue)
+        protected virtual void OnVideoViewChanged(IVideoControl? oldValue, IVideoControl? newValue)
         {
             VideoViewChanged?.Invoke(this, EventArgs.Empty);
         }
@@ -111,7 +111,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="oldValue">old value</param>
         /// <param name="newValue">new value</param>
-        protected virtual void OnLibVLCChanged(LibVLC oldValue, LibVLC newValue)
+        protected virtual void OnLibVLCChanged(LibVLC? oldValue, LibVLC? newValue)
         {
             LibVLCChanged?.Invoke(this, EventArgs.Empty);
         }
@@ -119,7 +119,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Called when <see cref="MediaPlayer"/> property value changes
         /// </summary>
-        protected virtual void OnMediaPlayerChanged(MediaPlayer oldValue, MediaPlayer newValue)
+        protected virtual void OnMediaPlayerChanged(MediaPlayer? oldValue, MediaPlayer? newValue)
         {
             if (oldValue != null)
             {
@@ -153,7 +153,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// </summary>
         /// <param name="eventHandler">event handler</param>
         /// <returns>The task object representing the asynchronous operation</returns>
-        protected Task DispatcherInvokeEventHandlerAsync(EventHandler eventHandler)
+        protected Task DispatcherInvokeEventHandlerAsync(EventHandler? eventHandler)
         {
             if (eventHandler == null)
             {
@@ -169,7 +169,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <param name="eventHandler">event handler</param>
         /// <param name="eventArgs">event args</param>
         /// <returns>The task object representing the asynchronous operation</returns>
-        protected Task DispatcherInvokeEventHandlerAsync<TEventArgs>(EventHandler<TEventArgs> eventHandler, TEventArgs eventArgs)
+        protected Task DispatcherInvokeEventHandlerAsync<TEventArgs>(EventHandler<TEventArgs>? eventHandler, TEventArgs eventArgs)
             where TEventArgs : EventArgs
         {
             if (eventHandler == null)

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/SeekBarManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/SeekBarManager.cs
@@ -12,18 +12,18 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when the media position changes
         /// </summary>
-        public event EventHandler PositionChanged;
+        public event EventHandler? PositionChanged;
 
         /// <summary>
         /// Occurs when the <see cref="Seekable"/> property value changes
         /// </summary>
-        public event EventHandler SeekableChanged;
+        public event EventHandler? SeekableChanged;
 
         /// <summary>
         /// Initializes a new instance of <see cref="SeekBarManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public SeekBarManager(IDispatcher dispatcher) : base(dispatcher)
+        public SeekBarManager(IDispatcher? dispatcher) : base(dispatcher)
         {
             MediaPlayerChanged += async (sender, e) => await UpdateSeekableAndPositionAsync();
         }

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/StateManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/StateManager.cs
@@ -13,38 +13,38 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when an error is encountered
         /// </summary>
-        public event EventHandler ErrorOccured;
+        public event EventHandler? ErrorOccured;
 
         /// <summary>
         /// Occurs when the error message should be cleared
         /// </summary>
-        public event EventHandler ErrorCleared;
+        public event EventHandler? ErrorCleared;
 
         /// <summary>
         /// Occurs when the <see cref="PlayPauseAvailable"/> property value changes
         /// </summary>
-        public event EventHandler PlayPauseAvailableChanged;
+        public event EventHandler? PlayPauseAvailableChanged;
 
         /// <summary>
         /// Occurs when the media player started playing a media
         /// </summary>
-        public event EventHandler Playing;
+        public event EventHandler? Playing;
 
         /// <summary>
         /// Occurs when the media player paused playback
         /// </summary>
-        public event EventHandler Paused;
+        public event EventHandler? Paused;
 
         /// <summary>
         /// Occurs when the media player paused playback
         /// </summary>
-        public event EventHandler Stopped;
+        public event EventHandler? Stopped;
 
         /// <summary>
         /// Initializes a new instance of <see cref="StateManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public StateManager(IDispatcher dispatcher) : base(dispatcher)
+        public StateManager(IDispatcher? dispatcher) : base(dispatcher)
         {
             MediaPlayerChanged += OnMediaPlayerChangedAsync;
         }
@@ -54,7 +54,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Gets the media resource locator
         /// </summary>
-        public string MediaResourceLocator => MediaPlayer?.Media?.Mrl;
+        public string? MediaResourceLocator => MediaPlayer?.Media?.Mrl;
 
         /// <summary>
         /// Gets a value indicating whether the playback is playing
@@ -130,7 +130,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             return Task.CompletedTask;
         }
 
-        private async Task PlayingOrPausedAsync(EventHandler eventHandler)
+        private async Task PlayingOrPausedAsync(EventHandler? eventHandler)
         {
             if (HasError)
             {

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/SubtitlesTracksManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/SubtitlesTracksManager.cs
@@ -13,7 +13,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// Initialized a new instance of <see cref="SubtitlesTracksManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public SubtitlesTracksManager(IDispatcher dispatcher) : base(dispatcher, TrackType.Text)
+        public SubtitlesTracksManager(IDispatcher? dispatcher) : base(dispatcher, TrackType.Text)
         {
         }
 
@@ -30,6 +30,6 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Gets the tracks descriptions
         /// </summary>
-        public override IEnumerable<TrackDescription> Tracks => MediaPlayer?.SpuDescription;
+        public override IEnumerable<TrackDescription>? Tracks => MediaPlayer?.SpuDescription;
     }
 }

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/TracksManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/TracksManager.cs
@@ -15,26 +15,26 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when tracks should be reinitialized
         /// </summary>
-        public event EventHandler TracksCleared;
+        public event EventHandler? TracksCleared;
         /// <summary>
         /// Occurs when a track is selected
         /// </summary>
-        public event EventHandler<MediaPlayerESSelectedEventArgs> TrackSelected;
+        public event EventHandler<MediaPlayerESSelectedEventArgs>? TrackSelected;
         /// <summary>
         /// Occurs when a track is added
         /// </summary>
-        public event EventHandler<MediaPlayerESAddedEventArgs> TrackAdded;
+        public event EventHandler<MediaPlayerESAddedEventArgs>? TrackAdded;
         /// <summary>
         /// Occurs when a track is deleted
         /// </summary>
-        public event EventHandler<MediaPlayerESDeletedEventArgs> TrackDeleted;
+        public event EventHandler<MediaPlayerESDeletedEventArgs>? TrackDeleted;
 
         /// <summary>
         /// Initializes a new instance of <see cref="TracksManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
         /// <param name="trackType">track type</param>
-        public TracksManager(IDispatcher dispatcher, TrackType trackType) : base(dispatcher)
+        public TracksManager(IDispatcher? dispatcher, TrackType trackType) : base(dispatcher)
         {
             TrackType = trackType;
             MediaPlayerChanged += async (sender, e) => await InitializeAsync();
@@ -45,7 +45,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Gets the tracks descriptions
         /// </summary>
-        public abstract IEnumerable<TrackDescription> Tracks { get; }
+        public abstract IEnumerable<TrackDescription>? Tracks { get; }
 
         /// <summary>
         /// Gets the current track identifier
@@ -84,7 +84,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             return Tracks.FirstOrDefault(t => t.Id == trackId);
         }
 
-        private Task OnTrackChangedAsync<TEventArgs>(TrackType trackType, EventHandler<TEventArgs> eventHandler, TEventArgs eventArgs)
+        private Task OnTrackChangedAsync<TEventArgs>(TrackType trackType, EventHandler<TEventArgs>? eventHandler, TEventArgs eventArgs)
             where TEventArgs : EventArgs
         {
             if (TrackType == trackType)

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/VolumeManager.cs
@@ -11,7 +11,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="Enabled"/> property value changes
         /// </summary>
-        public event EventHandler EnabledChanged;
+        public event EventHandler? EnabledChanged;
 
         ///// <summary>
         ///// Occurs when <see cref="Volume"/> property value changes
@@ -21,13 +21,13 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
         /// <summary>
         /// Occurs when <see cref="Mute"/> property value changes
         /// </summary>
-        public event EventHandler MuteChanged;
+        public event EventHandler? MuteChanged;
 
         /// <summary>
         /// Initializes a new instance of <see cref="VolumeManager"/> class
         /// </summary>
         /// <param name="dispatcher">dispatcher</param>
-        public VolumeManager(IDispatcher dispatcher) : base(dispatcher)
+        public VolumeManager(IDispatcher? dispatcher) : base(dispatcher)
         {
             MediaPlayerChanged += OnMediaPlayerChangedAsync;
         }

--- a/src/LibVLCSharp/Shared/RendererDiscoverer.cs
+++ b/src/LibVLCSharp/Shared/RendererDiscoverer.cs
@@ -10,7 +10,7 @@ namespace LibVLCSharp.Shared
     /// </summary>
     public class RendererDiscoverer : Internal
     {
-        RendererDiscovererEventManager _eventManager;
+        RendererDiscovererEventManager? _eventManager;
         const string Bonjour = "Bonjour_renderer";
         const string Mdns = "microdns_renderer";
 
@@ -45,7 +45,7 @@ namespace LibVLCSharp.Shared
         /// The service discovery protocol name depending on platform. Use <see cref="LibVLC.RendererList"/> to find the one for your platform,
         /// or let libvlcsharp find it for you
         /// </param>
-        public RendererDiscoverer(LibVLC libVLC, string name = null)
+        public RendererDiscoverer(LibVLC libVLC, string? name = null)
             : base(() =>
             {
                 if(string.IsNullOrEmpty(name))
@@ -163,17 +163,17 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Name of the renderer item
         /// </summary>
-        public string Name => Native.LibVLCRendererItemName(NativeReference).FromUtf8();
+        public string Name => Native.LibVLCRendererItemName(NativeReference).FromUtf8()!;
 
         /// <summary>
         /// Type of the renderer item
         /// </summary>
-        public string Type => Native.LibVLCRendererItemType(NativeReference).FromUtf8();
+        public string Type => Native.LibVLCRendererItemType(NativeReference).FromUtf8()!;
 
         /// <summary>
         /// IconUri of the renderer item
         /// </summary>
-        public string IconUri => Native.LibVLCRendererItemIconUri(NativeReference).FromUtf8();
+        public string? IconUri => Native.LibVLCRendererItemIconUri(NativeReference).FromUtf8();
 
         /// <summary>
         /// true if the renderer item can render video

--- a/src/LibVLCSharp/Shared/Structures/MediaDiscovererDescription.cs
+++ b/src/LibVLCSharp/Shared/Structures/MediaDiscovererDescription.cs
@@ -21,7 +21,7 @@ namespace LibVLCSharp.Shared
     /// </summary>
     public readonly struct MediaDiscovererDescription
     {
-        internal MediaDiscovererDescription(string name, string longName, MediaDiscovererCategory category)
+        internal MediaDiscovererDescription(string? name, string? longName, MediaDiscovererCategory category)
         {
             Name = name;
             LongName = longName;
@@ -31,12 +31,12 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Media discoverer description name
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// Media discoverer description long name
         /// </summary>
-        public string LongName { get; }
+        public string? LongName { get; }
 
         /// <summary>
         /// Media discoverer category

--- a/src/LibVLCSharp/Shared/Structures/MediaTrack.cs
+++ b/src/LibVLCSharp/Shared/Structures/MediaTrack.cs
@@ -108,14 +108,14 @@ namespace LibVLCSharp.Shared
     /// </summary>
     public readonly struct SubtitleTrack
     {
-        internal SubtitleTrack(string encoding)
+        internal SubtitleTrack(string? encoding)
         {
             Encoding = encoding;
         }
         /// <summary>
         /// Subtitle encoding
         /// </summary>
-        public readonly string Encoding;
+        public readonly string? Encoding;
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ namespace LibVLCSharp.Shared
     public readonly struct MediaTrack
     {
         internal MediaTrack(uint codec, uint originalFourcc, int id, TrackType trackType, int profile, 
-            int level, MediaTrackData data, uint bitrate, string language, string description)
+            int level, MediaTrackData data, uint bitrate, string? language, string? description)
         {
             Codec = codec;
             OriginalFourcc = originalFourcc;
@@ -180,11 +180,11 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Media track language
         /// </summary>
-        public readonly string Language;
+        public readonly string? Language;
 
         /// <summary>
         /// Media track description
         /// </summary>
-        public readonly string Description;
+        public readonly string? Description;
     }
 }

--- a/src/LibVLCSharp/Shared/Structures/ModuleDescription.cs
+++ b/src/LibVLCSharp/Shared/Structures/ModuleDescription.cs
@@ -25,7 +25,7 @@ namespace LibVLCSharp.Shared.Structures
         /// <param name="shortName">Module short name</param>
         /// <param name="longName">Module long name</param>
         /// <param name="help">Module help</param>
-        internal ModuleDescription(string name, string shortName, string longName, string help)
+        internal ModuleDescription(string? name, string? shortName, string? longName, string? help)
         {
             Name = name;
             ShortName = shortName;
@@ -36,21 +36,21 @@ namespace LibVLCSharp.Shared.Structures
         /// <summary>
         /// Module name
         /// </summary>
-        public readonly string Name;
+        public readonly string? Name;
 
         /// <summary>
         /// Module short name
         /// </summary>
-        public readonly string ShortName;
+        public readonly string? ShortName;
 
         /// <summary>
         /// Module long name
         /// </summary>
-        public readonly string LongName;
+        public readonly string? LongName;
 
         /// <summary>
         /// Module help
         /// </summary>
-        public readonly string Help;
+        public readonly string? Help;
     }
 }

--- a/src/LibVLCSharp/Shared/Structures/RendererDescription.cs
+++ b/src/LibVLCSharp/Shared/Structures/RendererDescription.cs
@@ -22,14 +22,14 @@ namespace LibVLCSharp.Shared
         /// <summary>
         /// Renderer Name
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// Renderer long name
         /// </summary>
-        public string LongName { get; }
+        public string? LongName { get; }
 
-        internal RendererDescription(string name, string longName)
+        internal RendererDescription(string? name, string? longName)
         {
             Name = name;
             LongName = longName;


### PR DESCRIPTION
### Description of Change ###

Bring nullable back.

For context, see:
- https://code.videolan.org/videolan/LibVLCSharp/-/issues/78,
- https://github.com/videolan/libvlcsharp/pull/75
- https://github.com/videolan/libvlcsharp/pull/85
- https://code.videolan.org/videolan/LibVLCSharp/issues/269

### Issues Resolved ### 
- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/78

### API Changes ###
 
 None

### Platforms Affected ### 

- Core (all platforms)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

Should probably build and run the tests.