### PR TITLE
CD: push LibVLCSharp.* nupkg to feedz

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # LibVLCSharp
 
-[![Build Status](https://videolan.visualstudio.com/LibVLCSharp/_apis/build/status/videolan.libvlcsharp?branchName=master)](https://videolan.visualstudio.com/LibVLCSharp/_build/latest?definitionId=22&branchName=master)
+[![Build Status](https://videolan.visualstudio.com/LibVLCSharp/_apis/build/status/videolan.libvlcsharp?branchName=master)](https://videolan.visualstudio.com/LibVLCSharp/_build?definitionId=22)
 [![Join the chat at https://discord.gg/3h3K3JF](https://img.shields.io/discord/716939396464508958?label=discord)](https://discord.gg/3h3K3JF)
 
 LibVLCSharp is a cross-platform audio and video API for .NET platforms based on VideoLAN's LibVLC Library.

--- a/buildsystem/azure-pipelines.yml
+++ b/buildsystem/azure-pipelines.yml
@@ -6,21 +6,51 @@ pr:
 - master
 - 3.x
 
-jobs:
-- job: Linux
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
-  - template: linux-build.yml
+stages:
+- stage: Build
+  variables:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
-- job: macOS
-  pool:
-    vmImage: 'macOS-10.15'
-  steps:
-  - template: mac-build.yml
+  jobs:
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - template: linux-build.yml
 
-- job: Windows
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-  - template: windows-build.yml
+  - job: macOS
+    pool:
+      vmImage: 'macOS-10.15'
+    steps:
+    - template: mac-build.yml
+
+  - job: Windows
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - template: windows-build.yml
+
+- stage: Deploy
+  dependsOn: Build
+  condition: and(succeeded('Build'), not(eq(variables['build.reason'], 'PullRequest')))
+
+  jobs:
+  - job: feedz
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          artifactName: 'nugets'
+          itemPattern: '**/*.nupkg'
+          downloadPath: $(Build.Repository.LocalPath)
+      - task: PowerShell@2
+        displayName: 'Deploy'
+        env:
+          FEEDZ: $(FEEDZ)
+        inputs:
+          targetType: filePath
+          filePath: ./buildsystem/build.ps1
+          arguments: -target CIDeploy
+          workingDirectory: buildsystem

--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -7,15 +7,23 @@ var configuration = Argument("configuration", "Release");
 var solutionName = "LibVLCSharp";
 var solutionFile = IsRunningOnWindows() ? $"{solutionName}.sln" : $"{solutionName}.Mac.sln";
 var solutionPath = $"../src/{solutionFile}";
+var libvlcsharpCsproj = "../src/libvlcsharp/libvlcsharp.csproj";
+
 var packagesDir = "../packages";
+var isCiBuild = BuildSystem.IsRunningOnAzurePipelines || BuildSystem.IsRunningOnAzurePipelinesHosted;
+var suffixVersion = $"alpha-{DateTime.Today.ToString("yyyyMMdd")}-{BuildSystem.AzurePipelines.Environment.Build.Id}";
+var feedzLVSSource = "https://f.feedz.io/videolan/libvlcsharp/nuget/index.json";
+var FEEDZ = "FEEDZ";
+const uint totalPackageCount = 8;
+var buildProp = new FilePath("../src/Directory.build.props");
 
 //////////////////////////////////////////////////////////////////////
 // PREPARATION
 //////////////////////////////////////////////////////////////////////
 
 // Define directories.
-var artifacts = Directory("./build") + Directory(configuration);
-var builds = "../src/**/bin/Release/*.nupkg";
+var artifactsDir = Directory("../nugets");
+var artifactRelativePathPattern = "./../nugets/*";
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
@@ -24,8 +32,7 @@ var builds = "../src/**/bin/Release/*.nupkg";
 Task("Clean")
     .Does(() =>
 {
-    DeleteFiles(builds);
-    CleanDirectory(artifacts);
+    CleanDirectory(artifactsDir);
     if(DirectoryExists(packagesDir))
     {
         DeleteDirectory(packagesDir, new DeleteDirectorySettings 
@@ -47,15 +54,45 @@ Task("Build")
     .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
 {
-    MSBuild(solutionPath, settings => settings.SetConfiguration(configuration));    
+    Build(solutionPath);
 });
 
-Task("CopyNugets")
-    .IsDependentOn("Build")
+// just for (faster) testing
+Task("Build-only-libvlcsharp")
+    .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
 {
-    CopyFiles(GetFiles(builds), artifacts);
+    Build(libvlcsharpCsproj);
 });
+
+Task("CIDeploy")
+    .Does(() =>
+{
+    var packages = GetFiles(artifactRelativePathPattern);
+    
+    Information($"packages count: {packages.Count}");
+
+    if(packages.Count != totalPackageCount)
+    {
+        throw new Exception($"There should be {totalPackageCount} packages but there is {packages.Count} packages");
+    }
+
+    NuGetPush(packages, new NuGetPushSettings 
+    {
+        Source = feedzLVSSource,
+        ApiKey = EnvironmentVariable(FEEDZ)
+    });
+});
+
+void Build(string project)
+{
+    if(isCiBuild)
+    {
+        XmlPoke(buildProp, "//Project/PropertyGroup/VersionSuffix", suffixVersion);
+    }
+
+    MSBuild(project, settings => settings.SetConfiguration(configuration).WithProperty("PackageOutputPath", MakeAbsolute(artifactsDir).FullPath));
+}
 
 //////////////////////////////////////////////////////////////////////
 // TASK TARGETS

--- a/buildsystem/windows-build.yml
+++ b/buildsystem/windows-build.yml
@@ -14,5 +14,10 @@ steps:
   displayName: 'Build all'
   inputs:
     targetType: filePath
-    filePath: ./buildsystem/build.ps1
+    filePath: ./buildsystem/build.ps1 
     workingDirectory: buildsystem
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: 'nugets'
+    artifactName: 'nugets'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,7 @@
     <DefineConstants>$(DefineConstants);UWP10_0</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>3.4.5</Version>
+    <VersionPrefix>3.4.5</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

Setup continuous delivery for the 8 LibVLCSharp nuget packages to feedz.

Only deploy for 3.x/master commits, if the build of all nugets has been successful. Versioning uses the current day and the build ID, as a pre-release package.

This will allow testing libvlcsharp 4/libvlc 4 more easily, and enable users to try it out.

### Issues Resolved ### 
- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/349

### API Changes ###
 
 None