### PR TITLE
Wpf eventhandler fixes

### DIFF
--- a/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -102,8 +102,13 @@ namespace LibVLCSharp.WPF
 
         void Wndhost_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
             var source = PresentationSource.FromVisual(_wndhost);
+            if (source == null)
+            {
+                return;
+            }
+
+            var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
             var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
             Left = targetPoints.X;
             Top = targetPoints.Y;

--- a/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -125,6 +125,10 @@ namespace LibVLCSharp.WPF
         void Wndhost_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             Close();
+
+            _bckgnd.DataContextChanged -= Background_DataContextChanged;
+            _bckgnd.Loaded -= Background_Loaded;
+            _bckgnd.Unloaded -= Background_Unloaded;
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -58,6 +58,11 @@ namespace LibVLCSharp.WPF
 
         void Background_Loaded(object sender, RoutedEventArgs e)
         {
+            if (_wndhost != null)
+            {
+                return;
+            }
+
             _wndhost = GetWindow(_bckgnd);
             Trace.Assert(_wndhost != null);
             if (_wndhost == null)

--- a/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.xaml.cs
@@ -84,10 +84,10 @@ namespace LibVLCSharp.WPF
                 Show();
                 _wndhost.Focus();
             }
-            catch
+            catch(Exception ex)
             {
                 Hide();
-                throw new VLCException("Unable to create WPF Window in VideoView.");
+                throw new VLCException("Unable to create WPF Window in VideoView.", ex);
             }
         }
 


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

1. The WPF window loaded event can fire multiple times, therefore a check has been added to ensure this is now only executed once as otherwise there is the risk of attempting to show a window more than once (which is illegal in WPF and throws an exception)
2. When the WPF window is closing, event handlers are now unsubscribed

### Issues Resolved ### 
Exceptions thrown by WPF when docking/undocking/showing/hiding a window.

### API Changes ###
None

### Platforms Affected ### 
WPF

### Behavioral/Visual Changes ###
No exceptions thrown when docking/undocking window.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
https://code.videolan.org/videolan/LibVLCSharp/-/issues/384

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
