### PR TITLE
Media: Internally keep a reference to the last set Media

### DIFF
--- a/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
+++ b/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
@@ -93,7 +93,8 @@ namespace LibVLCSharp.Tests
             List<string> notImplementedOnPurpose = new List<string>
             {
                 "libvlc_printerr", "libvlc_vprinterr", "libvlc_clock", "libvlc_dialog_get_context", "libvlc_dialog_set_context",
-                "libvlc_event_type_name", "libvlc_log_get_object", "libvlc_vlm", "libvlc_media_list_player", "libvlc_media_library"
+                "libvlc_event_type_name", "libvlc_log_get_object", "libvlc_vlm", "libvlc_media_list_player", "libvlc_media_library",
+                "libvlc_media_player_get_media"
             };
 
             List<string> exclude = new List<string>();

--- a/src/LibVLCSharp.Tests/MediaPlayerTests.cs
+++ b/src/LibVLCSharp.Tests/MediaPlayerTests.cs
@@ -208,5 +208,18 @@ namespace LibVLCSharp.Tests
             Assert.True(mp.SetRole(MediaPlayerRole.None));
             Assert.AreEqual(MediaPlayerRole.None, mp.Role);
         }
+
+        [Test]
+        public void MediaRefCountTestFail()
+        {
+            var media1 = new Media(_libVLC, new Uri(RealStreamMediaPath));
+            var media2 = new Media(_libVLC, new Uri(RealStreamMediaPath));
+
+            var mp = new MediaPlayer(media1);
+            media1.Dispose();
+            Debug.WriteLine(mp.Media.Mrl);
+
+            mp.Media = media2;
+        }
     }
 }

--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -436,7 +436,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>Get duration (in ms) of media descriptor object item.</summary>
         /// <returns>duration of media item or -1 on error</returns>
-        public long Duration => NativeReference == IntPtr.Zero ? -1 : Native.LibVLCMediaGetDuration(NativeReference);
+        public long Duration => Native.LibVLCMediaGetDuration(NativeReference);
 
         /// <summary>
         /// Parse the media asynchronously with options.      
@@ -486,7 +486,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>Return true is the media descriptor object is parsed</summary>
         /// <returns>true if media object has been parsed otherwise it returns false</returns>
-        public bool IsParsed => NativeReference == IntPtr.Zero ? false : Native.LibVLCMediaIsParsed(NativeReference) != 0;
+        public bool IsParsed => Native.LibVLCMediaIsParsed(NativeReference) != 0;
 
         /// <summary>Get Parsed status for media descriptor object.</summary>
         /// <returns>a value of the libvlc_media_parsed_status_t enum</returns>

--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -436,7 +436,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>Get duration (in ms) of media descriptor object item.</summary>
         /// <returns>duration of media item or -1 on error</returns>
-        public long Duration => Native.LibVLCMediaGetDuration(NativeReference);
+        public long Duration => NativeReference == IntPtr.Zero ? -1 : Native.LibVLCMediaGetDuration(NativeReference);
 
         /// <summary>
         /// Parse the media asynchronously with options.      
@@ -486,7 +486,7 @@ namespace LibVLCSharp.Shared
 
         /// <summary>Return true is the media descriptor object is parsed</summary>
         /// <returns>true if media object has been parsed otherwise it returns false</returns>
-        public bool IsParsed => Native.LibVLCMediaIsParsed(NativeReference) != 0;
+        public bool IsParsed => NativeReference == IntPtr.Zero ? false : Native.LibVLCMediaIsParsed(NativeReference) != 0;
 
         /// <summary>Get Parsed status for media descriptor object.</summary>
         /// <returns>a value of the libvlc_media_parsed_status_t enum</returns>

--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -663,11 +663,9 @@ namespace LibVLCSharp.Shared
         /// <returns>true if successful</returns>
         public bool Play()
         {
-            var media = Media;
-            if(media != null)
+            if(_media != null)
             {
-                media.AddOption(Configuration);
-                media.Dispose();
+                _media.AddOption(Configuration);
             }
             return Native.LibVLCMediaPlayerPlay(NativeReference) == 0;
         }

--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -631,20 +631,23 @@ namespace LibVLCSharp.Shared
         /// </summary>
         public Media? Media
         {
-            get
-            {
-                return _media;
-            }
+            get => _media;
             set
             {
-                if(_media?.NativeReference != IntPtr.Zero)
+                if(_media != null)
                 {
-                    _media?.Dispose();
+                    _media.Dispose();
                     _media = null;
                 }
 
                 _media = value;
-                Native.LibVLCMediaPlayerSetMedia(NativeReference, value?.NativeReference ?? IntPtr.Zero);
+                
+                if(_media != null)
+                {
+                    _media.Retain();
+                }
+
+                Native.LibVLCMediaPlayerSetMedia(NativeReference, _media?.NativeReference ?? IntPtr.Zero);
             }
         }
 

--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -2416,7 +2416,8 @@ namespace LibVLCSharp.Shared
             {
                 if (_gcHandle.IsAllocated)
                     _gcHandle.Free();
-                if (_media?.NativeReference != IntPtr.Zero)
+
+                if (_media != null)
                 {
                     _media?.Dispose();
                     _media = null;


### PR DESCRIPTION
### Description of Change ###

libvlc_media_player_get_media increments the ref count of the media, which may easily
cause a memory leak, as this is very unusual behavior for C# property getter to
have these types of consequences. Users don't have the reflex to dispose every Media returned
by the getter property.

Holding a ref internally in the mediaplayer prevents from incrementing the native ref count
of the media object.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/442

### API Changes ###
 
 None, but the usage is subtly changed. Docs should probably mentioned it somewhere.

### Platforms Affected ### 

- Core (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I have not tested this thoroughly.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
