### PR TITLE
unity: add android support

### DIFF
--- a/src/LibVLCSharp/Core/Core.Desktop.cs
+++ b/src/LibVLCSharp/Core/Core.Desktop.cs
@@ -78,6 +78,9 @@ namespace LibVLCSharp
         static void InitializeDesktop(string? libvlcDirectoryPath = null)
         {
 #if UNITY
+            // early return for unity android, allows us to share the same libvlcsharp unity dll
+            if(!PlatformHelper.IsWindows) return;
+
             if(string.IsNullOrEmpty(libvlcDirectoryPath))
             {
                 throw new VLCException("Please provide UnityEngine.Application.dataPath to Core.Initialize for proper initialization.");


### PR DESCRIPTION
It would be really nice to have only 1 single libvlcsharp dll for all unity platforms.
I'm not sure whether it is really doable, but it might, because it has to be a netstandard2.0 dll either way.
A new Core.Unity.cs file might be a good idea