### PR TITLE
MediaElement XF: Tracks Selection too much space fixed - Fixes #497

### DIFF
--- a/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
+++ b/src/LibVLCSharp.Forms/Shared/Themes/Generic.xaml
@@ -337,6 +337,11 @@
                     <ContentView HeightRequest="300" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" x:Name="TracksOverlayView" AbsoluteLayout.LayoutBounds="0, 0, 1, 1"  AbsoluteLayout.LayoutFlags="All" IsVisible="False" BackgroundColor="#7F000000">
                         <ScrollView VerticalScrollBarVisibility="Never" HorizontalOptions="FillAndExpand" VerticalOptions="Fill" Orientation="Vertical">
                             <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
                                 <StackLayout Grid.Row="0" HorizontalOptions="FillAndExpand">
                                     <Label Style="{StaticResource TrackTypeLabelStyle}" x:Name="AudioTracksLabel" />
                                     <ListView x:Name="AudioTracksListView" ItemTemplate="{StaticResource TrackViewCellDataTemplate}" Style="{StaticResource TracksListViewStyle}" />


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###
Fixes Trackselection layout issue on mkv files with many tracks.
<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/497

### API Changes ###

Changed:
 - Generic.xaml

 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
Before|  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26142591/130434197-2daaf5d5-bc79-4fca-9504-e3142ef98c43.png" width="200" height="400" /> |  <img src="https://user-images.githubusercontent.com/26142591/130434523-d504ee55-68a1-4073-88ea-749605f63e9e.png" width="200" height="400" />


![Screenshot_1629715297](https://user-images.githubusercontent.com/26142591/130434726-83aae4ba-fb13-4641-a997-7733d5accfd4.png)
### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
