### PR TITLE
Avalonia: Bump version reference

### DIFF
--- a/src/LibVLCSharp.Avalonia/LibVLCSharp.Avalonia.csproj
+++ b/src/LibVLCSharp.Avalonia/LibVLCSharp.Avalonia.csproj
@@ -18,7 +18,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <PackageTags>$(PackageTags);avalonia</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0" />
+    <PackageReference Include="Avalonia" Version="0.10.2" />
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
The new Avalonia version includes a fix for https://code.videolan.org/videolan/LibVLCSharp/-/issues/458