### PR TITLE
Log interop: Fix netcore support for libvlc logs on macOS

### DIFF
--- a/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -65,6 +65,8 @@ namespace LibVLCSharp.Shared.Helpers
 
         internal static string GetLogMessage(IntPtr format, IntPtr args)
         {
+            if(PlatformHelper.IsMac)
+                return AppleLogCallback(format, args);
 #if APPLE
             return AppleLogCallback(format, args);
 #else


### PR DESCRIPTION
### Description of Change ###

Apple specific interop wasn't used for libvlc logs on mac netcore. Worked fine for mono/cocoa.

### API Changes ###
- None

### Platforms Affected ### 

- macOS