### PR TITLE
Add WinUI TFM support

### DIFF
--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -31,6 +31,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.1;net40;net471</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);monoandroid81;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);uap10.0.18362;net6.0;net6.0-windows;net6.0-ios;net6.0-android;net6.0-tvos;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
     <Configurations>Debug;Release;Win32Debug;Win32Release</Configurations>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAWindow</TargetsForTfmSpecificBuildOutput>
     <RootNamespace>LibVLCSharp</RootNamespace>

--- a/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK || NETSTANDARD || NET6_0
+﻿#if NETFRAMEWORK || NETSTANDARD || NET6_0 || NET6_0_WINDOWS10_0_19041
 
 using System;
 using System.Diagnostics;

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -56,7 +56,7 @@ namespace LibVLCSharp.Shared
 #endif
         }
 
-#if (NETFRAMEWORK || NETSTANDARD || NET6_0) && !NETSTANDARD1_1
+#if (NETFRAMEWORK || NETSTANDARD || NET6_0 || NET6_0_WINDOWS10_0_19041) && !NETSTANDARD1_1
         static bool Loaded => LibvlcHandle != IntPtr.Zero;
         static List<(string libvlccore, string libvlc)> ComputeLibVLCSearchPaths()
         {


### PR DESCRIPTION
### Description of Change ###

Adds the `net6.0-windows10.0.19041` TFM. This should enable support for using LibVLC in WinUI.

WinUI is more like standard Windows Desktop apps than UWP, so, apart from specific Video Views used for rendering in UI, you should be able to use the standard Windows Desktop DLLs and processes. 

If you try running the video side from within a WinUI app with this, it currently pops out into a new Direct3D window.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- .NET 6
- WinUI

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
