### PR TITLE
mediatrack: Use old Id if new StrId API is not used

### DIFF
--- a/src/LibVLCSharp/Structures/MediaTrack.cs
+++ b/src/LibVLCSharp/Structures/MediaTrack.cs
@@ -174,6 +174,10 @@ namespace LibVLCSharp
             Language = MediaTrackStructure.Language.FromUtf8();
             Description = MediaTrackStructure.Description.FromUtf8();
             Id = MediaTrackStructure.StrId.FromUtf8();
+            if(string.IsNullOrEmpty(Id))
+            {
+                Id = MediaTrackStructure.Id.ToString();
+            }
             Stable = MediaTrackStructure.IdStable;
             Name = MediaTrackStructure.Name.FromUtf8();
             Selected = MediaTrackStructure.Selected;


### PR DESCRIPTION
See https://code.videolan.org/videolan/vlc/-/commit/635ecd1f2b52f976b47b81b6433eec1328d2e880

"All libvlc deprecated functions/members will be removed before VLC 4.0
freeze." 

But the freeze has not happened yet, so we need to keep this working.
