### PR TITLE
dialog: split error callback

### DIFF
--- a/samples/Forms/LibVLCSharp.Forms.Sample.GTK/LibVLCSharp.Forms.Sample.GTK.csproj
+++ b/samples/Forms/LibVLCSharp.Forms.Sample.GTK/LibVLCSharp.Forms.Sample.GTK.csproj
@@ -6,7 +6,7 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.2" />
     <ProjectReference Include="..\..\..\src\LibVLCSharp.Forms.Platforms.GTK\LibVLCSharp.Forms.Platforms.GTK.csproj" />
     <ProjectReference Include="..\LibVLCSharp.Forms.Sample\LibVLCSharp.Forms.Sample.csproj" />

--- a/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
+++ b/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.7" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/LibVLCSharp.CustomRendering.Direct3D11/LibVLCSharp.CustomRendering.Direct3D11.csproj
+++ b/samples/LibVLCSharp.CustomRendering.Direct3D11/LibVLCSharp.CustomRendering.Direct3D11.csproj
@@ -23,7 +23,7 @@
   
   <ItemGroup>
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.19041-beta2-643406799" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibVLCSharp\LibVLCSharp.csproj" />

--- a/samples/LibVLCSharp.Eto.Sample/LibVLCSharp.Eto.Sample.csproj
+++ b/samples/LibVLCSharp.Eto.Sample/LibVLCSharp.Eto.Sample.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="('$(BuildPlatform)'=='Windows') Or ('$(BuildPlatform)'=='Wpf')" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Condition="('$(BuildPlatform)'=='Windows') Or ('$(BuildPlatform)'=='Wpf')" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
     <PackageReference Condition="('$(BuildPlatform)'=='Mac64') Or ('$(BuildPlatform)'=='XamMac2')" Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
     <!--
     <PackageReference Condition="'$(BuildPlatform)'=='Gtk'" Include= ... https://code.videolan.org/videolan/LibVLCSharp/-/blob/3.x/docs/linux-setup.md

--- a/samples/LibVLCSharp.GTK.Sample/LibVLCSharp.GTK.Sample.csproj
+++ b/samples/LibVLCSharp.GTK.Sample/LibVLCSharp.GTK.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.2" />
   </ItemGroup>
 

--- a/samples/LibVLCSharp.NetCore.Sample/LibVLCSharp.NetCore.Sample.csproj
+++ b/samples/LibVLCSharp.NetCore.Sample/LibVLCSharp.NetCore.Sample.csproj
@@ -10,7 +10,7 @@
     <NoNFloatUsing>true</NoNFloatUsing>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.3" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/LibVLCSharp.WPF.Sample/LibVLCSharp.WPF.Sample.csproj
+++ b/samples/LibVLCSharp.WPF.Sample/LibVLCSharp.WPF.Sample.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>LibVLCSharp.WPF.Sample</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibVLCSharp.WPF\LibVLCSharp.WPF.csproj" />

--- a/samples/LibVLCSharp.WinForms.Sample/LibVLCSharp.WinForms.Sample.csproj
+++ b/samples/LibVLCSharp.WinForms.Sample/LibVLCSharp.WinForms.Sample.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworks>netcoreapp3.1;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibVLCSharp.WinForms\LibVLCSharp.WinForms.csproj" />

--- a/samples/LibVLCSharp.Windows.Net45.Sample/LibVLCSharp.Windows.Net45.Sample.csproj
+++ b/samples/LibVLCSharp.Windows.Net45.Sample/LibVLCSharp.Windows.Net45.Sample.csproj
@@ -5,7 +5,7 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20200819" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibVLCSharp\LibVLCSharp.csproj" />

