### PR TITLE
Avoid a copy in StreamMediaInput on modern platform

### DIFF
--- a/src/LibVLCSharp/Helpers/MarshalExtensions.cs
+++ b/src/LibVLCSharp/Helpers/MarshalExtensions.cs
@@ -166,5 +166,31 @@ namespace LibVLCSharp.Helpers
                 MarshalUtils.LibVLCFree(ref nativeString);
             return Encoding.UTF8.GetString(buffer, 0, buffer.Length);
         }
+
+#if !APPLE && !ANDROID && !NETSTANDARD2_1
+        /// <summary>
+        /// The Span-based APIs on Stream are not available on older targets. Span can be backported on older TFMs through the System.Memory package,
+        /// but System.IO does not provide the same benefit. This code is extracted from dotnet/runtime to allow efficient media callbacks implementation.
+        /// </summary>
+        /// <remarks>https://github.com/dotnet/runtime/blob/c4b9dabec8186a0d61f0cc3ea0b7efea579bf24e/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs#L720-L734</remarks>
+        /// <param name="stream">the .NET stream</param>
+        /// <param name="buffer">the buffer to read</param>
+        /// <returns>number of bytes read</returns>
+        internal static int Read(this System.IO.Stream stream, Span<byte> buffer)
+        {
+            var sharedBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var numRead = stream.Read(sharedBuffer, 0, buffer.Length);
+                if ((uint)numRead > (uint)buffer.Length)
+                {
+                    throw new System.IO.IOException("StreamTooLong");
+                }
+                new Span<byte>(sharedBuffer, 0, numRead).CopyTo(buffer);
+                return numRead;
+            }
+            finally { System.Buffers.ArrayPool<byte>.Shared.Return(sharedBuffer); }
+        }
+#endif
     }
 }

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -28,7 +28,7 @@ This package also contains the views for the following platforms:
 If you need Xamarin.Forms support, see LibVLCSharp.Forms.
 
 LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0;uap10.0.16299;net45;net471</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAWindow</TargetsForTfmSpecificBuildOutput>
@@ -49,6 +49,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>https://code.videolan.org/videolan/LibVLCSharp/blob/master/NEWS</PackageReleaseNotes>
     <PackageTags>libvlc;vlc;videolan;native;c/c++;video;audio;player;media;mediaplayer;codec;ffmpeg;xamarin;graphics;ios;android;linux;windows;macos;cross-platform</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -60,6 +61,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <Compile Include="Platforms\Android\**\*.cs" />
@@ -86,7 +88,13 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     </Page>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+   <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+
+  </ItemGroup>
+
   <Target Name="IncludeAWindow" Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)LibVLCSharp.Android.AWindow.dll" />


### PR DESCRIPTION
### Description of Change ###
By leveraging Span<byte> and unsafe construct, we can get rid of a Marshal.Copy that bothered me from the beginning of the implementation of StreamMediaInput.

This implementation should give better performances around media input callback, and use less ram, but I didn't take time to benchmark.

Note : This PR is on top of #154 because I needed to build the projects... Feel free to rebase after #154 is merged

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/345

### API Changes ###

 None

### Platforms Affected ### 
- netstandard2.1
- Android
- Apple

(looks weird to me that the mono projects build with that change, but either they did, or I fail to build them properly. Will adapt depending on the CI result)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Try using the StreamMediaInput and see if it still work.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
