### PR TITLE
Fixes #294

### DIFF
--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -14,7 +14,8 @@ var packagesDir = "../packages";
 //////////////////////////////////////////////////////////////////////
 
 // Define directories.
-var buildDir = Directory("./build") + Directory(configuration);
+var artifacts = Directory("./build") + Directory(configuration);
+var builds = "../src/**/bin/Release/*.nupkg";
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
@@ -23,8 +24,8 @@ var buildDir = Directory("./build") + Directory(configuration);
 Task("Clean")
     .Does(() =>
 {
-    DeleteFiles("./**/bin/Release/*.nupkg");
-    CleanDirectory(buildDir);
+    DeleteFiles(builds);
+    CleanDirectory(artifacts);
     if(DirectoryExists(packagesDir))
     {
         DeleteDirectory(packagesDir, new DeleteDirectorySettings 
@@ -46,14 +47,14 @@ Task("Build")
     .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
 {
-    MSBuild(solutionPath, settings => settings.SetConfiguration(configuration));
+    MSBuild(solutionPath, settings => settings.SetConfiguration(configuration));    
 });
 
 Task("CopyNugets")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    CopyFiles(GetFiles("./**/bin/Release/*.nupkg"), buildDir);
+    CopyFiles(GetFiles(builds), artifacts);
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/samples/Uno/LibVLCSharp.Uno.Sample.Droid/LibVLCSharp.Uno.Sample.Droid.csproj
+++ b/samples/Uno/LibVLCSharp.Uno.Sample.Droid/LibVLCSharp.Uno.Sample.Droid.csproj
@@ -65,9 +65,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
+    <PackageReference Include="Uno.UI" Version="2.0.527" />
     <PackageReference Include="VideoLAN.LibVLC.Android">
-      <Version>3.1.2.1</Version>
+      <Version>3.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/Uno/LibVLCSharp.Uno.Sample.iOS/LibVLCSharp.Uno.Sample.iOS.csproj
+++ b/samples/Uno/LibVLCSharp.Uno.Sample.iOS/LibVLCSharp.Uno.Sample.iOS.csproj
@@ -115,9 +115,9 @@
     <BundleResource Include="Resources\Fonts\winjs-symbols.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
+    <PackageReference Include="Uno.UI" Version="2.0.527" />
     <PackageReference Include="VideoLAN.LibVLC.iOS">
-      <Version>3.1.5.1</Version>
+      <Version>3.3.10</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Droid/Sample.MediaPlayerElement.Droid.csproj
+++ b/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Droid/Sample.MediaPlayerElement.Droid.csproj
@@ -61,7 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
+    <PackageReference Include="Uno.UI" Version="2.0.527" />
     <PackageReference Include="VideoLAN.LibVLC.Android">
       <Version>3.2.0</Version>
     </PackageReference>

--- a/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.iOS/Sample.MediaPlayerElement.iOS.csproj
+++ b/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.iOS/Sample.MediaPlayerElement.iOS.csproj
@@ -114,9 +114,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
+    <PackageReference Include="Uno.UI" Version="2.0.527" />
     <PackageReference Include="VideoLAN.LibVLC.iOS">
-      <Version>3.1.5.1</Version>
+      <Version>3.3.10</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/LibVLCSharp.Uno/LibVLCSharp.Uno.csproj
+++ b/src/LibVLCSharp.Uno/LibVLCSharp.Uno.csproj
@@ -5,7 +5,7 @@
     <Summary>Uno integration for LibVLCSharp</Summary>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>xamarinios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks>Xamarin.iOS10;MonoAndroid81</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <Authors>VideoLAN</Authors>
@@ -57,20 +57,23 @@ It also contains a VLC MediaPlayerElement for the Uno Platform (UWP, Android, iO
     <None Include="**\*.Android.xaml" />
     <None Include="**\*.iOS.xaml" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('xamarinios')) or $(TargetFramework.StartsWith('monoandroid'))">
-    <PackageReference Include="Uno.UI" Version="2.0.532" />
+  <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS')) or $(TargetFramework.StartsWith('MonoAndroid'))">
+    <PackageReference Include="Uno.UI" Version="2.0.527" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <Compile Include="**\*.UWP.*cs" />
     <Page Include="**\*.UWP.*xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('monoandroid'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <ProjectReference Include="..\LibVLCSharp.Android.AWindow\LibVLCSharp.Android.AWindow.csproj" />
     <Compile Include="**\*.Android.*cs" />
     <Page Include="**\*.Android.*xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('xamarinios'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS'))">
     <Compile Include="**\*.iOS.*cs" />
     <Page Include="**\*.iOS.*xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
+  <Target Name="_BeforeGenerateProjectPriFileCore" BeforeTargets="_GenerateProjectPriFileCore" Condition=" '$(Configuration)'=='Release' ">
+    <Copy SourceFiles="$(ProjectDir)\filtered.layout.resfiles" DestinationFolder="$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)" />
+  </Target>
 </Project>

--- a/src/LibVLCSharp.Uno/filtered.layout.resfiles
+++ b/src/LibVLCSharp.Uno/filtered.layout.resfiles
@@ -1,0 +1,4 @@
+LibVLCSharp.Uno\LibVLCSharp.Uno.xr.xml
+LibVLCSharp.Uno\Themes\Generic.xaml
+LibVLCSharp.Uno\Themes\MediaPlayerElement.xaml
+LibVLCSharp.Uno\Themes\PlaybackControls.xaml

--- a/src/LibVLCSharp.sln
+++ b/src/LibVLCSharp.sln
@@ -11,7 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "..\samples", "{799A84A2-2161-4676-878B-5610E3586137}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{799A84A2-2161-4676-878B-5610E3586137}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibVLCSharp.Forms", "LibVLCSharp.Forms\LibVLCSharp.Forms.csproj", "{06814458-C8B4-4D50-86E2-904E6A9E3499}"
 EndProject


### PR DESCRIPTION
### Description of Change ###
Adds the LibVLCSharp project as an assembly reference instead of a project reference. With this change, the LibVLCSharp.Uno.pri file is correctly generated for the UWP platform.

`<Reference Include="$(SolutionDir)LibVLCSharp\bin\$(Configuration)\$(TargetFramework)\LibVLCSharp.dll" />`

Disadvantage : the NuGet package can't be automatically generated on build anymore (because the package reference to LibVLCSharp is missing). A new nupsec file must be created.

### Issues Resolved ### 
- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/294

### API Changes ###
None