### PR TITLE
README: Add tldr legal link to LGPL license

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Please read and follow the [VideoLAN CoC](https://wiki.videolan.org/Code_of_Cond
 
 ## License
 
-LibVLCSharp is under the LGPLv2.1.
+LibVLCSharp is under the [LGPLv2.1](https://tldrlegal.com/license/gnu-lesser-general-public-license-v2.1-(lgpl-2.1)).
 
 Note: the .NET4.0 LibVLCSharp build references a nuget package that may indicate its license as the .NET Library license but it's actually [opensource](https://github.com/Microsoft/referencesource/commit/6952d2c3923d30a4d88bf57120688b9532bbe1d8) under MIT.
 


### PR DESCRIPTION
The LGPL license is not very common in the dotnet world,
so people should check their assumptions and make sure they understand what it allows and doesn't allow.