### PR TITLE
build: allow a range of compatible minor SDK versions

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -3,6 +3,6 @@
         "MSBuild.Sdk.Extras": "3.0.23"
     },
     "sdk": {
-        "version": "5.0.202"
+        "version": "5.0.x"
     }
 }


### PR DESCRIPTION
Sometimes when switching computers I end up with a slightly newer or older, but still compatible, .NET SDK version. Just pushing this small local patch for friendlier dev XP.