### PR TITLE
media: rewrite slashes for windows

### DIFF
--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -248,6 +248,11 @@ namespace LibVLCSharp.Shared
             if (string.IsNullOrEmpty(mrl))
                 throw new ArgumentNullException(nameof(mrl));
 
+            if(PlatformHelper.IsWindows && type == FromType.FromPath)
+            {
+                mrl = mrl.Replace("/", @"\");
+            }
+
             var mrlPtr = mrl.ToUtf8();
             if (mrlPtr == IntPtr.Zero)
                 throw new ArgumentException($"error marshalling {mrl} to UTF-8 for native interop");


### PR DESCRIPTION
### Description of Change ###

On Windows, when using `FromPath` in the `Media` constructor, we want to rewrite internally the forward slashes into backslashes, like explorer.exe does, before feeding the path to LibVLC.

This does not affect the `FromLocation`/`Uri` constructors.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/517

### API Changes ###

No real important breaking change. If the user was doing it already on their side, this does not change the behavior.
If they were not and catching an exception, well, no more exception I guess.

### Platforms Affected ### 

- Windows

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
