### PR TITLE
Revert "build: try workaround xamarin macios toolchain regression"

### DIFF
--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -36,7 +36,6 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <RootNamespace>LibVLCSharp</RootNamespace>
     <PackageId>LibVLCSharp</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoNFloatUsing Condition="$(DefineConstants.Contains('APPLE'))">true</NoNFloatUsing>
   </PropertyGroup>
   <!--Override TFMs when building from the LVS.Win32 solution-->
   <PropertyGroup Condition="$(Configuration.StartsWith('Win32'))">


### PR DESCRIPTION
This reverts commit 6b2665fee4941cf5da6a92574e2798c41feb456e. Toolchain has been fixed.