### PR TITLE
Fixed `null` check instead of IntPtr.Zero

### DIFF
--- a/src/LibVLCSharp.WPF/VideoView.cs
+++ b/src/LibVLCSharp.WPF/VideoView.cs
@@ -82,7 +82,7 @@ namespace LibVLCSharp.WPF
                 }
 
                 Hwnd = (Template.FindName(PART_PlayerView, this) as System.Windows.Forms.Panel)?.Handle ?? IntPtr.Zero;
-                if (Hwnd == null)
+                if (Hwnd == IntPtr.Zero)
                 {
                     Trace.WriteLine("HWND is NULL, aborting...");
                     return;


### PR DESCRIPTION
### Description of Change ###

Used `IntPtr.Zero` to compare value of type `IntPtr` instead of `null`

### Issues Resolved ### 

net6.0 warns that this is always false...

### API Changes ###
 None

### Platforms Affected ### 
-WPF

### Behavioral/Visual Changes ###

None, except for cases where this should already be crashing

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Build

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
