### PR TITLE
Update VideoViewRenderer.cs

### DIFF
--- a/src/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
+++ b/src/LibVLCSharp.Forms/Platforms/Android/VideoViewRenderer.cs
@@ -14,13 +14,28 @@ namespace LibVLCSharp.Forms.Platforms.Android
     /// Xamarin.Forms custom renderer for the Android VideoView
     /// </summary>
     public class VideoViewRenderer : ViewRenderer<LibVLCSharp.Forms.Shared.VideoView, LibVLCSharp.Platforms.Android.VideoView>
-    {
+    {    
+        private bool _isDisposing = false;
+        
         /// <summary>
         /// Main constructor (empty)
         /// </summary>
         /// <param name="context">Android context</param>
         public VideoViewRenderer(Context context) : base(context)
         {
+        }
+
+        /// <summary>
+        /// Gets triggered when the object gets disposed
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
+        {
+            _isDisposing = true;
+            base.Dispose(disposing);
+
+            Control!.MediaPlayer = null;
+            Control!.Dispose();
         }
 
         /// <summary>
@@ -53,6 +68,11 @@ namespace LibVLCSharp.Forms.Platforms.Android
 
         private void OnMediaPlayerChanging(object sender, MediaPlayerChangingEventArgs e)
         {
+            // Avoid updating the MediaPlayer if the Context from the Control is already disposed
+            if (_isDisposing)
+            {
+                return;
+            }
             Control.MediaPlayer = e.NewMediaPlayer;
             Control.TriggerLayoutChangeListener();
         }


### PR DESCRIPTION
As requested, I also made the changes here.
https://code.videolan.org/videolan/LibVLCSharp/-/merge_requests/20

### Description of Change ###
Added an override for the "Dispose" method and set a private boolean to true if the object is disposing.
Then, if it's disposing, no upadate of the MediaPlayer element is happening for the disposing object.
This avoids the "View is null" exception on Android.

```
at Java.Interop.JniEnvironment+InstanceMethods.CallVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0006e] in <bd6bd528a8784b7caf03e9f25c9f0d7b>:0 
  at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0002a] in <bd6bd528a8784b7caf03e9f25c9f0d7b>:0 
  at Org.Videolan.Libvlc.AWindow.SetVideoView (Android.Views.SurfaceView p0) [0x00031] in <7b7511c11eb74e4a92928dc74104a17e>:0 
  at LibVLCSharp.Platforms.Android.VideoView.Attach () [0x0002b] in <b891362fb4a04724910f1ae3d57b6cc1>:0 
  at LibVLCSharp.Platforms.Android.VideoView.set_MediaPlayer (LibVLCSharp.Shared.MediaPlayer value) [0x0001e] in <b891362fb4a04724910f1ae3d57b6cc1>:0 
  at LibVLCSharp.Forms.Platforms.Android.VideoViewRenderer.OnMediaPlayerChanging (System.Object sender, LibVLCSharp.Shared.MediaPlayerChangingEventArgs e) [0x0000c] in <1c512d0e0e3c4e059c601f600fc7013f>:0 
  at (wrapper delegate-invoke) System.EventHandler`1[LibVLCSharp.Shared.MediaPlayerChangingEventArgs].invoke_void_object_TEventArgs(object,LibVLCSharp.Shared.MediaPlayerChangingEventArgs)
  at LibVLCSharp.Forms.Shared.VideoView.OnMediaPlayerChanging (Xamarin.Forms.BindableObject bindable, System.Object oldValue, System.Object newValue) [0x00024] in <1c512d0e0e3c4e059c601f600fc7013f>:0 
  at Xamarin.Forms.BindableObject.SetValueActual (Xamarin.Forms.BindableProperty property, Xamarin.Forms.BindableObject+BindablePropertyContext context, System.Object value, System.Boolean currentlyApplying, Xamarin.Forms.Internals.SetValueFlags attributes, System.Boolean silent) [0x00051] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:475 
  at Xamarin.Forms.BindableObject.SetValueCore (Xamarin.Forms.BindableProperty property, System.Object value, Xamarin.Forms.Internals.SetValueFlags attributes, Xamarin.Forms.BindableObject+SetValuePrivateFlags privateAttributes) [0x00173] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:446 
  at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value, System.Boolean fromStyle, System.Boolean checkAccess) [0x0004d] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:374 
  at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value) [0x00000] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:349 
  at LibVLCSharp.Forms.Shared.VideoView.set_MediaPlayer (LibVLCSharp.Shared.MediaPlayer value) [0x00000] in <1c512d0e0e3c4e059c601f600fc7013f>:0 
  at LibVLCSharp.Forms.Shared.MediaPlayerElement.OnMediaPlayerChanged (LibVLCSharp.Shared.MediaPlayer mediaPlayer) [0x0000a] in <1c512d0e0e3c4e059c601f600fc7013f>:0 
  at LibVLCSharp.Forms.Shared.MediaPlayerElement.MediaPlayerPropertyChanged (Xamarin.Forms.BindableObject bindable, System.Object oldValue, System.Object newValue) [0x00000] in <1c512d0e0e3c4e059c601f600fc7013f>:0 
  at Xamarin.Forms.BindableObject.SetValueActual (Xamarin.Forms.BindableProperty property, Xamarin.Forms.BindableObject+BindablePropertyContext context, System.Object value, System.Boolean currentlyApplying, Xamarin.Forms.Internals.SetValueFlags attributes, System.Boolean silent) [0x00120] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:512 
  at Xamarin.Forms.BindableObject.SetValueCore (Xamarin.Forms.BindableProperty property, System.Object value, Xamarin.Forms.Internals.SetValueFlags attributes, Xamarin.Forms.BindableObject+SetValuePrivateFlags privateAttributes) [0x00173] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:446 
  at Xamarin.Forms.Internals.TypedBinding`2[TSource,TProperty].ApplyCore (System.Object sourceObject, Xamarin.Forms.BindableObject target, Xamarin.Forms.BindableProperty property, System.Boolean fromTarget) [0x0011f] in D:\a\1\s\Xamarin.Forms.Core\TypedBinding.cs:233 
  at Xamarin.Forms.Internals.TypedBinding`2[TSource,TProperty].Apply (System.Boolean fromTarget) [0x00029] in D:\a\1\s\Xamarin.Forms.Core\TypedBinding.cs:115 
  at Xamarin.Forms.Internals.TypedBinding`2+PropertyChangedProxy[TSource,TProperty].<OnPropertyChanged>b__16_0 () [0x00000] in D:\a\1\s\Xamarin.Forms.Core\TypedBinding.cs:297 
  at Xamarin.Forms.DispatcherExtensions.Dispatch (Xamarin.Forms.IDispatcher dispatcher, System.Action action) [0x00028] in D:\a\1\s\Xamarin.Forms.Core\DispatcherExtensions.cs:53 
  at Xamarin.Forms.Internals.TypedBinding`2+PropertyChangedProxy[TSource,TProperty].OnPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs e) [0x00033] in D:\a\1\s\Xamarin.Forms.Core\TypedBinding.cs:297 
  at Xamarin.Forms.BindingExpression+WeakPropertyChangedProxy.OnPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs e) [0x00012] in D:\a\1\s\Xamarin.Forms.Core\BindingExpression.cs:666 
  at (wrapper delegate-invoke) <Module>.invoke_void_object_PropertyChangedEventArgs(object,System.ComponentModel.PropertyChangedEventArgs)
  at RemoteControlRepetierServer.ViewModels.BaseViewModel.OnPropertyChanged (System.String propertyName) [0x00012] in C:\RCP\Source\RCRepetierServer\RCRS\ViewModels\BaseViewModel.cs:445 
  at RemoteControlRepetierServer.ViewModels.DashboardViewModel.set_MediaPlayer (LibVLCSharp.Shared.MediaPlayer value) [0x00017] in C:\RCP\Source\RCRepetierServer\RCRS\ViewModels\DashboardViewModel.cs:1924 
  at RemoteControlRepetierServer.ViewModels.DashboardViewModel.RefreshWebCamViewAction () [0x00351] in C:\RCP\Source\RCRepetierServer\RCRS\ViewModels\DashboardViewModel.cs:4497 
  --- End of managed Java.Lang.NullPointerException stack trace ---
java.lang.NullPointerException: view is null
	at org.videolan.libvlc.AWindow.setView(AWindow.java:235)
	at org.videolan.libvlc.AWindow.setVideoView(AWindow.java:268)
	at mono.java.lang.RunnableImplementor.n_run(Native Method)
	at mono.java.lang.RunnableImplementor.run(RunnableImplementor.java:30)
	at android.os.Handler.handleCallback(Handler.java:907)
	at android.os.Handler.dispatchMessage(Handler.java:105)
	at android.os.Looper.loop(Looper.java:216)
	at android.app.ActivityThread.main(ActivityThread.java:7625)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)

```

### Issues Resolved ### 
- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/506

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
