### PR TITLE
596 - removed x11 dependency and updated documentation

### DIFF
--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -25,5 +25,47 @@ For ubuntu:
 
 ## For other platforms
 
+If you are using the *X Window System*, it has to be initialized for multithreading support and this requires you to natively import `libx11`.
+
 If your application doesn't find `libX11.so`, you may need to install the `libx11-dev` package :
 > `sudo apt install libx11-dev`
+
+Code example:
+```c#
+using System.Runtime.InteropServices;
+
+namespace myApp;
+
+public static class ImportHelper
+{
+    public struct Native
+    {
+        /// <summary>
+        /// Initializes the X threading system
+        /// </summary>
+        /// <remarks>Linux X11 only</remarks>
+        /// <returns>non-zero on success, zero on failure</returns>
+        [DllImport("libX11", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int XInitThreads();
+
+    }
+}
+
+```
+
+Usage:
+
+```c#
+// initialize multithreading support
+ImportHelper.Native.XInitThreads();
+
+
+// player initialization
+using var libvlc = new LibVLC(enableDebugLogs: true);
+using var media = new Media(libvlc, new Uri(@"C:\tmp\big_buck_bunny.mp4"));
+using var mediaplayer = new MediaPlayer(media);
+
+mediaplayer.Play();
+
+Console.ReadKey();
+```

--- a/src/LibVLCSharp/Shared/Core/Constants.cs
+++ b/src/LibVLCSharp/Shared/Core/Constants.cs
@@ -22,7 +22,6 @@ namespace LibVLCSharp.Shared
         internal const string Libc = "libc";
         internal const string LibSystem = "libSystem";
         internal const string Kernel32 = "kernel32";
-        internal const string LibX11 = "libX11";
         internal const string WindowsLibraryExtension = ".dll";
         internal const string MacLibraryExtension = ".dylib";
         internal const string Lib = "lib";

--- a/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.Desktop.cs
@@ -16,14 +16,6 @@ namespace LibVLCSharp.Shared
     {
         partial struct Native
         {
-            /// <summary>
-            /// Initializes the X threading system
-            /// </summary>
-            /// <remarks>Linux X11 only</remarks>
-            /// <returns>non-zero on success, zero on failure</returns>
-            [DllImport(Constants.LibX11, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern int XInitThreads();
-
             [DllImport(Constants.Kernel32, SetLastError = true)]
             internal static extern ErrorModes SetErrorMode(ErrorModes uMode);
         }
@@ -78,11 +70,6 @@ namespace LibVLCSharp.Shared
                 {
                     throw new InvalidOperationException($"Using {nameof(libvlcDirectoryPath)} is not supported on the Linux platform. " +
                         $"The recommended way is to have the libvlc librairies in /usr/lib. Use LD_LIBRARY_PATH if you need more customization");
-                }
-                // Initializes X threads before calling VLC. This is required for vlc plugins like the VDPAU hardware acceleration plugin.
-                if (Native.XInitThreads() == 0)
-                {
-                    Debug.WriteLine("XInitThreads failed");
                 }
                 return;
             }

--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -195,7 +195,6 @@ namespace LibVLCSharp.Shared
         /// and where applicable:
         /// <para>- setlocale() and textdomain(),</para>
         /// <para>- setenv(), unsetenv() and putenv(),</para>
-        /// <para>- with the X11 display system, XInitThreads()</para>
         /// (see also libvlc_media_player_set_xwindow()) and
         /// <para>- on Microsoft Windows, SetErrorMode().</para>
         /// <para>- sigprocmask() shall never be invoked; pthread_sigmask() can be used.</para>
@@ -251,7 +250,6 @@ namespace LibVLCSharp.Shared
         /// and where applicable:
         /// <para>- setlocale() and textdomain(),</para>
         /// <para>- setenv(), unsetenv() and putenv(),</para>
-        /// <para>- with the X11 display system, XInitThreads()</para>
         /// (see also libvlc_media_player_set_xwindow()) and
         /// <para>- on Microsoft Windows, SetErrorMode().</para>
         /// <para>- sigprocmask() shall never be invoked; pthread_sigmask() can be used.</para>


### PR DESCRIPTION
### Description of Change ###

Removed x11 dependency / rework linux init to prevent errors when x11 is not used (e.g. on Wayland only environments)

### Issues Resolved ### 

- fixes #596



### API Changes ###
 
 None

### Platforms Affected ### 

- Linux

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Run the default media player example on a Wayland only system
- Use the code from the updated documentation to run the default media player example on an X11 system

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
