### PR TITLE
iOS: Add additional lifetime check

### DIFF
--- a/src/LibVLCSharp/Platforms/Apple/VideoView.cs
+++ b/src/LibVLCSharp/Platforms/Apple/VideoView.cs
@@ -50,7 +50,7 @@ namespace LibVLCSharp.Platforms.Mac
 
         void Attach()
         {
-            if (MediaPlayer != null)
+            if (MediaPlayer != null && MediaPlayer.NativeReference != IntPtr.Zero)
             {
                 MediaPlayer.NsObject = Handle;
             }
@@ -58,7 +58,7 @@ namespace LibVLCSharp.Platforms.Mac
 
         void Detach()
         {
-            if (MediaPlayer != null)
+            if (MediaPlayer != null && MediaPlayer.NativeReference != IntPtr.Zero)
             {
                 MediaPlayer.NsObject = IntPtr.Zero;
             }


### PR DESCRIPTION
### Description of Change ###

Avoid crashing if the mediaplayer gets disposed before the view is detached

Fix https://code.videolan.org/videolan/LibVLCSharp/-/issues/520

The WinForms view has a similar check.

### Issues Resolved ### 

- fixes https://code.videolan.org/videolan/LibVLCSharp/-/issues/520

### API Changes ###

 None

### Platforms Affected ### 

- iOS