--- a/src/LibVLCSharp.Tests/DialogTests.cs
+++ b/src/LibVLCSharp.Tests/DialogTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Threading.Tasks;
-using LibVLCSharp;
+﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace LibVLCSharp.Tests
@@ -18,18 +18,17 @@ namespace LibVLCSharp.Tests
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            _libVLC.SetDialogHandlers((title, text) => Task.CompletedTask,
-                (dialog, title, text, username, store, token) =>
-                {
-                    // show UI dialog
-                    // On "OK" call PostLogin
-                    dialog.PostLogin(Username, Password, false);
-                    tcs.TrySetResult(true);
-                    return Task.CompletedTask;
-                },
-                (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
-                (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
-                (dialog, position, text) => Task.CompletedTask);
+            _libVLC.SetDialogHandlers((dialog, title, text, username, store, token) =>
+            {
+                // show UI dialog
+                // On "OK" call PostLogin
+                dialog.PostLogin(Username, Password, false);
+                tcs.TrySetResult(true);
+                return Task.CompletedTask;
+            },
+            (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
+            (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
+            (dialog, position, text) => Task.CompletedTask);
 
             var mp = new MediaPlayer(_libVLC)
             {
@@ -49,17 +48,16 @@ namespace LibVLCSharp.Tests
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            _libVLC.SetDialogHandlers((title, text) => Task.CompletedTask,
-                (dialog, title, text, username, store, token) =>
-                {
-                    dialog.PostLogin(Username, Password, false);
-                    Assert.Throws<VLCException>(() => dialog.PostLogin(Username, Password, false), "Calling method on dismissed Dialog instance");
-                    tcs.TrySetResult(true);
-                    return Task.CompletedTask;
-                },
-                (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
-                (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
-                (dialog, position, text) => Task.CompletedTask);
+            _libVLC.SetDialogHandlers((dialog, title, text, username, store, token) =>
+            {
+                dialog.PostLogin(Username, Password, false);
+                Assert.Throws<VLCException>(() => dialog.PostLogin(Username, Password, false), "Calling method on dismissed Dialog instance");
+                tcs.TrySetResult(true);
+                return Task.CompletedTask;
+            },
+            (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
+            (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
+            (dialog, position, text) => Task.CompletedTask);
 
             var mp = new MediaPlayer(_libVLC)
             {
@@ -79,19 +77,18 @@ namespace LibVLCSharp.Tests
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            _libVLC.SetDialogHandlers((title, text) => Task.CompletedTask,
-                (dialog, title, text, username, store, token) =>
-                {
-                    var result = dialog.Dismiss();
-                    Assert.IsTrue(result);
-                    result = dialog.Dismiss();
-                    Assert.IsFalse(result);
-                    tcs.TrySetResult(true);
-                    return Task.CompletedTask;
-                },
-                (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
-                (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
-                (dialog, position, text) => Task.CompletedTask);
+            _libVLC.SetDialogHandlers((dialog, title, text, username, store, token) =>
+            {
+                var result = dialog.Dismiss();
+                Assert.IsTrue(result);
+                result = dialog.Dismiss();
+                Assert.IsFalse(result);
+                tcs.TrySetResult(true);
+                return Task.CompletedTask;
+            },
+            (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
+            (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
+            (dialog, position, text) => Task.CompletedTask);
 
             var mp = new MediaPlayer(_libVLC)
             {
@@ -107,8 +104,7 @@ namespace LibVLCSharp.Tests
         [Test]
         public void ShouldUnsetDialogHandlersWhenInstanceDisposed()
         {
-            _libVLC.SetDialogHandlers((title, text) => Task.CompletedTask,
-                (dialog, title, text, username, store, token) => Task.CompletedTask,
+            _libVLC.SetDialogHandlers((dialog, title, text, username, store, token) => Task.CompletedTask,
                 (dialog, title, text, type, cancelText, actionText, secondActionText, token) => Task.CompletedTask,
                 (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
                 (dialog, position, text) => Task.CompletedTask);
@@ -118,6 +114,29 @@ namespace LibVLCSharp.Tests
             _libVLC.Dispose();
 
             Assert.False(_libVLC.DialogHandlersSet);
+        }
+
+        [Test]
+        public async Task ShouldRaiseErrorCallback()
+        {
+            const string errorUrl = "https://zzz.mp4";
+            var tcs = new TaskCompletionSource<bool>();
+
+            _libVLC.SetErrorDialogCallback(DisplayError);
+            using var media = new Media(_libVLC, new Uri(errorUrl));
+            using var mp = new MediaPlayer(media);
+            mp.Play();
+
+            Task DisplayError(string title, string error)
+            {
+                Assert.AreEqual(title, "Your input can't be opened");
+                Assert.AreEqual(error, $"VLC is unable to open the MRL '{errorUrl}/'. Check the log for details.");
+                tcs.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+
+            await tcs.Task;
+            Assert.True(tcs.Task.Result);
         }
     }
 }

--- a/src/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
+++ b/src/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="NUnitLite" Version="3.13.2" />
-    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220117" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20220509" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />

--- a/src/LibVLCSharp.Tests/LibVLCTests.cs
+++ b/src/LibVLCSharp.Tests/LibVLCTests.cs
@@ -103,8 +103,7 @@ namespace LibVLCSharp.Tests
         [Test]
         public void DisposeLibVLC()
         {
-            _libVLC.SetDialogHandlers((title, text) => Task.CompletedTask,
-                (dialog, title, text, defaultUsername, askStore, token) => Task.CompletedTask,
+            _libVLC.SetDialogHandlers((dialog, title, text, defaultUsername, askStore, token) => Task.CompletedTask,
                 (dialog, title, text, type, cancelText, firstActionText, secondActonText, token) => Task.CompletedTask,
                 (dialog, title, text, indeterminate, position, cancelText, token) => Task.CompletedTask,
                 (dialog, position, text) => Task.CompletedTask);


### PR DESCRIPTION
Updating to match https://code.videolan.org/videolan/vlc/-/commit/211baa3ffee2380ea8adba35f164a3ecd11bc69c.

To able to test:
- https://code.videolan.org/videolan/vlc/-/merge_requests/1864 needs to be merged.
- the nightly build needs to be fixed (e.g. libvlcpp updated to match new API) so we can easily try from VS.
- might want to add a unit test.