### PR TITLE
XF: Add Lockscreen feature  - Fixes #180

### DIFF
--- a/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
+++ b/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
@@ -1,7 +1,9 @@
 ﻿using Foundation;
+using LibVLCSharp.Forms.Platforms.iOS;
 using LibVLCSharp.Forms.Sample.MediaPlayerElement;
 using LibVLCSharp.Forms.Shared;
 using UIKit;
+using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
 {
@@ -11,6 +13,7 @@ namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
     [Register("AppDelegate")]
     public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
     {
+        private static UIInterfaceOrientationMask orientationMode;
         //
         // This method is invoked when the application has loaded and is ready to run. In this 
         // method you should instantiate the window, load the UI into it and then make the window
@@ -25,6 +28,27 @@ namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
             LoadApplication(new App());
 
             return base.FinishedLaunching(app, options);
+        }
+
+        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, [Transient] UIWindow forWindow)
+        {
+            MessagingCenter.Subscribe<OrientationHandler>(this, "Landscape", o =>
+            {
+                orientationMode = UIInterfaceOrientationMask.Landscape;
+
+            });
+            MessagingCenter.Subscribe<OrientationHandler>(this, "Portrait", o =>
+            {
+                orientationMode = UIInterfaceOrientationMask.Portrait;
+
+            });
+            MessagingCenter.Subscribe<OrientationHandler>(this, "All", o =>
+            {
+                orientationMode = UIInterfaceOrientationMask.All;
+
+            });
+
+            return orientationMode;
         }
     }
 }

--- a/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
+++ b/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
@@ -2,6 +2,7 @@
 using LibVLCSharp.Forms.Platforms.iOS;
 using LibVLCSharp.Forms.Sample.MediaPlayerElement;
 using LibVLCSharp.Forms.Shared;
+using ObjCRuntime;
 using UIKit;
 using Xamarin.Forms;
 

--- a/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
+++ b/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement.iOS/AppDelegate.cs
@@ -4,7 +4,6 @@ using LibVLCSharp.Forms.Sample.MediaPlayerElement;
 using LibVLCSharp.Forms.Shared;
 using ObjCRuntime;
 using UIKit;
-using Xamarin.Forms;
 
 namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
 {
@@ -14,7 +13,7 @@ namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
     [Register("AppDelegate")]
     public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
     {
-        private static UIInterfaceOrientationMask orientationMode;
+        // private static UIInterfaceOrientationMask orientationMode;
         //
         // This method is invoked when the application has loaded and is ready to run. In this 
         // method you should instantiate the window, load the UI into it and then make the window
@@ -33,23 +32,7 @@ namespace LibVLCSharp.Forms.Sample.MediaElement.iOS
 
         public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, [Transient] UIWindow forWindow)
         {
-            MessagingCenter.Subscribe<OrientationHandler>(this, "Landscape", o =>
-            {
-                orientationMode = UIInterfaceOrientationMask.Landscape;
-
-            });
-            MessagingCenter.Subscribe<OrientationHandler>(this, "Portrait", o =>
-            {
-                orientationMode = UIInterfaceOrientationMask.Portrait;
-
-            });
-            MessagingCenter.Subscribe<OrientationHandler>(this, "All", o =>
-            {
-                orientationMode = UIInterfaceOrientationMask.All;
-
-            });
-
-            return orientationMode;
+            return OrientationChangeSuscriber.Suscribe(this);
         }
     }
 }

--- a/src/LibVLCSharp.Forms/Platforms/Android/OrientationHandler.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Android/OrientationHandler.cs
@@ -1,0 +1,48 @@
+﻿using Android.Content.PM;
+using LibVLCSharp.Forms.Platforms.Android;
+using LibVLCSharp.Forms.Shared;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(OrientationHandler))]
+namespace LibVLCSharp.Forms.Platforms.Android
+{
+ 
+    /// <summary>
+    /// Force orientation of Android device.
+    /// </summary>
+    public class OrientationHandler : IOrientationHandler
+    {
+        /// <summary>
+        /// Force Landscape mode.
+        /// </summary>
+        public void ForceLandscape()
+        {
+            var activity = Platform.Activity;
+            if (activity == null)
+                return;
+            activity.RequestedOrientation = ScreenOrientation.Landscape;
+        }
+
+        /// <summary>
+        /// Force Portrait mode.
+        /// </summary>
+        public void ForcePortrait()
+        {
+            var activity = Platform.Activity;
+            if (activity == null)
+                return;
+            activity.RequestedOrientation = ScreenOrientation.Portrait;
+        }
+
+        /// <summary>
+        /// Restore Landscape and Portrait orientation mode.
+        /// </summary>
+        public void ResetOrientation()
+        {
+            var activity = Platform.Activity;
+            if (activity == null)
+                return;
+            activity.RequestedOrientation = ScreenOrientation.User;
+        }
+    }
+}

