### PR TITLE
Added mention of KlingonWin10WPF to made_with_libvlcsharp.md

### DIFF
--- a/docs/made_with_libvlcsharp.md
+++ b/docs/made_with_libvlcsharp.md
@@ -81,3 +81,9 @@ https://github.com/selmaohneh/JukeCore
 A terminal based music player using dotnet core 5, libvlcsharp and Terminal.Gui
 
 https://github.com/gareth7562/climusicdotnet
+
+## KlingonWin10WPF 
+
+A FMV game made with libvlcsharp and WPF that utilizes the media on the original disks. The game includes clickable surfaces that trigger different videos to play and different outcomes. (The game will not play without the original media from the disks, but the source is still useful). 
+
+https://github.com/Teravus/KlingonWin10WPF


### PR DESCRIPTION
Added mention of KlingonWin10WPF to the made_with_libvlcsharp file.   This is an unofficial remake of the Executable of the FMV game portion of Star Trek: Klingon

<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

Added a mention to a project made with libvlcsharp and WPF

### Issues Resolved ### 
NA - Documenting

- fixes #

### API Changes ###
None

Added:
- Mention of a project that utilizes this software.


 
 -->
 
 None

### Platforms Affected ### 
None

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###


### PR Checklist ###

- [X ] Rebased on top of the target branch at time of PR
- [X ] Changes adhere to coding standard
