### PR TITLE
Few corrections in Uno MediaPlayerElement

### DIFF
--- a/src/LibVLCSharp.Uno/PlaybackControlsBase.cs
+++ b/src/LibVLCSharp.Uno/PlaybackControlsBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FontAwesome;
@@ -696,16 +696,27 @@ namespace LibVLCSharp.Uno
 
         private void AspectRatioMenuItemClick(AspectRatio aspectRatio)
         {
-            Manager.Get<AspectRatioManager>().AspectRatio = aspectRatio;
+            var aspectRatioManager = Manager.Get<AspectRatioManager>();
+            var currentAspectRatio = aspectRatioManager.AspectRatio;
+            aspectRatioManager.AspectRatio = aspectRatio;
+            if (currentAspectRatio == aspectRatio)
+            {
+                // To prevent the menu item from being unchecked
+                UpdateZoomMenu(aspectRatio);
+            }
+        }
+
+        private void UpdateZoomMenu(AspectRatio aspectRatio)
+        {
+            if (ZoomMenu != null)
+            {
+                CheckMenuItem(ZoomMenu, ZoomMenu.Items.OfType<ToggleMenuFlyoutItem>().First(i => (AspectRatio)i.CommandParameter == aspectRatio));
+            }
         }
 
         private void AspectRatioChanged(object sender, EventArgs e)
         {
-            if (ZoomMenu != null)
-            {
-                var aspectRatio = ((AspectRatioManager)sender).AspectRatio;
-                CheckMenuItem(ZoomMenu, ZoomMenu.Items.OfType<ToggleMenuFlyoutItem>().First(i => (AspectRatio)i.CommandParameter == aspectRatio));
-            }
+            UpdateZoomMenu(((AspectRatioManager)sender).AspectRatio);
         }
 
         private void Flyout_Opened(object sender, object e)

--- a/src/LibVLCSharp.Uno/Themes/PlaybackControls.xaml
+++ b/src/LibVLCSharp.Uno/Themes/PlaybackControls.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vlc="using:LibVLCSharp.Uno">
@@ -368,6 +368,10 @@
                             <VisualStateGroup x:Name="ControlPanelVisibilityStates">
                                 <VisualState x:Name="ControlPanelFadeIn">
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility"
+																	   Storyboard.TargetName="ControlPanel_ControlPanelVisibilityStates_Border">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
 														 Storyboard.TargetName="ControlPanelGrid"
 														 From="50" To="0.5" Duration="0:0:0.3" />
@@ -388,6 +392,10 @@
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity"
 														 Storyboard.TargetName="ControlPanel_ControlPanelVisibilityStates_Border"
 														 From="1" To="0" Duration="0:0:0.7" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility"
+																	   Storyboard.TargetName="ControlPanel_ControlPanelVisibilityStates_Border">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.7" Value="Collapsed" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -452,7 +460,7 @@
                             <!--Seek bar visibility states-->
                             <VisualStateGroup x:Name="SeekBarAvailablityStates">
                                 <VisualState x:Name="SeekBarAvailable" />
-                                <VisualState x:Name="SeekBarUnvailable">
+                                <VisualState x:Name="SeekBarUnavailable">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ProgressSlider"
                                                                        Storyboard.TargetProperty="Visibility">

--- a/src/LibVLCSharp.Uno/Themes/PlaybackControls.xaml
+++ b/src/LibVLCSharp.Uno/Themes/PlaybackControls.xaml
@@ -503,15 +503,15 @@
                             </VisualStateGroup>
                             <!--Zoom button visibility states-->
                             <VisualStateGroup x:Name="ZoomAvailablityStates">
-                                <VisualState x:Name="ZoomAvailable">
+                                <VisualState x:Name="ZoomAvailable" />
+                                <VisualState x:Name="ZoomUnavailable">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ZoomButton"
                                                                        Storyboard.TargetProperty="Visibility">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
-                                <VisualState x:Name="ZoomUnavailable" />
                             </VisualStateGroup>
                             <!--Cast button visibility states-->
                             <VisualStateGroup x:Name="CastAvailablityStates">

--- a/src/LibVLCSharp/Shared/MediaPlayerElement/AspectRatioManager.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayerElement/AspectRatioManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace LibVLCSharp.Shared.MediaPlayerElement
@@ -27,13 +27,13 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
 
         private IDisplayInformation DisplayInformation { get; }
 
