### PR TITLE
core: Add logging helper to libvlc constructor

### DIFF
--- a/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement/MainViewModel.cs
+++ b/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement/MainViewModel.cs
@@ -49,7 +49,7 @@ namespace LibVLCSharp.Forms.Sample.MediaPlayerElement
         {
             Core.Initialize();
 
-            LibVLC = new LibVLC();
+            LibVLC = new LibVLC(enableDebugLogs: true);
 
             var media = new Media(LibVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
 

--- a/samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -39,7 +39,7 @@ namespace LibVLCSharp.Forms.Sample
         {
             Core.Initialize();
 
-            LibVLC = new LibVLC();
+            LibVLC = new LibVLC(enableDebugLogs: true);
             var media = new Media(LibVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
 
             MediaPlayer = new MediaPlayer(LibVLC)

--- a/samples/LibVLCSharp.Android.Sample/MainActivity.cs
+++ b/samples/LibVLCSharp.Android.Sample/MainActivity.cs
@@ -29,7 +29,7 @@ namespace LibVLCSharp.Android.Sample
 
             Core.Initialize();
 
-            _libVLC = new LibVLC();
+            _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new MediaPlayer(_libVLC)
             {
                 EnableHardwareDecoding = true

--- a/samples/LibVLCSharp.FSharp.Sample/Program.fs
+++ b/samples/LibVLCSharp.FSharp.Sample/Program.fs
@@ -4,7 +4,7 @@ open LibVLCSharp.Shared
 [<EntryPoint>]
 let main argv =
     Core.Initialize()
-    let libVLC = new LibVLC()
+    let libVLC = new LibVLC(true)
     let mp = new MediaPlayer(libVLC)
     let media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"))
     mp.Play(media) |> ignore

--- a/samples/LibVLCSharp.GTK.Sample/Program.cs
+++ b/samples/LibVLCSharp.GTK.Sample/Program.cs
@@ -13,7 +13,7 @@ namespace LibVLCSharp.GTK.Sample
             // Initializes the GTK# app
             Application.Init();
 
-            using var libvlc = new LibVLC();
+            using var libvlc = new LibVLC(enableDebugLogs: true);
             using var mediaPlayer = new MediaPlayer(libvlc);
 
             // Create the window in code. This could be done in glade as well, I guess...

--- a/samples/LibVLCSharp.Mac.Sample/ViewController.cs
+++ b/samples/LibVLCSharp.Mac.Sample/ViewController.cs
@@ -24,7 +24,7 @@ namespace LibVLCSharp.Mac.Sample
 
             Core.Initialize();
 
-            _libVLC = new LibVLC("--verbose=2");
+            _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new Shared.MediaPlayer(_libVLC);
 
             _videoView = new VideoView { MediaPlayer = _mediaPlayer };

--- a/samples/LibVLCSharp.NetCore.Sample/Program.cs
+++ b/samples/LibVLCSharp.NetCore.Sample/Program.cs
@@ -9,7 +9,7 @@ namespace LibVLCSharp.NetCore.Sample
         {
             Core.Initialize();
 
-            using var libVLC = new LibVLC();
+            using var libVLC = new LibVLC(enableDebugLogs: true);
             using var media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4"));
             using var mp = new MediaPlayer(media);
             mp.Play();

--- a/samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
+++ b/samples/LibVLCSharp.UWP.Sample/MainViewModel.cs
@@ -60,7 +60,7 @@ namespace LibVLCSharp.UWP.Sample
 
         private void Initialize(InitializedEventArgs eventArgs)
         {
-            LibVLC = new LibVLC(eventArgs.SwapChainOptions);
+            LibVLC = new LibVLC(enableDebugLogs: true, eventArgs.SwapChainOptions);
             MediaPlayer = new MediaPlayer(LibVLC);
             using var media = new Media(LibVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
             MediaPlayer.Play(media);

--- a/samples/LibVLCSharp.WPF.Sample/Controls.xaml.cs
+++ b/samples/LibVLCSharp.WPF.Sample/Controls.xaml.cs
@@ -33,7 +33,7 @@ namespace LibVLCSharp.WPF.Sample
 
         private void VideoView_Loaded(object sender, RoutedEventArgs e)
         {
-            _libVLC = new LibVLC();
+            _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new MediaPlayer(_libVLC);
 
             parent.VideoView.MediaPlayer = _mediaPlayer;

--- a/samples/LibVLCSharp.Windows.Net40.Sample/Program.cs
+++ b/samples/LibVLCSharp.Windows.Net40.Sample/Program.cs
@@ -9,7 +9,7 @@ namespace LibVLCSharp.Windows.Net40.Sample
         {
             Core.Initialize();
 
-            using var libVLC = new LibVLC();
+            using var libVLC = new LibVLC(enableDebugLogs: true);
             using var media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
             using var mp = new MediaPlayer(media);
             mp.Play();

--- a/samples/LibVLCSharp.iOS.Sample/ViewController.cs
+++ b/samples/LibVLCSharp.iOS.Sample/ViewController.cs
@@ -15,7 +15,7 @@ namespace LibVLCSharp.iOS.Sample
         {
             base.ViewDidLoad();
 
-            _libVLC = new LibVLC();
+            _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new Shared.MediaPlayer(_libVLC);
 
             _videoView = new VideoView { MediaPlayer = _mediaPlayer };

--- a/samples/LibVLCSharp.tvOS.Sample/ViewController.cs
+++ b/samples/LibVLCSharp.tvOS.Sample/ViewController.cs
@@ -15,7 +15,7 @@ namespace LibVLCSharp.tvOS.Sample
         {
             base.ViewDidLoad();
 
-            _libVLC = new LibVLC();
+            _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new Shared.MediaPlayer(_libVLC);
 
             _videoView = new VideoView { MediaPlayer = _mediaPlayer };

--- a/samples/Uno/LibVLCSharp.Uno.Sample.Shared/MainViewModel.cs
+++ b/samples/Uno/LibVLCSharp.Uno.Sample.Shared/MainViewModel.cs
@@ -59,7 +59,7 @@ namespace LibVLCSharp.Uno.Sample
 
         private void Initialize(string[] swapChainOptions)
         {
-            LibVLC = new LibVLC(swapChainOptions);
+            LibVLC = new LibVLC(enableDebugLogs: true, swapChainOptions);
             MediaPlayer = new Shared.MediaPlayer(LibVLC);
             MediaPlayer.Play(new Media(LibVLC,
                 new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")));

--- a/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Shared/MainViewModel.cs
+++ b/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Shared/MainViewModel.cs
@@ -82,7 +82,7 @@ namespace Sample.MediaPlayerElement
 
         private void Initialize(string[] swapChainOptions)
         {
-            LibVLC = new LibVLC(swapChainOptions);
+            LibVLC = new LibVLC(enableDebugLogs: true, swapChainOptions);
             MediaPlayer = new LibVLCSharp.Shared.MediaPlayer(LibVLC);
             MediaPlayer.Play(new Media(LibVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
                 FromType.FromLocation));

--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -232,12 +232,62 @@ namespace LibVLCSharp.Shared
         }
 
         /// <summary>
+        /// Create and initialize a libvlc instance.
+        /// This functions accept a list of &quot;command line&quot; arguments similar to the
+        /// main(). These arguments affect the LibVLC instance default configuration.
+        /// LibVLC may create threads. Therefore, any thread-unsafe process
+        /// initialization must be performed before calling libvlc_new(). In particular
+        /// and where applicable:
+        /// <para>- setlocale() and textdomain(),</para>
+        /// <para>- setenv(), unsetenv() and putenv(),</para>
+        /// <para>- with the X11 display system, XInitThreads()</para>
+        /// (see also libvlc_media_player_set_xwindow()) and
+        /// <para>- on Microsoft Windows, SetErrorMode().</para>
+        /// <para>- sigprocmask() shall never be invoked; pthread_sigmask() can be used.</para>
+        /// On POSIX systems, the SIGCHLD signalmust notbe ignored, i.e. the
+        /// signal handler must set to SIG_DFL or a function pointer, not SIG_IGN.
+        /// Also while LibVLC is active, the wait() function shall not be called, and
+        /// any call to waitpid() shall use a strictly positive value for the first
+        /// parameter (i.e. the PID). Failure to follow those rules may lead to a
+        /// deadlock or a busy loop.
+        /// Also on POSIX systems, it is recommended that the SIGPIPE signal be blocked,
+        /// even if it is not, in principles, necessary, e.g.:
+        /// On Microsoft Windows Vista/2008, the process error mode
+        /// SEM_FAILCRITICALERRORS flagmustbe set before using LibVLC.
+        /// On later versions, that is optional and unnecessary.
+        /// Also on Microsoft Windows (Vista and any later version), setting the default
+        /// DLL directories to SYSTEM32 exclusively is strongly recommended for
+        /// security reasons:
+        /// Arguments are meant to be passed from the command line to LibVLC, just like
+        /// VLC media player does. The list of valid arguments depends on the LibVLC
+        /// version, the operating system and platform, and set of available LibVLC
+        /// plugins. Invalid or unsupported arguments will cause the function to fail
+        /// (i.e. return NULL). Also, some arguments may alter the behaviour or
+        /// otherwise interfere with other LibVLC functions.
+        /// There is absolutely no warranty or promise of forward, backward and
+        /// cross-platform compatibility with regards to libvlc_new() arguments.
+        /// We recommend that you do not use them, other than when debugging.
+        /// </summary>
+        /// <param name="enableDebugLogs">enable verbose debug logs</param>
+        /// <param name="options">list of arguments (should be NULL)</param>
+        public LibVLC(bool enableDebugLogs, params string[] options)
+            : base(() => MarshalUtils.CreateWithOptions(PatchOptions(options, enableDebugLogs), Native.LibVLCNew), Native.LibVLCRelease)
+        {
+            _gcHandle = GCHandle.Alloc(this);
+        }
+
+        /// <summary>
         /// Make dirty hacks to include necessary defaults on some platforms.
         /// </summary>
         /// <param name="options">The options given by the user</param>
+        /// <param name="enableDebugLogs">enable debug logs</param>
         /// <returns>The patched options</returns>
-        static string[] PatchOptions(string[] options)
+        static string[] PatchOptions(string[] options, bool enableDebugLogs = false)
         {
+            if(enableDebugLogs)
+            {
+                options = options.Concat(new[] { "--verbose=2" }).ToArray();
+            }
 #if UWP
             return options.Concat(new[] {"--aout=winstore"}).ToArray();
 #elif ANDROID


### PR DESCRIPTION
### Description of Change ###

The goal is have it enabled by default (?).
So many times people are not aware of the --verbose option, because exposing only an array of strings
means you need to go check the vlc cli page for information.

Having an enum explicitly for this makes it discoverable from the VS intellisense. It may be good to have it enabled by default.

### Issues Resolved ### 

- None, but in most I have to point to docs on how to enable logging.

### API Changes ###

Added:
 - LibVLCLog enum. Probably to be enabled by default.

### Platforms Affected ### 

- Core (all platforms)