### PR TITLE
Make Core.Initialize implicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,8 @@ For more advanced samples, have a look at [libvlcsharp-samples](https://code.vid
 Feel free to suggest and contribute new samples.
 
 ## Quick API overview
-```csharp
-Core.Initialize();
 
+```csharp
 using var libvlc = new LibVLC(enableDebugLogs: true);
 using var media = new Media(libvlc, new Uri(@"C:\tmp\big_buck_bunny.mp4"));
 using var mediaplayer = new MediaPlayer(media);

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -30,6 +30,20 @@ If you need to call back into LibVLCSharp from an event, you need to switch thre
 mediaPlayer.EndReached += (sender, args) => ThreadPool.QueueUserWorkItem(_ => mediaPlayer.Play(nextMedia);
 ```
 
+## Generate a plugin cache (LibVLC.Windows only for now)
+
+If you want `Core.Initialize()` or `new LibVLC()` (if you don't call `Core.Initialize` yourself) to be faster, you could generate a plugins cache (if it is not already there and up to date).
+
+Just run your app once with:
+
+```csharp
+new LibVLC("--reset-plugins-cache");
+```
+
+This will generate a new `plugins.dat` file in your libvlc plugins folder. LibVLC will use this file to get information on the available plugins in advance, reducing dramatically the loading process.
+
+This file should be updated everytime LibVLC is updated (not LibVLCSharp). We will likely ship it in the LibVLC.Windows NuGet in the future, but you can already generate it yourself by simply using the above code once.
+
 ## Check how official VLC apps do it
 
 VLC for iOS and VLC for Android are the biggest libvlc consumer out there. They use libvlc just like anyone using LibVLCSharp uses libvlc to make their app.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,7 @@ The `MinimalPlayback` one provides a simple approach to getting video on the scr
 
 The steps are:
 1. Instantiate a `VideoView` and add it to your main View. 
-2. Call `Core.Initialize()` to load the `libvlc` native libraries. **This call _must_ be made before creating any libvlcsharp object!**
+2. (Optional) Call `Core.Initialize()` to load the `libvlc` native libraries. If you are using LibVLCSharp with the provided LibVLC native nugets, you do not need to make this call yourself (LibVLCSharp handles it for you) but you can. Reasons you'd want to do it yourself, could be to separate the libvlc loading process (which may take a bit of time) and the mediaplayback starting process. Also, if you put your libvlc build in a custom location, you may want to call `Core.Initialize(string path)` yourself with the custom path location.
 3. The `VideoView` offers a `MediaPlayer` object (with data-binding support) which you should create and set on the `VideoView`. The `MediaPlayer` allows you to control playback with APIs such as `Play`, `Pause`, set a new media or listen for playback events.
 4. In case you are using `LibVLCSharp.Forms`, make sure to call `LibVLCSharpFormsRenderer.Init()` in your platform specific project [*before*](https://forums.xamarin.com/discussion/comment/57605/#Comment_57605) `Xamarin.Forms.Forms.Init` is called. See the [Forms sample](https://github.com/videolan/libvlcsharp/tree/master/Samples/Forms).
 

--- a/docs/how_do_I_do_X.md
+++ b/docs/how_do_I_do_X.md
@@ -63,8 +63,6 @@ MediaPlayer.EnableHardwareDecoding = true
 Like this, for example:
 
 ```csharp
-Core.Initialize();
-
 using(var libVLC = new LibVLC())
 {
     var media = new Media(libVLC, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", FromType.FromLocation);
@@ -86,8 +84,6 @@ Full list commands and arguments https://wiki.videolan.org/VLC_command-line_help
 ## How do I set subtitles?
 
 ```csharp
-Core.Initialize();
-
 using(var libVLC = new LibVLC())
 {
     var media = new Media(_libVLC, "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4", FromType.FromLocation);

--- a/docs/migrating_from_Vlc.DotNet.md
+++ b/docs/migrating_from_Vlc.DotNet.md
@@ -57,7 +57,7 @@ Both being based off of the same libvlc APIs, the public C# APIs are quite simil
 
 At the time of writing, both Vlc.DotNet and LibVLCSharp support libvlc 3.x, but only LibVLCSharp has started implementing libvlc 4 features.
 
-For loading LibVLC, unlike with Vlc.DotNet, you may just call `Core.Initialize()`. The path will be found automatically, provided you have installed the LibVLC Windows nuget (see section below).
+For loading LibVLC, unlike with Vlc.DotNet, it is done automatically. If you prefer to do it yourself, you may just call `Core.Initialize()`. The path will be found automatically, provided you have installed the LibVLC Windows nuget (see section below), or you can provide it as a string parameter to `Initialize()`.
 
 Short example of API differences
 
@@ -128,8 +128,6 @@ namespace ConsoleApp1
     {
         static async Task Main(string[] args)
         {
-            Core.Initialize();
-
             using var libvlc = new LibVLC();
             using var mediaPlayer = new MediaPlayer(libvlc);
 

--- a/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement/MainViewModel.cs
+++ b/samples/Forms/LibVLCSharp.Forms.MediaElement/LibVLCSharp.Forms.Sample.MediaElement/MainViewModel.cs
@@ -47,8 +47,6 @@ namespace LibVLCSharp.Forms.Sample.MediaPlayerElement
         /// </summary>
         public void OnAppearing()
         {
-            Core.Initialize();
-
             LibVLC = new LibVLC(enableDebugLogs: true);
 
             var media = new Media(LibVLC, new Uri("http://streams.videolan.org/streams/mkv/multiple_tracks.mkv"));

--- a/samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
+++ b/samples/Forms/LibVLCSharp.Forms.Sample/MainViewModel.cs
@@ -37,8 +37,6 @@ namespace LibVLCSharp.Forms.Sample
 
         private void Initialize()
         {
-            Core.Initialize();
-
             LibVLC = new LibVLC(enableDebugLogs: true);
             var media = new Media(LibVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
 

--- a/samples/LibVLCSharp.Android.Sample/MainActivity.cs
+++ b/samples/LibVLCSharp.Android.Sample/MainActivity.cs
@@ -27,8 +27,6 @@ namespace LibVLCSharp.Android.Sample
         {
             base.OnResume();
 
-            Core.Initialize();
-
             _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new MediaPlayer(_libVLC)
             {

--- a/samples/LibVLCSharp.Avalonia.Sample/App.xaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/App.xaml.cs
@@ -12,7 +12,6 @@ namespace LibVLCSharp.Avalonia.Sample
     {
         public override void Initialize()
         {
-            Core.Initialize();
             AvaloniaXamlLoader.Load(this);
         }
 

--- a/samples/LibVLCSharp.FSharp.Sample/Program.fs
+++ b/samples/LibVLCSharp.FSharp.Sample/Program.fs
@@ -3,7 +3,6 @@ open LibVLCSharp.Shared
 
 [<EntryPoint>]
 let main argv =
-    Core.Initialize()
     let libVLC = new LibVLC(true)
     let mp = new MediaPlayer(libVLC)
     let media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"))

--- a/samples/LibVLCSharp.GTK.Sample/Program.cs
+++ b/samples/LibVLCSharp.GTK.Sample/Program.cs
@@ -8,8 +8,6 @@ namespace LibVLCSharp.GTK.Sample
     {
         public static void Main()
         {
-            Core.Initialize();
-
             // Initializes the GTK# app
             Application.Init();
 

--- a/samples/LibVLCSharp.Mac.Sample/ViewController.cs
+++ b/samples/LibVLCSharp.Mac.Sample/ViewController.cs
@@ -22,8 +22,6 @@ namespace LibVLCSharp.Mac.Sample
         {
             base.ViewDidLoad();
 
-            Core.Initialize();
-
             _libVLC = new LibVLC(enableDebugLogs: true);
             _mediaPlayer = new Shared.MediaPlayer(_libVLC);
 

--- a/samples/LibVLCSharp.NetCore.Sample/Program.cs
+++ b/samples/LibVLCSharp.NetCore.Sample/Program.cs
@@ -7,8 +7,6 @@ namespace LibVLCSharp.NetCore.Sample
     {
         static void Main(string[] args)
         {
-            Core.Initialize();
-
             using var libVLC = new LibVLC(enableDebugLogs: true);
             using var media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4"));
             using var mp = new MediaPlayer(media);

--- a/samples/LibVLCSharp.UWP.Sample/App.xaml.cs
+++ b/samples/LibVLCSharp.UWP.Sample/App.xaml.cs
@@ -29,7 +29,6 @@ namespace LibVLCSharp.UWP.Sample
         /// </summary>
         public App()
         {
-            Core.Initialize(); // LibVLCSharp initialization
             this.InitializeComponent();
             this.Suspending += OnSuspending;
         }

--- a/samples/LibVLCSharp.WPF.Sample/App.xaml.cs
+++ b/samples/LibVLCSharp.WPF.Sample/App.xaml.cs
@@ -7,7 +7,6 @@ namespace LibVLCSharp.WPF.Sample
     {
         public App()
         {
-            Core.Initialize();
         }
     }
 }

--- a/samples/LibVLCSharp.Windows.Net40.Sample/Program.cs
+++ b/samples/LibVLCSharp.Windows.Net40.Sample/Program.cs
@@ -7,8 +7,6 @@ namespace LibVLCSharp.Windows.Net40.Sample
     {
         static void Main(string[] args)
         {
-            Core.Initialize();
-
             using var libVLC = new LibVLC(enableDebugLogs: true);
             using var media = new Media(libVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
             using var mp = new MediaPlayer(media);

--- a/samples/Uno/LibVLCSharp.Uno.Sample.Shared/App.xaml.cs
+++ b/samples/Uno/LibVLCSharp.Uno.Sample.Shared/App.xaml.cs
@@ -19,8 +19,6 @@ namespace LibVLCSharp.Uno.Sample
         /// </summary>
         public App()
         {
-            Core.Initialize(); // LibVLCSharp initialization
-
             InitializeComponent();
             Suspending += OnSuspending;
         }

--- a/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Shared/App.xaml.cs
+++ b/samples/Uno/Sample.MediaPlayerElement/Sample.MediaPlayerElement.Shared/App.xaml.cs
@@ -19,8 +19,6 @@ namespace Sample.MediaPlayerElement
         /// </summary>
         public App()
         {
-            Core.Initialize(); // LibVLCSharp initialization
-
             InitializeComponent();
             Suspending += OnSuspending;
             Resuming += OnResuming;

--- a/src/LibVLCSharp.Tests/BaseSetup.cs
+++ b/src/LibVLCSharp.Tests/BaseSetup.cs
@@ -15,8 +15,6 @@ namespace LibVLCSharp.Tests
         [SetUp]
         public void SetUp()
         {
-            Core.Initialize();
-
             _libVLC = new LibVLC("--no-audio", "--no-video");
         }
 

--- a/src/LibVLCSharp.Tests/RendererDiscovererTests.cs
+++ b/src/LibVLCSharp.Tests/RendererDiscovererTests.cs
@@ -18,8 +18,6 @@ namespace LibVLCSharp.Tests
         [Ignore("requires network calls that may fail when run from CI")]
         public async Task DiscoverItems()
         {
-            Core.Initialize();
-
             var mp = new MediaPlayer(_libVLC)
             {
                 Media = new Media(_libVLC, "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4",

--- a/src/LibVLCSharp/Shared/Core/Core.Android.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.Android.cs
@@ -34,6 +34,8 @@ namespace LibVLCSharp.Shared
             InitializeAndroid();
 
             EnsureVersionsMatch();
+
+            LibVLCLoaded = true;
         }
 
         static void LoadLibCpp()

--- a/src/LibVLCSharp/Shared/Core/Core.Apple.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.Apple.cs
@@ -23,6 +23,7 @@ namespace LibVLCSharp.Shared
         public static void Initialize(string? libvlcDirectoryPath = null)
         {
             EnsureVersionsMatch();
+            LibVLCLoaded = true;
         }
     }
 }

--- a/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
@@ -49,6 +49,7 @@ namespace LibVLCSharp.Shared
 #if !NETSTANDARD1_1
             EnsureVersionsMatch();
 #endif
+            LibVLCLoaded = true;
         }
 
         /// <summary>

--- a/src/LibVLCSharp/Shared/Core/Core.UWP.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.UWP.cs
@@ -36,6 +36,7 @@ namespace LibVLCSharp.Shared
 #if !UWP10_0
             EnsureVersionsMatch();
 #endif
+            LibVLCLoaded = true;
         }
 
         static void InitializeUWP()

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -56,8 +56,18 @@ namespace LibVLCSharp.Shared
 #endif
         }
 
+        static bool _libvlcLoaded;
+        static internal bool LibVLCLoaded
+        {
 #if DESKTOP && !NETSTANDARD1_1
-        static bool Loaded => LibvlcHandle != IntPtr.Zero;
+            get => _libvlcLoaded || LibvlcHandle != IntPtr.Zero;
+#else
+            get => _libvlcLoaded;
+#endif
+            set => _libvlcLoaded = value;
+        }
+
+#if DESKTOP && !NETSTANDARD1_1
         static List<(string libvlccore, string libvlc)> ComputeLibVLCSearchPaths()
         {
             var paths = new List<(string, string)>();
@@ -149,7 +159,7 @@ namespace LibVLCSharp.Shared
                     break;
             }
 
-            if (!Loaded)
+            if (!LibVLCLoaded)
             {
                 throw new VLCException("Failed to load required native libraries. " +
                     $"{Environment.NewLine}Have you installed the latest LibVLC package from nuget for your target platform?" +
@@ -157,6 +167,16 @@ namespace LibVLCSharp.Shared
             }
         }
 #endif
+        internal static void EnsureLoaded()
+        {
+            if (LibVLCLoaded)
+            {
+                return;
+            }
+
+            Initialize();
+        }
+
         static bool LoadNativeLibrary(string nativeLibraryPath, out IntPtr handle)
         {
             handle = IntPtr.Zero;

--- a/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -214,13 +214,13 @@ namespace LibVLCSharp.Shared.Helpers
             try
             {
                 utf8Args = options.ToUtf8();
+                Core.EnsureLoaded();
                 return create(utf8Args.Length, utf8Args);
             }
             catch (DllNotFoundException ex)
             {
                 throw new VLCException("LibVLC could not be created. Make sure that you have done the following:" +
                     $"{Environment.NewLine}- Installed latest LibVLC from nuget for your target platform." +
-                    $"{Environment.NewLine}- Called LibVLCSharp.Shared.Core.Initialize() before creating any LibVLCSharp object." +
                     $"{Environment.NewLine}{ex.Message} {ex.StackTrace}");
             }
             finally

--- a/src/LibVLCSharp/Shared/Internal.cs
+++ b/src/LibVLCSharp/Shared/Internal.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace LibVLCSharp.Shared
 {

--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -222,7 +222,9 @@ namespace LibVLCSharp.Shared
         /// There is absolutely no warranty or promise of forward, backward and
         /// cross-platform compatibility with regards to libvlc_new() arguments.
         /// We recommend that you do not use them, other than when debugging.
-        /// 
+        /// <para/> This will throw a <see cref="VLCException"/> if the native libvlc libraries cannot be found or loaded.
+        /// <para/> It may also throw a <see cref="VLCException"/> if the LibVLC and LibVLCSharp major versions do not match.
+        /// See https://code.videolan.org/videolan/LibVLCSharp/-/blob/master/docs/versioning.md for more info about the versioning strategy.
         /// <example>
         /// <code>
         /// // example <br/>
@@ -276,6 +278,9 @@ namespace LibVLCSharp.Shared
         /// There is absolutely no warranty or promise of forward, backward and
         /// cross-platform compatibility with regards to libvlc_new() arguments.
         /// We recommend that you do not use them, other than when debugging.
+        /// <para/> This will throw a <see cref="VLCException"/> if the native libvlc libraries cannot be found or loaded.
+        /// <para/> It may also throw a <see cref="VLCException"/> if the LibVLC and LibVLCSharp major versions do not match.
+        /// See https://code.videolan.org/videolan/LibVLCSharp/-/blob/master/docs/versioning.md for more info about the versioning strategy.
         /// </summary>
         /// <param name="enableDebugLogs">enable verbose debug logs</param>
         /// <param name="options">list of arguments (should be NULL)</param>


### PR DESCRIPTION
Just creating this draft while I think more about it.

It should be documented that:
- if you need a custom location for libvlc, implicit loading won't guess the path for you, you need to call Core.Initialize() yourself with the custom path.
- it should be documented that the first `new LibVLC` can appear slower. That is because the same code now also loads libvlc on first time, while before it was just a regular constructor. Link to guidance to make libvlc load faster (plugins.dat, plugin cherry picking). If still too slow or not acceptable, load libvlc yourself by calling Core.Initialize() _way before_ you call `new LibVLC`.
- No lock is needed because only LibVLC and Equalizer could be created from multiple threads with the `Loaded` value potentially not up to date.
  - You don't want to create multiple LibVLC instance anyway, so you're likely doing something wrong in the first place.
  - If for some reason you want to create multiple Equalizer instances from multiple threads, and run into multithreading issue due to implicit libvlc loading, just load libvlc yourself explicitly beforehand.
  
Need to test on Unity editor/standalone.