### PR TITLE
Declared non-seekable streams as non-seekable in callback input

### DIFF
--- a/samples/LibVLCSharp.NetCore.Sample/LibVLCSharp.NetCore.Sample.csproj
+++ b/samples/LibVLCSharp.NetCore.Sample/LibVLCSharp.NetCore.Sample.csproj
@@ -7,7 +7,7 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="3.0.8" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="3.0.11" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -44,7 +44,7 @@ namespace LibVLCSharp.Shared
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_new_callbacks")]
             internal static extern IntPtr LibVLCMediaNewCallbacks(IntPtr libVLC, InternalOpenMedia openCb, InternalReadMedia readCb, 
-                InternalSeekMedia seekCb, InternalCloseMedia closeCb, IntPtr opaque);
+                InternalSeekMedia? seekCb, InternalCloseMedia closeCb, IntPtr opaque);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_add_option")]
@@ -284,7 +284,7 @@ namespace LibVLCSharp.Shared
             return Native.LibVLCMediaNewCallbacks(libVLC.NativeReference,
                 OpenMediaCallbackHandle,
                 ReadMediaCallbackHandle,
-                SeekMediaCallbackHandle,
+                input.CanSeek ? SeekMediaCallbackHandle : null,
                 CloseMediaCallbackHandle,
                 GCHandle.ToIntPtr(input.GcHandle));
         }

--- a/src/LibVLCSharp/Shared/MediaInput.cs
+++ b/src/LibVLCSharp/Shared/MediaInput.cs
@@ -24,6 +24,11 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
+        /// A value indicating whether this Media input can be seeked in.
+        /// </summary>
+        public bool CanSeek { get; protected set; } = true;
+
+        /// <summary>
         /// LibVLC calls this method when it wants to open the media
         /// </summary>
         /// <param name="size">This value must be filled with the length of the media (or ulong.MaxValue if unknown)</param>

--- a/src/LibVLCSharp/Shared/MediaInput.cs
+++ b/src/LibVLCSharp/Shared/MediaInput.cs
@@ -40,7 +40,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="buf">The buffer where read data must be written</param>
         /// <param name="len">The buffer length</param>
-        /// <returns>The number of bytes actually read, -1 on error</returns>
+        /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
         public abstract int Read(IntPtr buf, uint len);
 
         /// <summary>

--- a/src/LibVLCSharp/Shared/StreamMediaInput.cs
+++ b/src/LibVLCSharp/Shared/StreamMediaInput.cs
@@ -24,6 +24,7 @@ namespace LibVLCSharp.Shared
         public StreamMediaInput(Stream stream)
         {
             _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            CanSeek = stream.CanSeek;
         }
 
         /// <summary>

--- a/src/LibVLCSharp/Shared/StreamMediaInput.cs
+++ b/src/LibVLCSharp/Shared/StreamMediaInput.cs
@@ -65,7 +65,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         /// <param name="buf">The buffer where read data must be written</param>
         /// <param name="len">The buffer length</param>
-        /// <returns>The number of bytes actually read, -1 on error</returns>
+        /// <returns>strictly positive number of bytes read, 0 on end-of-stream, or -1 on non-recoverable error</returns>
         public unsafe override int Read(IntPtr buf, uint len)
         {
             try

--- a/src/LibVLCSharp/Shared/StreamMediaInput.cs
+++ b/src/LibVLCSharp/Shared/StreamMediaInput.cs
@@ -70,6 +70,11 @@ namespace LibVLCSharp.Shared
         {
             try
             {
+                if(_stream.CanSeek)
+                {
+                    if (_stream.Position == _stream.Length)
+                        return 0;
+                }
 #if NET40
                 var read = _stream.Read(_readBuffer, 0, Math.Min((int)len, _readBuffer.Length));
                 Marshal.Copy(_readBuffer, 0, buf, read);


### PR DESCRIPTION
### Description of Change ###

These are the same changes as https://github.com/ZeBobo5/Vlc.DotNet/pull/648

Streams where CanSeek is false should not be declared as seekable in libvlc.
Also increased the buffer size to match the libvlc buffer size.

### Issues Resolved ### 

None opened on LVS, but see https://github.com/ZeBobo5/Vlc.DotNet/issues/647

### API Changes ###
Added:
 - bool MediaInput.CanSeek { get; protected set; } // Defaults to true, must be set to false in subclasses constructor.

Changed:
 - Native.LibVLCMediaNewCallbacks now has a nullable parameter for seekCb
 
### Platforms Affected ### 
- Core (all platforms)

### Behavioral/Visual Changes ###

Will not attempt to call Seek if the `Stream` is not seekable in `StreamMediaInput`. LibVLC will now understand that the stream is not seekable and will show appropriate log messages.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Didn't have time to push it to a repo, sorry:

```cs
            Core.Initialize();

            using var libVLC = new LibVLC("-vv");

            var FileStream = new FileStream(path: @"D:\Projects\Tests\vlc_text_encr\Encrypted_Video\video.ded", mode: FileMode.Open, access: FileAccess.Read);
            RijndaelManaged AES = new RijndaelManaged();
            SHA256 SHA256 = SHA256.Create();

            // read key from TextBox4.Text
            AES.Key = SHA256.ComputeHash(Encoding.ASCII.GetBytes("U[#x5:jg0$e-^etBx#MjWH5Zu_ndd9"));
            AES.Mode = CipherMode.ECB;


            // cryptostream starts here
            var cryptoStream = new CryptoStream(FileStream, AES.CreateDecryptor(), CryptoStreamMode.Read);
            using var input = new StreamMediaInput(cryptoStream);
            using var media = new Media(libVLC, input);
            using var mp = new MediaPlayer(media);
            mp.Play();
            Console.ReadKey();
```

The video can be found here: https://github.com/graysuit/vlc_text_encr/tree/master/Encrypted_Video

Expected result : "mp4 stream error: no moov before mdat and the stream is not seekable" in the log

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