--- a/src/LibVLCSharp.Forms/Platforms/Apple/OrientationChangeSuscriber.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Apple/OrientationChangeSuscriber.cs
@@ -1,0 +1,41 @@
+﻿#if IOS
+using UIKit;
+using Xamarin.Forms;
+
+namespace LibVLCSharp.Forms.Platforms.iOS
+{
+    /// <summary>
+    /// Suscribes AppDelegate.cs to orientation change event.
+    /// </summary>
+    public static class OrientationChangeSuscriber
+    {
+        private static UIInterfaceOrientationMask OrientationMode;
+
+        /// <summary>
+        /// Susbscriber.
+        /// </summary>
+        /// <param name="application">UIApplication from GetSupportedInterfaceOrientations method.</param>
+        /// <returns>the desired orientation to lock</returns>
+        public static UIInterfaceOrientationMask Suscribe(object application)
+        {
+            MessagingCenter.Subscribe<OrientationHandler>(application, "Landscape", o =>
+            {
+                OrientationMode = UIInterfaceOrientationMask.Landscape;
+
+            });
+            MessagingCenter.Subscribe<OrientationHandler>(application, "Portrait", o =>
+            {
+                OrientationMode = UIInterfaceOrientationMask.Portrait;
+
+            });
+            MessagingCenter.Subscribe<OrientationHandler>(application, "All", o =>
+            {
+                OrientationMode = UIInterfaceOrientationMask.All;
+
+            });
+
+            return OrientationMode;
+        }
+    }
+}
+#endif

--- a/src/LibVLCSharp.Forms/Platforms/Apple/OrientationHandler.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Apple/OrientationHandler.cs
@@ -1,0 +1,42 @@
+﻿#if IOS
+using Foundation;
+using LibVLCSharp.Forms.Platforms.iOS;
+using LibVLCSharp.Forms.Shared;
+using UIKit;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(OrientationHandler))]
+namespace LibVLCSharp.Forms.Platforms.iOS
+{
+    /// <summary>
+    /// Force orientation of iOS device.
+    /// In iOs client project, Developer should subscribe the AppDelegate.cs class to
+    /// all MessagingCenter below.
+    /// Refer to the sample LibVLCSharp.Forms.Sample.MediaElement for to see how to do it.
+    /// </summary>
+    public class OrientationHandler : IOrientationHandler
+    {
+        /// <summary>
+        /// Force Landscape mode.
+        /// </summary>
+        public void ForceLandscape()
+        {
+            MessagingCenter.Send(this, "Landscape");
+            UIDevice.CurrentDevice.SetValueForKey(new NSNumber((int)UIInterfaceOrientation.LandscapeLeft), new NSString("orientation"));
+        }
+        /// <summary>
+        /// Force Portrait mode.
+        /// </summary>
+        public void ForcePortrait()
+        {
+            MessagingCenter.Send(this, "Portrait");
+            UIDevice.CurrentDevice.SetValueForKey(new NSNumber((int)UIInterfaceOrientation.Portrait), new NSString("orientation"));
+        }
+
+        /// <summary>
+        /// Restore Landscape and Portrait orientation mode.
+        /// </summary>
+        public void ResetOrientation() => MessagingCenter.Send(this, "All");
+    }
+}
+#endif

--- a/src/LibVLCSharp.Forms/README.md
+++ b/src/LibVLCSharp.Forms/README.md
@@ -22,6 +22,38 @@ This package has multiple target frameworks, which means it will pick the right 
 
 This package includes a Xamarin.Forms MediaPlayerElement component. It currently supports iOS and Android only.
 
