### PR TITLE
Updated linux documentation

### DIFF
--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -1,25 +1,29 @@
-# Getting started on LibVLCSharp.Gtk for Linux
+# Getting started on LibVLCSharp for Linux
 
 [Back](home.md)
 
-_This procedure was tested on ubuntu 18.10. If you have another distribution, make sure that all requirements are available, and adapt the following commands_
+_This procedure was tested on ubuntu 20.10. If you have another distribution, make sure that all requirements are available, and adapt the following commands_
 
-1. Install **[Mono](https://www.mono-project.com/download/stable/#download-lin)**. Make sure you can invoke `msbuild`.
+1. Install the [.net core SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux)
 2. Install **libvlc**: 
 
 For ubuntu:
-> `apt-get install libvlc-dev`. 
+> `sudo apt install libvlc-dev`. 
 
 *`libvlc.so` and `libvlccore.so` will be located at `/usr/lib`.*
+Should you want to load the libvlc libraries from another location than `/usr/lib`, you'd need to set `LD_LIBRARY_PATH`.
 
 You may need:
-> `apt-get install vlc`
+> `sudo apt install vlc`
 
-Though note this might pull libvlc 2.x depending on the repository and distro you pull it from.
+## For [gtk-sharp](https://github.com/mono/gtk-sharp)
 
-3. Install **gtk-sharp** (or monodevelop which uses it)
+Install **gtk-sharp** (or monodevelop which uses it)
 
 For ubuntu:
-> `apt-get install gtk-sharp2`
+> `sudo apt install gtk-sharp2`
 
-Should you want to load the libvlc libraries from another location than `/usr/lib`, you'd need to set `LD_LIBRARY_PATH`.
+## For other platforms
+
+If your application doesn't find `libX11.so`, you may need to install the `libx11-dev` package :
+> `sudo apt install libx11-dev`


### PR DESCRIPTION
### Description of Change ###

The documentation was referring to ubuntu 18.10. Things have changed since then and mono/msbuild is not needed anymore (`dotnet build` works fine)

### Issues Resolved ### 

None

### API Changes ###

Not applicable

### Platforms Affected ### 

Not applicable

### Behavioral/Visual Changes ###

Not applicable

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Tried to install the Avalonia project on linux, had issues with missing `libX11.so`. Installing gtk-sharp installs a `/lib/libX11.so`, but we don't need such a heavy thing, and `libx11-dev` is enough to make it work.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
