### PR TITLE
media: clarify error message if native media constructor fails

### DIFF
--- a/src/LibVLCSharp/Shared/Internal.cs
+++ b/src/LibVLCSharp/Shared/Internal.cs
@@ -33,9 +33,8 @@ namespace LibVLCSharp.Shared
         {
             Release = release;
             var nativeRef = create();
-            if(nativeRef == IntPtr.Zero)
-                throw new VLCException("Failed to perform instanciation on the native side. " +
-                    "Make sure you installed the correct VideoLAN.LibVLC.[YourPlatform] package in your platform specific project");
+            if (nativeRef == IntPtr.Zero)
+                OnNativeInstanciationError();
             NativeReference = nativeRef;
         }
 
@@ -61,5 +60,8 @@ namespace LibVLCSharp.Shared
             NativeReference = IntPtr.Zero;
             IsDisposed = true;
         }
+
+        internal virtual void OnNativeInstanciationError() => throw new VLCException("Failed to perform instanciation on the native side. " +
+                    "Make sure you installed the correct VideoLAN.LibVLC.[YourPlatform] package in your platform specific project");
     }
 }

--- a/src/LibVLCSharp/Shared/Media.cs
+++ b/src/LibVLCSharp/Shared/Media.cs
@@ -635,6 +635,13 @@ namespace LibVLCSharp.Shared
                 Native.LibVLCMediaRetain(NativeReference);
         }
 
+        internal override void OnNativeInstanciationError()
+        {
+            throw new VLCException("Failed to instanciate the Media on the native side. " +
+                    $"{Environment.NewLine}Have you installed the latest LibVLC package from nuget for your target platform?" +
+                    $"{Environment.NewLine}Is your MRL correct? Do check the native LibVLC verbose logs for more information.");
+        }
+
         #region MediaFromStream
 
         static readonly InternalOpenMedia OpenMediaCallbackHandle = OpenMediaCallback;


### PR DESCRIPTION
### Description of Change ###

When a user provides an incorrect MRL to create a media, the native function will return null and we will throw with a generic message. The exception message is cryptic in case of Media, so clarify it.

### Issues Resolved ### 

- None but mentioned in https://code.videolan.org/videolan/LibVLCSharp/-/issues/517 and discord.

### API Changes ###

 None

### Platforms Affected ### 

- Core (all platforms)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
