### PR TITLE
Avoid a copy in StreamMediaInput on modern platforms

### DIFF
--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -49,6 +49,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>https://code.videolan.org/videolan/LibVLCSharp/blob/master/NEWS</PackageReleaseNotes>
     <PackageTags>libvlc;vlc;videolan;native;c/c++;video;audio;player;media;mediaplayer;codec;ffmpeg;xamarin;graphics;ios;android;linux;windows;macos;cross-platform</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -71,6 +72,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <Compile Remove="Shared\MediaPlayerElement\*.*" />
     <None Include="Shared\MediaPlayerElement\*.*" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Compile Remove="Shared\MediaPlayerElement\*.*" />
@@ -86,6 +88,10 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     </Page>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
   <Target Name="IncludeAWindow" Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <ItemGroup>

--- a/src/LibVLCSharp/Shared/Helpers/MarshalExtensions.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalExtensions.cs
@@ -168,5 +168,31 @@ namespace LibVLCSharp.Shared.Helpers
                 MarshalUtils.LibVLCFree(ref nativeString);
             return Encoding.UTF8.GetString(buffer, 0, buffer.Length);
         }
+
+ #if !APPLE && !ANDROID && !NETSTANDARD2_1 && !NET40
+        /// <summary>
+        /// The Span-based APIs on Stream are not available on older targets. Span can be backported on older TFMs through the System.Memory package,
+        /// but System.IO does not provide the same benefit. This code is extracted from dotnet/runtime to allow efficient media callbacks implementation.
+        /// </summary>
+        /// <remarks>https://github.com/dotnet/runtime/blob/c4b9dabec8186a0d61f0cc3ea0b7efea579bf24e/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs#L720-L734</remarks>
+        /// <param name="stream">the .NET stream</param>
+        /// <param name="buffer">the buffer to read</param>
+        /// <returns>number of bytes read</returns>
+        internal static int Read(this System.IO.Stream stream, Span<byte> buffer)
+        {
+            var sharedBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var numRead = stream.Read(sharedBuffer, 0, buffer.Length);
+                if ((uint)numRead > (uint)buffer.Length)
+                {
+                    throw new System.IO.IOException("StreamTooLong");
+                }
+                new Span<byte>(sharedBuffer, 0, numRead).CopyTo(buffer);
+                return numRead;
+            }
+            finally { System.Buffers.ArrayPool<byte>.Shared.Return(sharedBuffer); }
+        }
+#endif
     }
 }


### PR DESCRIPTION
backporting https://github.com/videolan/libvlcsharp/pull/155 to 3.x branch