### PR TITLE
WPF: Fix airspace issue to synchronize content over video

### DIFF
--- a/src/LibVLCSharp.WPF/ForegroundWindow.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.cs
@@ -58,10 +58,10 @@ namespace LibVLCSharp.WPF
         void Background_Unloaded(object sender, RoutedEventArgs e)
         {
             _bckgnd.SizeChanged -= Wndhost_SizeChanged;
+            _bckgnd.LayoutUpdated -= Wndhost_LayoutUpdated;
             if (_wndhost != null)
             {
                 _wndhost.Closing -= Wndhost_Closing;
-                _wndhost.LocationChanged -= Wndhost_LocationChanged;
             }
 
             Hide();
@@ -85,7 +85,7 @@ namespace LibVLCSharp.WPF
 
             _wndhost.Closing += Wndhost_Closing;
             _bckgnd.SizeChanged += Wndhost_SizeChanged;
-            _wndhost.LocationChanged += Wndhost_LocationChanged;
+            _bckgnd.LayoutUpdated += Wndhost_LayoutUpdated;
 
             try
             {
@@ -105,6 +105,15 @@ namespace LibVLCSharp.WPF
                 Hide();
                 throw new VLCException("Unable to create WPF Window in VideoView.", ex);
             }
+        }
+
+        void Wndhost_LayoutUpdated(object sender, EventArgs e)
+        {
+            var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
+            var source = PresentationSource.FromVisual(_wndhost);
+            var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
+            Left = targetPoints.X;
+            Top = targetPoints.Y;
         }
 
         void Wndhost_LocationChanged(object? sender, EventArgs e)

--- a/src/LibVLCSharp.WPF/ForegroundWindow.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.cs
@@ -107,16 +107,7 @@ namespace LibVLCSharp.WPF
             }
         }
 
-        void Wndhost_LayoutUpdated(object sender, EventArgs e)
-        {
-            var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
-            var source = PresentationSource.FromVisual(_wndhost);
-            var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
-            Left = targetPoints.X;
-            Top = targetPoints.Y;
-        }
-
-        void Wndhost_LocationChanged(object? sender, EventArgs e)
+        void Wndhost_LayoutUpdated(object? sender, EventArgs e)
         {
             var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
             var source = PresentationSource.FromVisual(_wndhost);


### PR DESCRIPTION
### Description of Change ###

Fix the incorrect position of the top element of the video

### Issues Resolved ### 

- fixes #474
[https://code.videolan.org/videolan/LibVLCSharp/-/issues/474](https://code.videolan.org/videolan/LibVLCSharp/-/issues/474)

### Changes ###

Added:
 - event _bckgnd.LayoutUpdated -= Wndhost_LayoutUpdated;
 - event _bckgnd.LayoutUpdated += Wndhost_LayoutUpdated;
 - void Wndhost_LayoutUpdated(object？ sender, EventArgs e)
 
 Removed:
 - event _wndhost.LocationChanged -= Wndhost_LocationChanged;
 - event _wndhost.LocationChanged += Wndhost_LocationChanged;
 - void Wndhost_LocationChanged(object？ sender, EventArgs e)
  
### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- .net
