### PR TITLE
Libvlc 4 coverage

### DIFF
--- a/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
+++ b/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
@@ -117,6 +117,8 @@ namespace LibVLCSharp.Tests
                 }
             }
 
+            var unusedDllImports = dllImports.Except(libvlcSymbols);
+
             var missingApis = libvlcSymbols
                 .Where(symbol => !exclude.Any(excludeSymbol => symbol.StartsWith(excludeSymbol))) // Filters out excluded symbols
                 .Except(dllImports)
@@ -132,7 +134,15 @@ namespace LibVLCSharp.Tests
                 Debug.WriteLine(miss);
             }
 
+            var unusedDllImportsCount = unusedDllImports.Count();
+            Debug.WriteLine($"{unusedDllImportsCount} unused DllImports implementation");
+            foreach (var unused in unusedDllImports)
+            {
+                Debug.WriteLine(unused);
+            }
+
             Assert.Zero(missingApisCount);
+            Assert.Zero(unusedDllImportsCount);
         }
     }
 }

--- a/src/LibVLCSharp/MediaDiscoverer.cs
+++ b/src/LibVLCSharp/MediaDiscoverer.cs
@@ -30,10 +30,6 @@ namespace LibVLCSharp
             internal static extern void LibVLCMediaDiscovererRelease(IntPtr mediaDiscoverer);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "libvlc_media_discoverer_localized_name")]
-            internal static extern IntPtr LibVLCMediaDiscovererLocalizedName(IntPtr mediaDiscoverer);
-
-            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                             EntryPoint = "libvlc_media_discoverer_is_running")]
             internal static extern int LibVLCMediaDiscovererIsRunning(IntPtr mediaDiscoverer);
 
@@ -68,12 +64,6 @@ namespace LibVLCSharp
         /// Stop media discovery.
         /// </summary>
         public void Stop() => Native.LibVLCMediaDiscovererStop(NativeReference);
-
-        /// <summary>
-        /// Get media service discover object its localized name.
-        /// under v3 only
-        /// </summary>
-        public string? LocalizedName => Native.LibVLCMediaDiscovererLocalizedName(NativeReference).FromUtf8();
 
         /// <summary>
         /// Query if media service discover object is running.

--- a/src/LibVLCSharp/MediaPlayer.cs
+++ b/src/LibVLCSharp/MediaPlayer.cs
@@ -140,12 +140,6 @@ namespace LibVLCSharp
                 EntryPoint = "libvlc_media_player_get_chapter_count")]
             internal static extern int LibVLCMediaPlayerGetChapterCount(IntPtr mediaPlayer);
 
-
-            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "libvlc_media_player_will_play")]
-            internal static extern int LibVLCMediaPlayerWillPlay(IntPtr mediaPlayer);
-
-
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_get_chapter_count_for_title")]
             internal static extern int LibVLCMediaPlayerGetChapterCountForTitle(IntPtr mediaPlayer, int title);
@@ -442,15 +436,6 @@ namespace LibVLCSharp
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_chapter_descriptions_release")]
             internal static extern void LibVLCChapterDescriptionsRelease(IntPtr chapters, uint count);
-
-
-            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "libvlc_video_get_crop_geometry")]
-            internal static extern IntPtr LibVLCVideoGetCropGeometry(IntPtr mediaPlayer);
-
-            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "libvlc_video_set_crop_geometry")]
-            internal static extern void LibVLCVideoSetCropGeometry(IntPtr mediaPlayer, IntPtr geometry);
 
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_video_get_teletext")]
@@ -796,11 +781,6 @@ namespace LibVLCSharp
         /// Get the number of chapters in movie, or -1.
         /// </summary>
         public int ChapterCount => Native.LibVLCMediaPlayerGetChapterCount(NativeReference);
-
-        /// <summary>
-        /// True if the player is able to play
-        /// </summary>
-        public bool WillPlay => Native.LibVLCMediaPlayerWillPlay(NativeReference) != 0;
 
         /// <summary>
         /// Get the number of chapters in title, or -1
@@ -1505,20 +1485,6 @@ namespace LibVLCSharp
             MarshalUtils.PtrToStructure<ChapterDescriptionStructure>,
             t => t.Build(),
             Native.LibVLCChapterDescriptionsRelease);
-
-        /// <summary>
-        /// Get/Set current crop filter geometry.
-        /// Empty string to unset
-        /// </summary>
-        public string? CropGeometry
-        {
-            get => Native.LibVLCVideoGetCropGeometry(NativeReference).FromUtf8(libvlcFree: true);
-            set
-            {
-                var cropGeometryUtf8 = value.ToUtf8();
-                MarshalUtils.PerformInteropAndFree(() => Native.LibVLCVideoSetCropGeometry(NativeReference, cropGeometryUtf8), cropGeometryUtf8);
-            }
-        }
 
         /// <summary>
         /// Get current teletext page requested.


### PR DESCRIPTION
Adapt test to include unused dllimport statements.
Removed 4 libvlc APIs not available anymore.

At the time of writing, there are 13 libvlc APIs left to implement for 100% libvlc coverage on libvlcsharp 4/libvlc 4:
```
libvlc_media_get_tracklist
libvlc_media_track_hold
libvlc_media_track_release
libvlc_media_tracklist_at
libvlc_media_tracklist_count
libvlc_media_tracklist_delete
libvlc_media_player_get_tracklist
libvlc_media_player_get_track_from_id
libvlc_media_player_get_selected_track
libvlc_media_player_select_track
libvlc_media_player_select_tracks
libvlc_media_player_select_tracks_by_ids
libvlc_video_set_output_callbacks
```

`libvlc_video_set_output_callbacks` has been implemented before, but needs some updating.

This doesn't test for:
- signature changes (params, return types, etc).
- events changes,
- structures changes.