### PR TITLE
Add reference to Microsoft.CodeAnalysis.FxCopAnalyzers

### DIFF
--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -93,6 +93,12 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <ItemGroup Condition="'$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <Target Name="IncludeAWindow" Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)LibVLCSharp.Android.AWindow.dll" />


### PR DESCRIPTION
Just trying it.

Some errors we will ignore, like 
`EventManager.cs(10,34,10,40): error CA1060: Move pinvokes to native methods class`

but there are likely good ones. Full logs:

```
LibVLCSharp\src\LibVLCSharp\Shared\Core\Constants.cs(3,23,3,29): error CA1716: Rename namespace LibVLCSharp.Shared so that it no longer conflicts with the reserved language keyword 'Shared'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.
1>LibVLCSharp\src\LibVLCSharp\Shared\Dialog.cs(17,16,17,22): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Core\Core.cs(18,24,18,30): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Equalizer.cs(12,16,12,22): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Events\EventManager.cs(35,53,35,56): error CA1805: Member 'HandlerCount' is explicitly initialized to its default value
1>LibVLCSharp\src\LibVLCSharp\Shared\Events\EventManager.cs(10,34,10,40): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(450,38,450,50): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(466,43,466,55): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(482,31,482,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(477,18,477,44): error CA1001: Type 'MediaSubItemAddedEventArgs' owns disposable field(s) 'SubItem' but is not disposable
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(498,30,498,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(509,18,509,37): error CA1001: Type 'MediaFreedEventArgs' owns disposable field(s) 'Media' but is not disposable
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(514,31,514,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(530,34,530,39): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(541,18,541,48): error CA1001: Type 'MediaSubItemTreeAddedEventArgs' owns disposable field(s) 'SubItem' but is not disposable
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(546,31,546,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(561,18,561,50): error CA1001: Type 'MediaPlayerMediaChangedEventArgs' owns disposable field(s) 'Media' but is not disposable
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(566,31,566,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(582,31,582,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(598,30,598,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(614,31,614,39): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(646,29,646,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(630,29,630,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(662,29,662,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(678,29,678,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(710,30,710,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(726,29,726,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(694,32,694,40): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(758,29,758,31): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(763,35,763,39): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(742,29,742,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(785,35,785,39): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(780,29,780,31): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(802,29,802,31): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(807,35,807,39): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(824,32,824,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(840,31,840,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(860,31,860,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLCEvents.cs(865,29,865,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaDiscoverer.cs(15,25,15,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(515,29,515,35): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(570,29,570,35): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaInput.cs(54,36,54,43): error CA1805: Member 'disposedValue' is explicitly initialized to its default value
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(18,25,18,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaList.cs(17,25,17,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(30,43,30,49): error CA1805: Member '_aspectRatio' is explicitly initialized to its default value
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(7,28,7,42): error CA1815: VideoViewpoint should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(25,31,25,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(7,28,7,42): error CA1815: VideoViewpoint should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(30,31,30,35): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(35,31,35,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\VideoViewpoint.cs(20,31,20,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(907,17,907,32): error CA1714: Flags enums should have plural names
1>LibVLCSharp\src\LibVLCSharp\Shared\VLCException.cs(8,18,8,30): error CA1032: Add the following constructor to VLCException: public VLCException()
1>LibVLCSharp\src\LibVLCSharp\Shared\VLCException.cs(8,18,8,30): error CA2237: Add [Serializable] to VLCException as this type implements ISerializable
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(46,30,46,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(51,30,51,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(35,28,35,38): error CA1815: AudioTrack should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(35,28,35,38): error CA1815: AudioTrack should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaSlave.cs(21,28,21,38): error CA1815: MediaSlave should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaSlave.cs(21,28,21,38): error CA1815: MediaSlave should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaSlave.cs(33,32,33,35): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaSlave.cs(38,40,38,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaSlave.cs(43,30,43,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(63,30,63,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(68,30,68,35): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(58,28,58,38): error CA1815: VideoTrack should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(73,30,73,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(58,28,58,38): error CA1815: VideoTrack should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(78,30,78,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(9,28,9,38): error CA1815: MediaStats should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(9,28,9,38): error CA1815: MediaStats should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(14,29,14,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(83,30,83,42): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(19,31,19,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(88,30,88,42): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(24,29,24,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(93,42,93,53): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(29,31,29,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(98,41,98,51): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(34,29,34,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(103,40,103,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(39,29,39,47): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(44,29,44,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(49,29,49,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(54,29,54,46): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(59,29,59,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(64,29,64,47): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(69,29,69,45): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(74,29,74,40): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(79,29,79,38): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaStats.cs(84,31,84,42): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(109,28,109,41): error CA1815: SubtitleTrack should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(109,28,109,41): error CA1815: SubtitleTrack should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(118,33,118,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(124,28,124,38): error CA1815: MediaTrack should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(124,28,124,38): error CA1815: MediaTrack should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(143,30,143,35): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(148,30,148,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(153,29,153,31): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(158,35,158,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(163,29,163,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(168,29,168,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(173,40,173,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(178,30,178,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(183,33,183,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrack.cs(188,33,188,44): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrackData.cs(22,36,22,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrackData.cs(17,36,17,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrackData.cs(27,39,27,47): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrackData.cs(6,28,6,42): error CA1815: MediaTrackData should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaTrackData.cs(6,28,6,42): error CA1815: MediaTrackData should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\RendererDescription.cs(20,28,20,47): error CA1815: RendererDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\RendererDescription.cs(20,28,20,47): error CA1815: RendererDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatio.cs(1,30,1,48): error CA1716: Rename namespace LibVLCSharp.Shared.MediaPlayerElement so that it no longer conflicts with the reserved language keyword 'Shared'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1124,36,1124,57): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1175,35,1175,56): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1321,21,1321,35): error CA1044: Because property EnableKeyInput is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1333,21,1333,37): error CA1044: Because property EnableMouseInput is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1420,35,1420,49): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1444,35,1444,51): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1509,35,1509,56): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(14,25,14,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Helpers\MarshalUtils.cs(10,34,10,40): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Helpers\PlatformHelper.cs(9,18,9,32): error CA1052: Type 'PlatformHelper' is a static holder type but is neither static nor NotInheritable
1>LibVLCSharp\src\LibVLCSharp\Shared\Internal.cs(19,43,19,50): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Internal.cs(24,24,24,34): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(460,36,460,48): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(412,33,412,36): error CA1805: Member '_logSubscriberCount' is explicitly initialized to its default value
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(475,36,475,48): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(488,41,488,53): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(649,38,649,50): error CA1819: Properties should not return arrays
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(67,25,67,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\RendererDiscoverer.cs(17,25,17,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\RendererDiscoverer.cs(176,24,176,31): error CA1056: Change the type of property 'RendererItem.IconUri' from 'string' to 'System.Uri'
1>LibVLCSharp\src\LibVLCSharp\Shared\RendererDiscoverer.cs(130,25,130,31): error CA1060: Move pinvokes to native methods class
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDescription.cs(17,28,17,50): error CA1815: AudioOutputDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDescription.cs(33,32,33,36): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDescription.cs(17,28,17,50): error CA1815: AudioOutputDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDescription.cs(4,30,4,40): error CA1716: Rename namespace LibVLCSharp.Shared.Structures so that it no longer conflicts with the reserved language keyword 'Shared'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDescription.cs(38,32,38,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDevice.cs(17,28,17,45): error CA1815: AudioOutputDevice should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDevice.cs(33,32,33,48): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDevice.cs(17,28,17,45): error CA1815: AudioOutputDevice should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\AudioOutputDevice.cs(38,32,38,43): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ChapterDescription.cs(17,28,17,46): error CA1815: ChapterDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ChapterDescription.cs(17,28,17,46): error CA1815: ChapterDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(19,28,19,45): error CA1815: ModuleDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(19,28,19,45): error CA1815: ModuleDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(44,33,44,42): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(49,33,49,41): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(54,33,54,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\ModuleDescription.cs(39,33,39,37): error CA1051: Do not declare visible instance fields
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\TrackDescription.cs(18,28,18,44): error CA1815: TrackDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\TrackDescription.cs(18,28,18,44): error CA1815: TrackDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaDiscovererDescription.cs(22,28,22,54): error CA1815: MediaDiscovererDescription should override Equals
1>LibVLCSharp\src\LibVLCSharp\Shared\Structures\MediaDiscovererDescription.cs(22,28,22,54): error CA1815: MediaDiscovererDescription should override the equality (==) and inequality (!=) operators
1>LibVLCSharp\src\LibVLCSharp\Shared\StreamMediaInput.cs(42,17,42,22): error CA1031: Modify 'Open' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\StreamMediaInput.cs(55,13,55,18): error CA1031: Modify 'Open' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\StreamMediaInput.cs(80,13,80,18): error CA1031: Modify 'Read' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\StreamMediaInput.cs(98,13,98,18): error CA1031: Modify 'Seek' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\StreamMediaInput.cs(114,13,114,18): error CA1031: Modify 'Close' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\Core\Core.cs(25,14,25,64): error CA2101: Specify marshaling for P/Invoke string arguments
1>LibVLCSharp\src\LibVLCSharp\Shared\Core\Core.cs(28,14,28,67): error CA2101: Specify marshaling for P/Invoke string arguments
1>LibVLCSharp\src\LibVLCSharp\Shared\Core\Core.cs(39,38,39,118): error CA1305: The behavior of 'int.Parse(string)' could vary based on the current user's locale settings. Replace this call in 'Core.EnsureVersionsMatch()' with a call to 'int.Parse(string, IFormatProvider)'.
1>LibVLCSharp\src\LibVLCSharp\Shared\RendererDiscoverer.cs(14,22,14,29): error CA1823: Unused field 'Bonjour'
1>LibVLCSharp\src\LibVLCSharp\Shared\Equalizer.cs(129,24,129,34): error CA1822: Member 'PresetName' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Equalizer.cs(145,22,145,35): error CA1822: Member 'BandFrequency' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Equalizer.cs(136,21,136,30): error CA1822: Member 'BandCount' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Equalizer.cs(121,21,121,32): error CA1822: Member 'PresetCount' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Helpers\MarshalUtils.cs(132,21,132,75): error CA1806: LinuxX64LogCallback calls vsprintf_linux but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.
1>LibVLCSharp\src\LibVLCSharp\Shared\Internal.cs(35,29,35,35): error CA1062: In externally visible method 'Internal.Internal(Func<IntPtr> create, Action<IntPtr> release)', validate parameter 'create' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
1>LibVLCSharp\src\LibVLCSharp\Shared\Internal.cs(45,21,45,28): error CA1816: Change Internal.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.
1>LibVLCSharp\src\LibVLCSharp\Shared\Helpers\MarshalUtils.cs(25,14,25,151): error CA2101: Specify marshaling for P/Invoke string arguments
1>LibVLCSharp\src\LibVLCSharp\Shared\Helpers\MarshalUtils.cs(35,14,35,132): error CA2101: Specify marshaling for P/Invoke string arguments
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaInput.cs(75,21,75,28): error CA1816: Change MediaInput.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaConfiguration.cs(71,24,71,52): error CA1822: Member 'HardwareDecodingOptionString' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaConfiguration.cs(104,24,104,47): error CA1822: Member 'FileCachingOptionString' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaConfiguration.cs(109,24,109,50): error CA1822: Member 'NetworkCachingOptionString' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaList.cs(134,94,134,99): error CA1062: In externally visible method 'void MediaList.SetMedia(Media media)', validate parameter 'media' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(80,19,80,67): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(105,13,105,18): error CA1031: Modify 'GetVideoTrack' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AutoHideNotifier.cs(28,62,28,73): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AutoHideNotifier.cs(29,50,29,61): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(88,29,88,42): error CA1822: Member 'GetVideoTrack' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(117,30,117,44): error CA1822: Member 'GetAspectRatio' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AspectRatioManager.cs(111,22,111,36): error CA1822: Member 'IsVideoSwapped' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AutoHideNotifier.cs(80,19,80,59): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(972,112,972,121): error CA1062: In externally visible method 'bool MediaPlayer.SetEqualizer(Equalizer equalizer)', validate parameter 'equalizer' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\VolumeManager.cs(91,19,96,15): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\CastRenderersDiscoverer.cs(27,62,27,100): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\CastRenderersDiscoverer.cs(28,57,28,79): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\BufferingProgressNotifier.cs(65,19,65,81): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\VolumeManager.cs(106,19,106,65): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\DeviceAwakeningManager.cs(76,19,76,53): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\Events\EventManager.cs(121,33,121,49): error CA1822: Member 'OnEventUnhandled' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Events\EventManager.cs(119,40,119,53): error CA1822: Member 'RetrieveEvent' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(28,62,28,94): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\MediaPlayerElementManagerBase.cs(204,29,204,36): error CA1816: Change MediaPlayerElementManagerBase.Dispose() to call GC.SuppressFinalize(object). This will prevent unnecessary finalization of the object once it has been disposed and it has fallen out of scope.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(121,19,121,40): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(122,19,122,43): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TimeSpanExtensions.cs(19,24,19,55): error CA1305: The behavior of 'TimeSpan.ToString(string)' could vary based on the current user's locale settings. Replace this call in 'TimeSpan.ToShortString()' with a call to 'TimeSpan.ToString(string, IFormatProvider)'.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TimeSpanExtensions.cs(23,24,23,52): error CA1305: The behavior of 'TimeSpan.ToString(string)' could vary based on the current user's locale settings. Replace this call in 'TimeSpan.ToShortString()' with a call to 'TimeSpan.ToString(string, IFormatProvider)'.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TimeSpanExtensions.cs(25,20,25,44): error CA1305: The behavior of 'TimeSpan.ToString(string)' could vary based on the current user's locale settings. Replace this call in 'TimeSpan.ToShortString()' with a call to 'TimeSpan.ToString(string, IFormatProvider)'.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(132,19,132,43): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(127,19,127,40): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(138,23,138,70): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(140,19,140,66): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\SeekBarManager.cs(137,19,137,51): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(151,19,151,53): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(155,27,155,56): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(158,27,158,55): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(161,27,161,48): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(164,27,164,69): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(99,19,99,64): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(171,19,171,40): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(40,62,40,79): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(104,19,104,61): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(176,19,176,48): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(177,19,177,53): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(182,19,182,47): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(109,19,109,63): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(187,19,187,61): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(188,19,188,53): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(114,19,114,41): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\StateManager.cs(193,19,193,53): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(25,43,25,48): error CA1062: In externally visible method 'bool LibVLC.Equals(LibVLC other)', validate parameter 'other' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\TracksManager.cs(59,23,59,40): error CA1822: Member 'GetCurrentTrackId' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(546,73,546,76): error CA1054: Change the type of parameter 'uri' of method 'Media.AddSlave(MediaSlaveType, uint, string)' from 'string' to 'System.Uri', or provide an overload to 'Media.AddSlave(MediaSlaveType, uint, string)' that allows 'uri' to be passed as a 'System.Uri' object
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(579,23,579,39): error CA1822: Member 'CodecDescription' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\AutoHideNotifier.cs(114,19,114,30): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\CastRenderersDiscoverer.cs(125,19,125,57): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1164,20,1164,71): error CA1806: set_Volume calls LibVLCAudioSetVolume but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\CastRenderersDiscoverer.cs(131,19,131,57): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayerElement\CastRenderersDiscoverer.cs(103,23,103,61): error CA2007: Consider calling ConfigureAwait on the awaited task
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(701,21,701,37): error CA1822: Member 'ClearLibVLCError' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(742,13,742,18): error CA1031: Modify 'LogCallback' to catch a more specific allowed exception type, or rethrow the exception
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(403,16,403,29): error CA1822: Member 'NativeFilePtr' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(707,23,707,37): error CA1822: Member 'LibVLCCompiler' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(683,23,683,30): error CA1822: Member 'Version' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(686,23,686,32): error CA1822: Member 'Changeset' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\LibVLC.cs(694,24,694,39): error CA1822: Member 'LastLibVLCError' does not access instance data and can be marked as static
1>LibVLCSharp\src\LibVLCSharp\Shared\MediaPlayer.cs(1677,58,1677,61): error CA1054: Change the type of parameter 'uri' of method 'MediaPlayer.AddSlave(MediaSlaveType, string, bool)' from 'string' to 'System.Uri', or provide an overload to 'MediaPlayer.AddSlave(MediaSlaveType, string, bool)' that allows 'uri' to be passed as a 'System.Uri' object
1>LibVLCSharp\src\LibVLCSharp\Shared\Internal.cs(9,27,9,35): error CA1724: The type name Internal conflicts in whole or in part with the namespace name 'System.Deployment.Internal' defined in the .NET Framework. Rename the type to eliminate the conflict.
1>LibVLCSharp\src\LibVLCSharp\Shared\Media.cs(16,18,16,23): error CA1724: The type name Media conflicts in whole or in part with the namespace name 'System.Media' defined in the .NET Framework. Rename the type to eliminate the conflict.
```

https://code.videolan.org/videolan/LibVLCSharp/-/issues/129