### PR TITLE
Update sdks

### DIFF
--- a/buildsystem/base-template.yml
+++ b/buildsystem/base-template.yml
@@ -3,7 +3,7 @@ steps:
   displayName: 'Use .NET Core SDK'
   inputs:
     packageType: sdk
-    version: 6.0.100
+    version: 6.0.101
 
 - bash: |
    dotnet workload install android

--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -54,7 +54,7 @@ Task("Restore-NuGet-Packages")
 Task("unity")
     .Does(() =>
 {
-    DotNetCoreBuild($"../src/{solutionName}/{solutionName}.csproj", new DotNetCoreBuildSettings()
+    DotNetBuild($"../src/{solutionName}/{solutionName}.csproj", new DotNetBuildSettings()
     {
         Configuration = configuration,
         ArgumentCustomization = args => args.Append("/p:UNITY=true"),


### PR DESCRIPTION
> Warning: The alias DotNetCoreBuild has been made obsolete. DotNetCoreBuild is obsolete and will be removed in a future release. Use DotNetBuild instead.