+Note: In your iOS project, you must override the `GetSupportedInterfaceOrientations` method in `AppDelegate.cs` to enable the lock screen feature.
+
+```c#
+using Foundation;
+using LibVLCSharp.Forms.Platforms.iOS;
+using LibVLCSharp.Forms.Shared;
+using ObjCRuntime;
+using UIKit;
+// ...
+
+namespace MyAppNameSpace.iOS
+{
+    
+    [Register("AppDelegate")]
+    public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
+    {
+       
+        public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+        {
+            LibVLCSharpFormsRenderer.Init();
+            // ...
+        }
+
+        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, [Transient] UIWindow forWindow)
+        {
+            return OrientationChangeSuscriber.Suscribe(this);
+        }
+    }
+}
+
+```
+
 See the [sample](../../samples/Forms/LibVLCSharp.Forms.MediaElement) for more info.
 
 ## Why should I reference this package in my project?

--- a/src/LibVLCSharp.Forms/Shared/IOrientationHandler.cs
+++ b/src/LibVLCSharp.Forms/Shared/IOrientationHandler.cs
@@ -1,0 +1,23 @@
+﻿namespace LibVLCSharp.Forms.Shared
+{
+    /// <summary>
+    /// Force Device Orientation.
+    /// </summary>
+    public interface IOrientationHandler
+    {
+        /// <summary>
+        /// Force Landscape orientation mode.
+        /// </summary>
+        void ForceLandscape();
+
+        /// <summary>
+        /// Force Portrait orientation mode.
+        /// </summary>
+        void ForcePortrait();
+
+        /// <summary>
+        /// Restore Landscape and Portrait orientation mode.
+        /// </summary>
+        void ResetOrientation();
+    }
+}

--- a/src/LibVLCSharp.Forms/Shared/MediaPlayerElement.xaml.cs
+++ b/src/LibVLCSharp.Forms/Shared/MediaPlayerElement.xaml.cs
@@ -237,12 +237,37 @@ namespace LibVLCSharp.Forms.Shared
             {
                 MessagingCenter.Unsubscribe<LifecycleMessage>(this, "OnSleep");
                 MessagingCenter.Unsubscribe<LifecycleMessage>(this, "OnResume");
+                MessagingCenter.Unsubscribe<PlaybackControls>(this, "ChangeOrientation");
             }
         }
 
         private void GestureRecognized(object sender, EventArgs e)
         {
             PlaybackControls.Show();
+        }
+
+        /// <summary>
+        /// On size allocated , sucbribes the page to the lock screen message wich will be sent by PlaybackControls.cs.
+        /// </summary>
+        /// <param name="width">Screen's with</param>
+        /// <param name="height">Screen's height</param>
+        protected override void OnSizeAllocated(double width, double height)
+        {
+            base.OnSizeAllocated(width, height);
+            MessagingCenter.Subscribe<PlaybackControls>(this, "ChangeOrientation", o =>
+            {
+                var OrientationHandler = DependencyService.Get<IOrientationHandler>();
+
+                if (OrientationHandler != null)
+                {
+                    // Portrait Mode
+                    if (Width < Height)
+                        OrientationHandler.ForcePortrait();
+                    else
+                        OrientationHandler.ForceLandscape();
+                }
+
+            });
         }
     }
 }

--- a/src/LibVLCSharp.Forms/Shared/Resources/Strings.Designer.cs
+++ b/src/LibVLCSharp.Forms/Shared/Resources/Strings.Designer.cs
@@ -185,5 +185,14 @@ namespace LibVLCSharp.Forms.Shared.Resources {
                 return ResourceManager.GetString("Track", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SWIPE TO UNLOCK.
+        /// </summary>
+        internal static string Unlock {
+            get {
+                return ResourceManager.GetString("Unlock", resourceCulture);
+            }
+        }
     }
 }

--- a/src/LibVLCSharp.Forms/Shared/Resources/Strings.fr.resx
+++ b/src/LibVLCSharp.Forms/Shared/Resources/Strings.fr.resx
@@ -138,4 +138,7 @@
   <data name="Track" xml:space="preserve">
     <value>Piste {0}</value>
   </data>
+  <data name="Unlock" xml:space="preserve">
+    <value>DÉVERROUILLER</value>
+  </data>
 </root>

--- a/src/LibVLCSharp.Forms/Shared/Resources/Strings.resx
+++ b/src/LibVLCSharp.Forms/Shared/Resources/Strings.resx
@@ -159,4 +159,7 @@
   <data name="Track" xml:space="preserve">
     <value>Track {0}</value>
   </data>
