### PR TITLE
Remove stop call in Dispose method of MediaPlayer ... this should occ…

### DIFF
--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -2404,9 +2404,6 @@ namespace LibVLCSharp.Shared
 
             if(disposing)
             {
-                if(IsPlaying)
-                    Stop();
-
                 if (_gcHandle.IsAllocated)
                     _gcHandle.Free();
             }


### PR DESCRIPTION
### Description of Change ###

Remove Stop call from MediaPlayer dispose method.  (As discussed on Discord)

Reasons:

* Player Stop method can produce a deadlock on Windows under certain conditions of multiple player instances and RTSP streams unless it is called from another thread.
* Not strictly required anyway prior to dispose ... should be left to application discretion.

### Issues Resolved ### 

N/A

### API Changes ###

None

### Platforms Affected ### 

- Core (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