-        private AspectRatio _aspectRatio = AspectRatio.BestFit;
+        private AspectRatio? _aspectRatio = null;
         /// <summary>
         /// Gets the aspect ratio
         /// </summary>
         public AspectRatio AspectRatio
         {
-            get => _aspectRatio;
+            get => _aspectRatio ?? AspectRatio.BestFit;
             set { UpdateAspectRatio(value); }
         }
 
@@ -114,11 +114,11 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             return orientation == VideoOrientation.LeftBottom || orientation == VideoOrientation.RightTop;
         }
 
-        private AspectRatio GetAspectRatio(Shared.MediaPlayer? mediaPlayer)
+        private AspectRatio? GetAspectRatio(Shared.MediaPlayer? mediaPlayer)
         {
             if (mediaPlayer == null)
             {
-                return AspectRatio.BestFit;
+                return null;
             }
 
             var aspectRatio = mediaPlayer.AspectRatio;
@@ -133,7 +133,11 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
             var videoView = VideoView;
             if (aspectRatio == null)
             {
-                aspectRatio = GetAspectRatio(mediaPlayer);
+                aspectRatio = _aspectRatio ?? GetAspectRatio(mediaPlayer);
+                if (aspectRatio == null)
+                {
+                    return;
+                }
             }
             if (videoView != null && mediaPlayer != null)
             {
@@ -167,20 +171,27 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
                         var videoSwapped = IsVideoSwapped(track);
                         var videoWidth = videoSwapped ? track.Height : track.Width;
                         var videoHeigth = videoSwapped ? track.Width : track.Height;
-                        if (track.SarNum != track.SarDen)
+                        if (videoWidth == 0 || videoHeigth == 0)
                         {
-                            videoWidth = videoWidth * track.SarNum / track.SarDen;
+                            mediaPlayer.Scale = 0;
                         }
+                        else
+                        {
+                            if (track.SarNum != track.SarDen)
+                            {
+                                videoWidth = videoWidth * track.SarNum / track.SarDen;
+                            }
 
-                        var ar = videoWidth / (double)videoHeigth;
-                        var videoViewWidth = videoView.Width;
-                        var videoViewHeight = videoView.Height;
-                        var dar = videoViewWidth / videoViewHeight;
+                            var ar = videoWidth / (double)videoHeigth;
+                            var videoViewWidth = videoView.Width;
+                            var videoViewHeight = videoView.Height;
+                            var dar = videoViewWidth / videoViewHeight;
 
-                        var rawPixelsPerViewPixel = DisplayInformation.ScalingFactor;
-                        var displayWidth = videoViewWidth * rawPixelsPerViewPixel;
-                        var displayHeight = videoViewHeight * rawPixelsPerViewPixel;
-                        mediaPlayer.Scale = (float)(dar >= ar ? (displayWidth / videoWidth) : (displayHeight / videoHeigth));
+                            var rawPixelsPerViewPixel = DisplayInformation.ScalingFactor;
+                            var displayWidth = videoViewWidth * rawPixelsPerViewPixel;
+                            var displayHeight = videoViewHeight * rawPixelsPerViewPixel;
+                            mediaPlayer.Scale = (float)(dar >= ar ? (displayWidth / videoWidth) : (displayHeight / videoHeigth));
+                        }
                         mediaPlayer.AspectRatio = null;
                         break;
                     case AspectRatio._16_9:
@@ -196,7 +207,7 @@ namespace LibVLCSharp.Shared.MediaPlayerElement
 
             if (_aspectRatio != aspectRatio)
             {
-                _aspectRatio = (AspectRatio)aspectRatio;
+                _aspectRatio = aspectRatio;
                 AspectRatioChanged?.Invoke(this, EventArgs.Empty);
             }
         }


### PR DESCRIPTION
### Description of Change ###

- Corrects the SeekBarUnavailable state.
- Corrects the ZoomUnavailablity state.
- Updates the visibility of the playback controls after fade in / fade out (currently, only the opacity is modified).
- Prevent AspectRatio menu item from being unchecked
- Corrects FitScreen aspect ratio when the video track width and height are equals to 0 (perhaps it will fix [#270](https://code.videolan.org/videolan/LibVLCSharp/-/issues/270) but I'm not sure).
- Always keep the selected aspect ratio

### Issues Resolved ### 
- The IsSeekBarVisible property doesn't work on PlaybackControls, so the seek bar can't be hidden.
- The IsZoomButtonVisible property doesn't work

### API Changes ###
None

### Platforms Affected ### 
- UWP / Uno MediaPlayerElement