### PR TITLE
core ui: the IVideoControl is used outside of the MediaPlayerElement

### DIFF
--- a/src/LibVLCSharp.Uno/VideoView.UWP.cs
+++ b/src/LibVLCSharp.Uno/VideoView.UWP.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using LibVLCSharp.Platforms.UWP;
-using LibVLCSharp.Shared.MediaPlayerElement;
+using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.Uno
 {

--- a/src/LibVLCSharp/Shared/IVideoControl.cs
+++ b/src/LibVLCSharp/Shared/IVideoControl.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace LibVLCSharp.Shared.MediaPlayerElement
+namespace LibVLCSharp.Shared
 {
     /// <summary>
     /// Interface for video control


### PR DESCRIPTION
### Description of Change ###

Fix crash

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/364

### API Changes ###
 
 None

### Platforms Affected ### 

- Core (all platforms)