### PR TITLE
CI: workaround VS 17.3.5 bug for missing xamarin.mac binaries

### DIFF
--- a/samples/Forms/LibVLCSharp.Forms.Sample.Mac/LibVLCSharp.Forms.Sample.Mac.csproj
+++ b/samples/Forms/LibVLCSharp.Forms.Sample.Mac/LibVLCSharp.Forms.Sample.Mac.csproj
@@ -72,7 +72,6 @@
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Xamarin.Forms.3.2.0.871581\lib\Xamarin.Mac\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
@@ -128,4 +127,9 @@
   </Target>
   <Import Project="..\..\..\packages\Xamarin.Forms.3.2.0.871581\build\netstandard2.0\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.3.2.0.871581\build\netstandard2.0\Xamarin.Forms.targets')" />
   <Import Project="..\..\..\packages\VideoLAN.LibVLC.Mac.3.1.3.1\build\VideoLAN.LibVLC.Mac.targets" Condition="Exists('..\..\..\packages\VideoLAN.LibVLC.Mac.3.1.3.1\build\VideoLAN.LibVLC.Mac.targets')" />
+  <ItemGroup>
+    <Reference Include="Xamarin.Mac">
+      <HintPath Condition="$([MSBuild]::IsOsPlatform('Windows'))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/src/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
+++ b/src/LibVLCSharp.Forms/LibVLCSharp.Forms.csproj
@@ -47,4 +47,9 @@ Xamarin.Forms support for GTK and WPF are in separate packages. LibVLC needs to 
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('xamarin.mac')) And $([MSBuild]::IsOsPlatform('Windows'))">
+    <Reference Include="Xamarin.Mac">
+      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -80,6 +80,11 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <ItemGroup Condition="'$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('xamarin.mac')) And $([MSBuild]::IsOsPlatform('Windows'))">
+    <Reference Include="Xamarin.Mac">
+      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <Target Name="IncludeAWindow" Condition="$(TargetFramework.Contains('android'))">
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)LibVLCSharp.Android.AWindow.dll" />


### PR DESCRIPTION
to revert next month when new VS build is shipped to the CI agents https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443