### PR TITLE
WPF: Fix VideoView Content (ForegroundWindow) losing winHost hook and…

### DIFF
--- a/src/LibVLCSharp.WPF/ForegroundWindow.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.cs
@@ -69,7 +69,7 @@ namespace LibVLCSharp.WPF
 
         void Background_Loaded(object sender, RoutedEventArgs e)
         {
-            if (_wndhost != null)
+            if (_wndhost != null && IsVisible)
             {
                 return;
             }
@@ -109,11 +109,14 @@ namespace LibVLCSharp.WPF
 
         void Wndhost_LayoutUpdated(object? sender, EventArgs e)
         {
-            var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
-            var source = PresentationSource.FromVisual(_wndhost);
-            var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
-            Left = targetPoints.X;
-            Top = targetPoints.Y;
+            if (PresentationSource.FromVisual(_bckgnd) != null)
+            {
+                var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
+                var source = PresentationSource.FromVisual(_wndhost);
+                var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);
+                Left = targetPoints.X;
+                Top = targetPoints.Y;
+            }
         }
 
         void Wndhost_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
… disappearing (Issue #491)

<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

The problem is that the ForegroundWindow is not prepared for an Unload -> Load triggered by the Tab control.
In the Wndhost_LayoutUpdated event an error is thrown, triggered by this line:
var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
https://code.videolan.org/videolan/LibVLCSharp/-/blob/3.x/src/LibVLCSharp.WPF/ForegroundWindow.cs#L112
The problem here is that the Wndhost_LayoutUpdated is thrown just before the Background_Unloaded event, even though our anchor "_bckgnd" has already been unloaded at this point (i.e. is no longer connected to a presentation source).
So we can avoid this error by simply asking for this in advance. Like this:
if (PresentationSource.FromVisual(_bckgnd) != null)
Additionally, the ForegroundWindow is now unattached from our anchor and hidden due to the Background_Unloaded event.
So we extend the first condition in the Background_Loaded event to ask if the ForegroundWindow is visible https://code.videolan.org/videolan/LibVLCSharp/-/blob/3.x/src/LibVLCSharp.WPF/ForegroundWindow.cs#L72
With this we make sure that the ForegroundWindow is attached to our anchor again.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes #491

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Windows WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Manual test

### PR Checklist ###

- [ x] Rebased on top of the target branch at time of PR
- [ x] Changes adhere to coding standard