+  <data name="Unlock" xml:space="preserve">
+    <value>SWIPE TO UNLOCK</value>
+  </data>
 </root>

--- a/src/LibVLCSharp.Forms/Shared/SwipeToUnLockView.cs
+++ b/src/LibVLCSharp.Forms/Shared/SwipeToUnLockView.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+
+namespace LibVLCSharp.Forms.Shared
+{
+    /// <summary>
+    /// Custom view that allows user to unlock the MediaPlayerElement View.
+    /// </summary>
+    public class SwipeToUnLockView : AbsoluteLayout
+    {
+        /// <summary>
+        /// Defines the ThumbProperty.
+        /// </summary>
+        public static readonly BindableProperty ThumbProperty =
+            BindableProperty.Create(
+                "Thumb", typeof(View), typeof(SwipeToUnLockView),
+                defaultValue: default(View));
+
+        /// <summary>
+        /// Gets or sets the Thumb.
+        /// </summary>
+        public View Thumb
+        {
+            get { return (View)GetValue(ThumbProperty); }
+            set { SetValue(ThumbProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the TrackBar Property.
+        /// </summary>
+        public static readonly BindableProperty TrackBarProperty =
+            BindableProperty.Create(
+                "TrackBar", typeof(View), typeof(SwipeToUnLockView),
+                defaultValue: default(View));
+
+        /// <summary>
+        /// Gets or sets the TrackBar.
+        /// </summary>
+        public View TrackBar
+        {
+            get { return (View)GetValue(TrackBarProperty); }
+            set { SetValue(TrackBarProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the FillBar Property.
+        /// </summary>
+        public static readonly BindableProperty FillBarProperty =
+            BindableProperty.Create(
+                "FillBar", typeof(View), typeof(SwipeToUnLockView),
+                defaultValue: default(View));
+
+        /// <summary>
+        /// Gets or sets the FillBar.
+        /// </summary>
+        public View FillBar
+        {
+            get { return (View)GetValue(FillBarProperty); }
+            set { SetValue(FillBarProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the PanGesture.
+        /// </summary>
+        private PanGestureRecognizer _panGesture = new PanGestureRecognizer();
+
+        /// <summary>
+        /// Defines the Gesture Listener.
+        /// </summary>
+        private View _gestureListener;
+
+        /// <summary>
+        /// Defaut Constructor.
+        /// </summary>
+        public SwipeToUnLockView()
+        {
+            _panGesture.PanUpdated += OnPanGestureUpdated;
+            SizeChanged += OnSizeChanged;
+
+            _gestureListener = new ContentView { BackgroundColor = Color.White, Opacity = 0.05 };
+            _gestureListener.GestureRecognizers.Add(_panGesture);
+        }
+
+        /// <summary>
+        /// The event wich will trigger when the view is completely swiped.
+        /// </summary>
+        public event EventHandler? SlideCompleted = null;
+
+        /// <summary>
+        /// Defines the FadeEffect default value.
+        /// </summary>
+        private const double FadeEffect = 0.5;
+
+        /// <summary>
+        /// Defines the Animation Length.
+        /// </summary>
+        private const uint AnimLength = 50;
+
+        internal async void OnPanGestureUpdated(object sender, PanUpdatedEventArgs e)
+        {
+            if (Thumb == null || TrackBar == null || FillBar == null)
+                return;
+
+            switch (e.StatusType)
+            {
+                case GestureStatus.Started:
+                    await TrackBar.FadeTo(FadeEffect, AnimLength);
+                    break;
+
+                case GestureStatus.Running:
+                    // Translate and ensure we don't pan beyond the wrapped user interface element bounds.
+                    var x = Math.Max(0, e.TotalX);
+                    if (x > (Width - Thumb.Width))
+                        x = (Width - Thumb.Width);
+
+                    // Uncomment this if you want only forward dragging.
+                    // if (e.TotalX < Thumb.TranslationX)
+                    //    return;
+                    Thumb.TranslationX = x;
+                    SetLayoutBounds(FillBar, new Rectangle(0, 0, x + Thumb.Width / 2, Height));
+                    break;
+
+                case GestureStatus.Completed:
+                    var posX = Thumb.TranslationX;
+                    SetLayoutBounds(FillBar, new Rectangle(0, 0, 0, Height));
+
+                    // Reset translation applied during the pan
+                    await Task.WhenAll(new Task[]
+                    {
+                        TrackBar.FadeTo(1, AnimLength),
+                        Thumb.TranslateTo(0, 0, AnimLength * 2, Easing.CubicIn),
+                    });
+
+                    if (posX >= (Width - Thumb.Width - 10 /* keep some margin for error*/))
+                        SlideCompleted?.Invoke(this, EventArgs.Empty);
+                    break;
+            }
+        }
+
+        internal void OnSizeChanged(object sender, EventArgs e)
+        {
+            if (Width == 0 || Height == 0)
+                return;
+            if (Thumb == null || TrackBar == null || FillBar == null)
+                return;
+
+            Children.Clear();
+
+            SetLayoutFlags(TrackBar, AbsoluteLayoutFlags.SizeProportional);
+            SetLayoutBounds(TrackBar, new Rectangle(0, 0, 1, 1));
+            Children.Add(TrackBar);
+
+            SetLayoutFlags(FillBar, AbsoluteLayoutFlags.None);
+            SetLayoutBounds(FillBar, new Rectangle(0, 0, 0, Height));
+            Children.Add(FillBar);
+
+            SetLayoutFlags(Thumb, AbsoluteLayoutFlags.None);
+            SetLayoutBounds(Thumb, new Rectangle(0, 0, Width / 5, Height));
+            Children.Add(Thumb);
+
+            SetLayoutFlags(_gestureListener, AbsoluteLayoutFlags.SizeProportional);
+            SetLayoutBounds(_gestureListener, new Rectangle(0, 0, 1, 1));
+            Children.Add(_gestureListener);
+        }
+    }
+}

--- a/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
+++ b/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
@@ -4,6 +4,7 @@
                     xmlns:converters="clr-namespace:LibVLCSharp.Forms.Shared.Converters"
                     xmlns:effects="clr-namespace:LibVLCSharp.Forms.Shared.Effects"
                     xmlns:fontawesome="clr-namespace:FontAwesome;assembly=LibVLCSharp"
+                    xmlns:local="clr-namespace:LibVLCSharp.Forms.Shared"
                     x:Class="LibVLCSharp.Forms.Shared.Themes.Generic">
     <converters:BufferingProgressToBoolConverter x:Key="BufferingProgressToBoolConverter" />
     <converters:ObjectToBoolConverter x:Key="ObjectToBoolConverter" />
@@ -56,6 +57,13 @@
     <Style x:Key="ControlsPanelStyle" TargetType="Layout">
         <Setter Property="BackgroundColor" Value="#30000000" />
         <Setter Property="Padding" Value="2,0,2,2" />
+    </Style>
+
+    <Style x:Key="UnLockControlsPanelStyle" TargetType="Layout">
+        <Setter Property="Margin" Value="0, 0, 0, 10" />
+        <Setter Property="WidthRequest" Value="300" />
+        <Setter Property="HorizontalOptions" Value="Center" />
+        <Setter Property="BackgroundColor" Value="Transparent"></Setter>
     </Style>
 
     <Style x:Key="SeekBarStyle" TargetType="Slider">
@@ -209,6 +217,14 @@
         <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.Stop}" />
     </Style>
 
+    <Style x:Key="LockButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
+        <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.UnlockAlt}" />
+    </Style>
+    
+    <Style x:Key="UnLockButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
+        <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.Lock}" />
+    </Style>
+
     <Style x:Key="AspectRatioButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
         <Setter Property="IsVisible" Value="{TemplateBinding IsAspectRatioButtonVisible}" />
         <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.ExpandArrowsAlt}" />
@@ -233,7 +249,8 @@
                     <ProgressBar Style="{TemplateBinding BufferingProgressBarStyle}" Progress="{TemplateBinding BufferingProgress}" 
                              IsVisible="{TemplateBinding BufferingProgress, Converter={StaticResource BufferingProgressToBoolConverter}}" />
                     <Label x:Name="AspectRatioLabel" Style="{TemplateBinding MessageStyle}"/>
-                    
+
+                    <!-- ControlsPanel -->
                     <StackLayout x:Name="ControlsPanel" Style="{TemplateBinding ControlsPanelStyle}">
                         <StackLayout Orientation="Horizontal" >
                             <StackLayout Orientation="Horizontal" HorizontalOptions="Start">
@@ -246,10 +263,11 @@
                         <StackLayout Orientation="Horizontal" IsVisible="{TemplateBinding IsSeekBarVisible}" Spacing="0">
                             <Slider x:Name="SeekBar" Style="{TemplateBinding SeekBarStyle}" />
                         </StackLayout>
-                        <StackLayout Orientation="Horizontal" Style="{TemplateBinding ButtonBarStyle}">
+                        <StackLayout x:Name="ButtonBar" Orientation="Horizontal" Style="{TemplateBinding ButtonBarStyle}">
                             <StackLayout Orientation="Horizontal" HorizontalOptions="Start" VerticalOptions="Center">
                                 <Button x:Name="AudioTracksSelectionButton" Style="{TemplateBinding AudioTracksSelectionButtonStyle}" />
                                 <Button x:Name="ClosedCaptionsSelectionButton" Style="{TemplateBinding ClosedCaptionsSelectionButtonStyle}" />
+                                <Button x:Name="LockButton" Style="{StaticResource LockButtonStyle}" />
                             </StackLayout>
                             <ContentPresenter Content="{TemplateBinding ButtonBarStartArea}" HorizontalOptions="Start" VerticalOptions="Center" />
                             <StackLayout Orientation="Horizontal" HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
@@ -265,6 +283,26 @@
                             </StackLayout>
                         </StackLayout>
                     </StackLayout>
+
+                    <!--  Unlock Control View  -->
+                    <StackLayout x:Name="UnLockControlsPanel" Style="{TemplateBinding UnLockControlsPanelStyle}" IsVisible="False">
+                        <local:SwipeToUnLockView x:Name="SwipeToUnLock" HeightRequest="60" VerticalOptions="Center">
+                            <local:SwipeToUnLockView.Thumb>
+                                <Button IsVisible="True" Style="{StaticResource UnLockButtonStyle}" />
+                            </local:SwipeToUnLockView.Thumb>
+
+                            <local:SwipeToUnLockView.TrackBar>
+                                <Frame Padding="0" BackgroundColor="#1C1C1C" CornerRadius="30" HasShadow="false">
+                                    <Label HorizontalOptions="CenterAndExpand" x:Name="TrackBarLabel" TextColor="White" VerticalOptions="CenterAndExpand" />
+                                </Frame>
+                            </local:SwipeToUnLockView.TrackBar>
+
+                            <local:SwipeToUnLockView.FillBar>
+                                <Frame Padding="0" BackgroundColor="#1C1C1C" CornerRadius="20" HasShadow="false" />
+                            </local:SwipeToUnLockView.FillBar>
+                        </local:SwipeToUnLockView>
+                    </StackLayout>
+                    
                 </StackLayout>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###
Added Lockscreen feature to the LibVLCSharp.Forms project. When user clicks on the lock button, PlayBack Controls are hidden, SeekBar is in read-only mode and the device's orientation is locked. 
<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/180

### API Changes ###

Added:
 - SwipeToUnLockView : a custom view to unlock screen
 - IOrientationHandler, OrientationHandler : Dependency to lock or unlock device's orientation.

Updated:
 - MediaPlayerElement.xaml.cs
 - Generic.xaml, Generic.xaml.cs
 - MediaPlayerElement.xaml.cs
 - Strings.resx

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- iOS
- Android


### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:

Andoid          |  iOS
:-------------------------:|:-------------------------:
<img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/before/MainView-Android.png" width="200" height="400" /> |  <img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/before/MinView-iOS.png" width="200" height="400" />

Before:
Andoid          |  iOS
:-------------------------:|:-------------------------:
<img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/after/mainView2-Android.png" width="200" height="400" /> |  <img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/after/mainView-iOS.png" width="200" height="400" />
<img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/after/LockSceenView-Android.png" width="200" height="400" /> |  <img src="https://raw.githubusercontent.com/egbakou/libvlcsharp-assets/master/lockscreen-feature/after/LockSceenView-iOS.png" width="200" height="400" />

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
On iOS, you have to override the GetSupportedInterfaceOrientations method in AppDelegate.cs.
(Refer to the sample LibVLCSharp.Forms.Sample.MediaElement)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
