### PR TITLE
CD: Fix continuous delivery script for existing pre-release nugets

### DIFF
--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -4,6 +4,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
+var version = Argument("VersionSuffix", suffixVersion);
 var solutionName = "LibVLCSharp";
 var solutionFile = IsRunningOnWindows() ? $"{solutionName}.sln" : $"{solutionName}.Mac.sln";
 var solutionPath = $"../src/{solutionFile}";
@@ -16,7 +17,6 @@ var suffixVersion = $"alpha-{DateTime.Today.ToString("yyyyMMdd")}-{BuildSystem.A
 var feedzLVSSource = "https://f.feedz.io/videolan/preview/nuget/index.json";
 var FEEDZ = "FEEDZ";
 const uint totalPackageCount = 9;
-var buildProp = new FilePath("../src/Directory.build.props");
 
 //////////////////////////////////////////////////////////////////////
 // PREPARATION
@@ -98,12 +98,16 @@ Task("CIDeploy")
 
 void Build(string project)
 {
+    var settings = new MSBuildSettings();
+    settings.SetConfiguration(configuration)
+            .WithProperty("PackageOutputPath", MakeAbsolute(artifactsDir).FullPath);
+
     if(isCiBuild)
     {
-        XmlPoke(buildProp, "//Project/PropertyGroup/VersionSuffix", suffixVersion);
+        settings.WithProperty("VersionSuffix", suffixVersion);
     }
 
-    MSBuild(project, settings => settings.SetConfiguration(configuration).WithProperty("PackageOutputPath", MakeAbsolute(artifactsDir).FullPath));
+    MSBuild(project, settings);
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The CD modifies version suffixes, override if there is an existing one,
So that CD works even for current pre-release packages.