### PR TITLE
CI: Fix recurring chocolatey CDN failures

### DIFF
--- a/buildsystem/windows-build.yml
+++ b/buildsystem/windows-build.yml
@@ -1,10 +1,14 @@
 steps:
 - template: base-template.yml
-- task: gep13.chocolatey-azuredevops.chocolatey-azuredevops.ChocolateyCommand@0
-  displayName: 'Install GTK#'
+- task: PowerShell@2
+  displayName: 'Install gtksharp'
   inputs:
-    command: install
-    installPackageId: gtksharp
+    targetType: 'inline'
+    script: |
+      $msiFile = "gtk-sharp-2.12.45.msi"
+      Invoke-WebRequest "https://xamarin.azureedge.net/GTKforWindows/Windows/$msiFile" -OutFile $msiFile
+      $arguments = "/i `"$msiFile`" /quiet"
+      Start-Process msiexec.exe -ArgumentList $arguments -Wait
 
 - task: DotNetCoreCLI@2
   displayName: 'Build'


### PR DESCRIPTION
Fixes regularly failing Windows CI

```
gtksharp v2.12.45 [Approved]
gtksharp package files install completed. Performing other installation steps.
Attempt to get headers for https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.45.msi failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.45.msi'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (500) Internal Server Error."
Downloading gtksharp 
  from 'https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.45.msi'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.45.msi'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (500) Internal Server Error." 
This package is likely not broken for licensed users - see https://chocolatey.org/docs/features-private-cdn.
The install of gtksharp was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\gtksharp\tools\chocolateyInstall.ps1'.
 See log for details.

Chocolatey installed 1/2 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```