### PR TITLE
CI: update gtk msi download url

### DIFF
--- a/buildsystem/windows-build.yml
+++ b/buildsystem/windows-build.yml
@@ -6,7 +6,7 @@ steps:
     targetType: 'inline'
     script: |
       $msiFile = "gtk-sharp-2.12.45.msi"
-      Invoke-WebRequest "https://xamarin.azureedge.net/GTKforWindows/Windows/$msiFile" -OutFile $msiFile
+      Invoke-WebRequest "https://github.com/mfkl/gtk-sharp-msi/raw/main/$msiFile" -OutFile $msiFile
       $arguments = "/i `"$msiFile`" /quiet"
       Start-Process msiexec.exe -ArgumentList $arguments -Wait
 


### PR DESCRIPTION
Not great but the original download link is 404.
gtk-sharp 2.x won't be receiving any update anyway. 

Will fix the CI for now, happy to revert when the original link is fixed (winget, chocolatey, etc all failing as they rely on it too).