### PR TITLE
build: workaround temporary xamarin apple toolchain regression

### DIFF
--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -36,6 +36,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <RootNamespace>LibVLCSharp</RootNamespace>
     <PackageId>LibVLCSharp</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoNFloatUsing Condition="$(DefineConstants.Contains('APPLE'))">true</NoNFloatUsing>
   </PropertyGroup>
   <!--Override TFMs when building from the LVS.Win32 solution-->
   <PropertyGroup Condition="$(Configuration.StartsWith('Win32'))">


### PR DESCRIPTION
We are already using .NET 6, and the CI started complaining recently anyway (cross-build mono issue, probably).

```
  D:\a\1\s\src\LibVLCSharp\obj\Release\net6.0-macos\LibVLCSharp.GlobalUsings.g.cs(2,1): error CS8773: Feature 'global using directive' is not available in C# 9.0. Please use language version 10.0 or greater. [D:\a\1\s\src\LibVLCSharp\LibVLCSharp.csproj]
```
