### PR TITLE
MediaElement XF: Fixes customization regression

### DIFF
--- a/src/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
+++ b/src/LibVLCSharp.Forms/Shared/PlaybackControls.xaml.cs
@@ -574,6 +574,34 @@ namespace LibVLCSharp.Forms.Shared
         }
 
         /// <summary>
+        /// Identifies the <see cref="IsLockButtonVisible"/> dependency property.
+        /// </summary>
+        public static readonly BindableProperty IsLockButtonVisibleProperty = BindableProperty.Create(nameof(IsLockButtonVisible), typeof(bool),
+            typeof(PlaybackControls), true);
+        /// <summary>
+        /// Gets or sets a value that indicates whether the lock button is shown.
+        /// </summary>
+        public bool IsLockButtonVisible
+        {
+            get => (bool)GetValue(IsLockButtonVisibleProperty);
+            set => SetValue(IsLockButtonVisibleProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="IsTracksButtonVisible"/> dependency property.
+        /// </summary>
+        public static readonly BindableProperty IsTracksButtonVisibleProperty = BindableProperty.Create(nameof(IsTracksButtonVisible), typeof(bool),
+            typeof(PlaybackControls), true);
+        /// <summary>
+        /// Gets or sets a value that indicates whether the tracks button is shown.
+        /// </summary>
+        public bool IsTracksButtonVisible
+        {
+            get => (bool)GetValue(IsTracksButtonVisibleProperty);
+            set => SetValue(IsTracksButtonVisibleProperty, value);
+        }
+
+        /// <summary>
         /// Identifies the <see cref="IsCastButtonVisible"/> dependency property.
         /// </summary>
         public static readonly BindableProperty IsCastButtonVisibleProperty = BindableProperty.Create(nameof(IsCastButtonVisible), typeof(bool),
@@ -760,21 +788,6 @@ namespace LibVLCSharp.Forms.Shared
             UpdatePauseAvailability();
             UpdateTime();
             OnBuffering();
-        }
-
-        private static void IsAudioTracksSelectionButtonVisiblePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            ((PlaybackControls)bindable).UpdateAudioTracksSelectionAvailability();
-        }
-
-        private static void IsVideoTracksSelectionButtonVisiblePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            ((PlaybackControls)bindable).UpdateVideoTracksSelectionAvailability();
-        }
-
-        private static void IsClosedCaptionsSelectionButtonVisiblePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            ((PlaybackControls)bindable).UpdateClosedCaptionsTracksSelectionAvailability();
         }
 
         private static void IsPlayPauseButtonVisiblePropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
+++ b/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
@@ -182,6 +182,7 @@
 
     <Style x:Key="LockButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
         <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.UnlockAlt}" />
+        <Setter Property="IsVisible" Value="{TemplateBinding IsLockButtonVisible}" />
     </Style>
 
     <Style x:Key="UnLockButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
@@ -190,6 +191,7 @@
 
     <Style x:Key="TracksButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">
         <Setter Property="Text" Value="{x:Static fontawesome:FontAwesomeIcons.ListAlt}" />
+        <Setter Property="IsVisible" Value="{TemplateBinding IsTracksButtonVisible}" />
     </Style>
 
     <Style x:Key="AspectRatioButtonStyle" BasedOn="{StaticResource ButtonStyle}" TargetType="Button">


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

<!-- Describe your changes here. -->
Add IsLockButtonVisible and IsTracksButtonVisible properties which allow to hide or show the LockButton and the TracksButton.
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/494

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - IsLockButtonVisible  { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->
![image](https://user-images.githubusercontent.com/26142591/129534661-eaca5ccb-363c-4d95-9a9e-1fa1ad191141.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
