### PR TITLE
Fixed WPF VideoView foreground window position bug

### DIFF
--- a/src/LibVLCSharp.WPF/ForegroundWindow.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.cs
@@ -58,10 +58,11 @@ namespace LibVLCSharp.WPF
         void Background_Unloaded(object sender, RoutedEventArgs e)
         {
             _bckgnd.SizeChanged -= Wndhost_SizeChanged;
-            _bckgnd.LayoutUpdated -= Wndhost_LayoutUpdated;
+            _bckgnd.LayoutUpdated -= RefreshOverlayPosition;
             if (_wndhost != null)
             {
                 _wndhost.Closing -= Wndhost_Closing;
+                _wndhost.LocationChanged -= RefreshOverlayPosition;
             }
 
             Hide();
@@ -84,8 +85,9 @@ namespace LibVLCSharp.WPF
             Owner = _wndhost;
 
             _wndhost.Closing += Wndhost_Closing;
+            _wndhost.LocationChanged += RefreshOverlayPosition;
+            _bckgnd.LayoutUpdated += RefreshOverlayPosition;
             _bckgnd.SizeChanged += Wndhost_SizeChanged;
-            _bckgnd.LayoutUpdated += Wndhost_LayoutUpdated;
 
             try
             {
@@ -100,20 +102,20 @@ namespace LibVLCSharp.WPF
                 Show();
                 _wndhost.Focus();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Hide();
                 throw new VLCException("Unable to create WPF Window in VideoView.", ex);
             }
         }
 
-        void Wndhost_LayoutUpdated(object? sender, EventArgs e)
+        void RefreshOverlayPosition(object? sender, EventArgs e)
         {
             if (PresentationSource.FromVisual(_bckgnd) == null)
             {
                 return;
             }
-            
+
             var locationFromScreen = _bckgnd.PointToScreen(_zeroPoint);
             var source = PresentationSource.FromVisual(_wndhost);
             var targetPoints = source.CompositionTarget.TransformFromDevice.Transform(locationFromScreen);


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

For whatever reason, the _bckgnd.LayoutUpdated event only fires inside of a debugger. So lets use the _wndhost.LocationChanged instead. I tested a few cases and everything seems to work fine now.

### Issues Resolved ### 

- fixes #523

### API Changes ###
 
 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###

The WPF VideoView overlay no longer magically floats around somewhere on the screen

### Before/After Screenshots ### 
Before
![{DE5A8AC6-489E-4B5A-B728-89E2E43B8E8D}](https://user-images.githubusercontent.com/88632464/143790413-745fb8e5-d33a-4294-ae66-f8263063d7c0.png)

After
![{D3F63A78-C087-47BD-A40F-9ECC11A10390}](https://user-images.githubusercontent.com/88632464/143790245-0c14ae86-1bcc-49e4-b092-8b3467c283af.png)

### Testing Procedure ###
Run LibVlcSharp WPF sample outside of the debugger and move the main window around the screen

### PR Checklist ###

- [x ] Rebased on top of the target branch at time of PR
- [x ] Changes adhere to coding standard
