### PR TITLE
tvOS: packaging changes following upstream updates

### DIFF
--- a/src/LibVLCSharp/Shared/Core/Constants.cs
+++ b/src/LibVLCSharp/Shared/Core/Constants.cs
@@ -7,7 +7,7 @@ namespace LibVLCSharp.Shared
 #if IOS
         internal const string LibraryName = "@rpath/DynamicMobileVLCKit.framework/DynamicMobileVLCKit";
 #elif TVOS
-        internal const string LibraryName = "@rpath/DynamicTVVLCKit.framework/DynamicTVVLCKit";
+        internal const string LibraryName = "@rpath/TVVLCKit.framework/TVVLCKit";
 #else
         internal const string LibraryName = "libvlc";
 #endif


### PR DESCRIPTION
### Description of Change ###

**Breaking change**

Since https://github.com/videolan/vlckit/commit/9e86882eca8ae209f5c0b29855c46e5ba4f6bd48, the vlckit project changed its packaging strategy by using the newer `xcframework` and retiring the XCode `DynamicMobileVLCKit` target that the LibVLC.iOS NuGet was using. For the record, the actual `MobileVLCKit` are still available and can be retrieved and used outside of the `xcframework` shell.

This change was motivated by adding support to M1 Macs and ARM64 simulators.

Well, shipping a new LibVLC iOS build on NuGet requires small but breaking changes
- [LibVLC iOS packaging changes](https://github.com/mfkl/libvlc-nuget/commit/634111ebd70e040c7c692e17362dbed1def68229).
- This PR, changing LibVLCSharp DLLImport section used in linking the final consumer app.

I have tested that the sample works on simulator with the 2 changes above.

Failing to update both LibVLC and LibVLCSharp (e.g. only updating one of the packages) will result in a build or runtime failure, depending on which package is updated.

_Need to try: rename the folder and file `MobileVLCKit` to the old `DynamicMobileVLCKit` and see what happens. Would be a convenient workaround. Probably need to use `install_name_tool`, but this could actually work, given that I am (still) not shipping the `xcframework` in the nuget (do we need to?)._

### Issues Resolved ### 

- fixes at least https://code.videolan.org/videolan/LibVLCSharp/-/issues/496,
- and plenty of others, see NEWS file at vlckit repository

### API Changes ###

Changed:
 - This version needs LibVLC.iOS 3.3.17 minimum (unless my workaround above works).

### Platforms Affected ### 

- iOS for now, tvOS later.

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Sample works

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [ ] Update all samples in/out this repo
- [ ] Try the workaround suggested above to avoid this PR altogether.
- [ ] Add ARM64 simulator support to libvlc-nuget docs