### PR TITLE
remove winform host from wpf project

### DIFF
--- a/src/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
+++ b/src/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj
@@ -16,7 +16,6 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <RootNamespace>LibVLCSharp.WPF</RootNamespace>
     <PackageId>LibVLCSharp.WPF</PackageId>
     <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
     <PackageTags>$(PackageTags);wpf</PackageTags>
   </PropertyGroup>
   <!--Override TFMs when building from the LVS.Win32 solution-->

--- a/src/LibVLCSharp.WPF/Themes/Generic.xaml
+++ b/src/LibVLCSharp.WPF/Themes/Generic.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:wf="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"
     xmlns:local="clr-namespace:LibVLCSharp.WPF">
 
     <Style TargetType="{x:Type local:VideoView}">
@@ -13,9 +12,7 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             Margin="{TemplateBinding Padding}">
                         <Grid>
-                            <WindowsFormsHost x:Name="PART_PlayerHost">
-                                <wf:Panel x:Name="PART_PlayerView" />
-                            </WindowsFormsHost>
+                            <local:VideoHwndHost x:Name="PART_PlayerHost" />
                             <ContentPresenter Content="{TemplateBinding Content}" />
                         </Grid>
                     </Border>

--- a/src/LibVLCSharp.WPF/User32Wrapper.cs
+++ b/src/LibVLCSharp.WPF/User32Wrapper.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibVLCSharp.WPF
+{
+    internal static class User32Wrapper
+    {
+        public const string LibraryName = "user32.dll";
+
+        public static class EntryPoints
+        {
+            public const string CreateWindow = "CreateWindowEx";
+            public const string DestroyWindow = "DestroyWindow";
+        }
+
+        /// <summary>
+        /// Provide the win32 window stype when call <see cref="EntryPoints.CreateWindow"/>
+        /// <para>See following link: <a href="https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles" /> </para>
+        /// </summary>
+        [Flags]
+        internal enum ExtendedWindow32Styles : int
+        {
+            /// <summary>
+            /// The window should not be painted until siblings beneath the window (that were created by the same thread) have been painted.
+            /// The window appears transparent because the bits of underlying sibling windows have already been painted.
+            /// </summary>
+            WS_EX_TRANSPARENT = 0x00000020
+        }
+
+        /// <summary>
+        /// Provide the win32 window stype when call <see cref="EntryPoints.CreateWindow"/>
+        /// <para>See following link: <a href="https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles" /> </para>
+        /// </summary>
+        [Flags]
+        internal enum Window32Styles : int
+        {
+            /// <summary>
+            /// The window is a child window. A window with this style cannot have a menu bar.
+            /// </summary>
+            WS_CHILD = 0x40000000,
+
+            /// <summary>
+            /// The window is initially visible.
+            /// </summary>
+            WS_VISIBLE = 0x10000000
+        }
+
+
+        [DllImport(LibraryName, EntryPoint = EntryPoints.CreateWindow, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr CreateWindowEx(ExtendedWindow32Styles dwExStyle,
+                string lpszClassName,
+                string lpszWindowName,
+                Window32Styles style,
+                int x, int y, int width, int height,
+                IntPtr hwndParent,
+                IntPtr hMenu,
+                IntPtr hInst);
+
+
+        [DllImport(LibraryName, EntryPoint = EntryPoints.DestroyWindow, CharSet = CharSet.Unicode)]
+        internal static extern bool DestroyWindow(IntPtr hwnd);
+    }
+}

--- a/src/LibVLCSharp.WPF/VideoHwndHost.cs
+++ b/src/LibVLCSharp.WPF/VideoHwndHost.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+
+namespace LibVLCSharp.WPF
+{
+    /// <summary>
+    /// Provide the UserControl with Handle Pointer in WPF
+    /// <para>This class will create instance of win32 window and hosted it in WPF Framework element</para>
+    /// <remark>As WPF only render the whole window, so all controls over the <see cref="VideoHwndHost"/> will not reneder</remark>
+    /// </summary>
+    internal class VideoHwndHost : HwndHost
+    {
+        /// <inheritdoc/>
+        protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+        {
+            var windowHandle = User32Wrapper.CreateWindowEx(User32Wrapper.ExtendedWindow32Styles.WS_EX_TRANSPARENT, "static", string.Empty,
+                                                       User32Wrapper.Window32Styles.WS_CHILD | User32Wrapper.Window32Styles.WS_VISIBLE, 
+                                                       0, 0, 0, 0, 
+                                                       hwndParent.Handle, IntPtr.Zero, IntPtr.Zero);
+            return new HandleRef(this, windowHandle);
+        }
+
+        /// <inheritdoc/>
+        protected override void DestroyWindowCore(HandleRef hwnd)
+        {
+            User32Wrapper.DestroyWindow(hwnd.Handle);
+        }
+    }
+}

--- a/src/LibVLCSharp.WPF/VideoView.cs
+++ b/src/LibVLCSharp.WPF/VideoView.cs
@@ -4,21 +4,17 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Forms.Integration;
 
 namespace LibVLCSharp.WPF
 {
     /// <summary>
     /// WPF VideoView with databinding for use with LibVLCSharp
     /// </summary>
-    [TemplatePart(Name = PART_PlayerHost, Type = typeof(WindowsFormsHost))]
-    [TemplatePart(Name = PART_PlayerView, Type = typeof(System.Windows.Forms.Panel))]
+    [TemplatePart(Name = PART_PlayerHost, Type = typeof(VideoHwndHost))]
     public class VideoView : ContentControl, IVideoView, IDisposable
     {
         private const string PART_PlayerHost = "PART_PlayerHost";
-        private const string PART_PlayerView = "PART_PlayerView";
-
-        private WindowsFormsHost? WindowsFormsHost => Template.FindName(PART_PlayerHost, this) as WindowsFormsHost;
+        private VideoHwndHost? _videoHwndHost = null;
 
         /// <summary>
         /// WPF VideoView constructor
@@ -41,19 +37,19 @@ namespace LibVLCSharp.WPF
         /// </summary>
         public MediaPlayer? MediaPlayer
         {
-            get { return GetValue(MediaPlayerProperty) as MediaPlayer; }
-            set { SetValue(MediaPlayerProperty, value); }
+            get => GetValue(MediaPlayerProperty) as MediaPlayer;
+            set => SetValue(MediaPlayerProperty, value);
         }
 
         private static void OnMediaPlayerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (e.OldValue is MediaPlayer oldMediaPlayer)
             {
-                oldMediaPlayer.Hwnd = IntPtr.Zero;
+                ((VideoView)d).DetachMediaPlayer(oldMediaPlayer);
             }
             if (e.NewValue is MediaPlayer newMediaPlayer)
             {
-                newMediaPlayer.Hwnd = ((VideoView)d).Hwnd;
+                ((VideoView)d).AttachMediaPlayer(newMediaPlayer);
             }
         }
 
@@ -61,7 +57,6 @@ namespace LibVLCSharp.WPF
         private ForegroundWindow? ForegroundWindow { get; set; }
         private bool IsUpdatingContent { get; set; }
         private UIElement? ViewContent { get; set; }
-        private IntPtr Hwnd { get; set; }
 
         /// <summary>
         /// ForegroundWindow management and MediaPlayer setup.
@@ -70,31 +65,52 @@ namespace LibVLCSharp.WPF
         {
             base.OnApplyTemplate();
 
-            if (!IsDesignMode)
+            if (IsDesignMode)
             {
-                var windowsFormsHost = WindowsFormsHost;
-                if (windowsFormsHost != null)
-                {
-                    ForegroundWindow = new ForegroundWindow(windowsFormsHost)
-                    {
-                        OverlayContent = ViewContent
-                    };
-                }
+                return;
+            }
 
-                Hwnd = (Template.FindName(PART_PlayerView, this) as System.Windows.Forms.Panel)?.Handle ?? IntPtr.Zero;
-                if (Hwnd == IntPtr.Zero)
-                {
-                    Trace.WriteLine("HWND is NULL, aborting...");
-                    return;
-                }
+            if (Template.FindName(PART_PlayerHost, this) is not VideoHwndHost controlHost)
+            {
+                Trace.WriteLine($"Couldn't find {PART_PlayerHost} of type {nameof(VideoHwndHost)}");
+                return;
+            }
 
-                if (MediaPlayer == null)
-                {
-                    Trace.Write("No MediaPlayer is set, aborting...");
-                    return;
-                }
+            _videoHwndHost = controlHost;
 
-                MediaPlayer.Hwnd = Hwnd;
+            ForegroundWindow = new ForegroundWindow(_videoHwndHost)
+            {
+                OverlayContent = ViewContent
+            };
+
+
+            if (_videoHwndHost.Handle == IntPtr.Zero)
+            {
+                Trace.WriteLine("HWND is NULL, aborting...");
+                return;
+            }
+
+            if (MediaPlayer == null)
+            {
+                Trace.Write("No MediaPlayer is set, aborting...");
+                return;
+            }
+            AttachMediaPlayer(MediaPlayer);
+        }
+
+        private void AttachMediaPlayer(MediaPlayer mediaPlayer)
+        {
+            if (mediaPlayer != null && _videoHwndHost != null)
+            {
+                mediaPlayer.Hwnd = _videoHwndHost.Handle;
+            }
+        }
+
+        private void DetachMediaPlayer(MediaPlayer mediaPlayer)
+        {
+            if (mediaPlayer != null)
+            {
+                mediaPlayer.Hwnd = IntPtr.Zero;
             }
         }
 
@@ -144,10 +160,11 @@ namespace LibVLCSharp.WPF
                 {
                     if (MediaPlayer != null)
                     {
-                        MediaPlayer.Hwnd = IntPtr.Zero;
+                        DetachMediaPlayer(MediaPlayer);
                     }
 
-                    WindowsFormsHost?.Dispose();
+                    _videoHwndHost?.Dispose();
+                    _videoHwndHost = null;
                     ForegroundWindow?.Close();
                 }
 


### PR DESCRIPTION
### Description of Change ###

- Remove WinFormsHost from the WPF and create a win32 window and pass it to the MediaPlayer by taking advantage of HwndHost (https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/walkthrough-hosting-a-win32-control-in-wpf)
- Hide this HwndHost when MediaPlayer stopped to don't see the win32's window background and see WPF window background.



### Platforms Affected ### 
- WPF

