### PR TITLE
#Fixes 330 - Adds PrivateAssets="All" to LibVLCSharp.Android.AWindow

### DIFF
--- a/src/LibVLCSharp.Uno/LibVLCSharp.Uno.csproj
+++ b/src/LibVLCSharp.Uno/LibVLCSharp.Uno.csproj
@@ -64,7 +64,7 @@ It also contains a VLC MediaPlayerElement for the Uno Platform (UWP, Android, iO
     <Page Include="**\*.UWP.*xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <ProjectReference Include="..\LibVLCSharp.Android.AWindow\LibVLCSharp.Android.AWindow.csproj" />
+    <ProjectReference Include="..\LibVLCSharp.Android.AWindow\LibVLCSharp.Android.AWindow.csproj" PrivateAssets="All" />
     <Compile Include="**\*.Android.*cs" />
     <Page Include="**\*.Android.*xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Adds PrivateAssets="All" to LibVLCSharp.Android.AWindow project reference in order to remove the dependency in the .nuspec file (dependency to a NuGet package "LibVLCSharp.Android.AWindow" that doesn't exist).

### Issues Resolved ### 

- fixes [#330](https://code.videolan.org/videolan/LibVLCSharp/-/issues/330)