### PR TITLE
libvlc: add libvlc clock binding

### DIFF
--- a/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
+++ b/src/LibVLCSharp.Tests/LibVLCAPICoverage.cs
@@ -92,7 +92,7 @@ namespace LibVLCSharp.Tests
             // not implemented symbols for lack of use case or user interest
             var notImplementedOnPurpose = new List<string>
             {
-                "libvlc_printerr", "libvlc_vprinterr", "libvlc_clock", "libvlc_dialog_get_context", "libvlc_dialog_set_context",
+                "libvlc_printerr", "libvlc_vprinterr", "libvlc_dialog_get_context", "libvlc_dialog_set_context",
                 "libvlc_event_type_name", "libvlc_log_get_object", "libvlc_vlm", "libvlc_media_list_player", "libvlc_media_library"
             };
 

--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -179,6 +179,9 @@ namespace LibVLCSharp.Shared
                 EntryPoint = "libvlc_get_compiler")]
             internal static extern IntPtr LibVLCGetCompiler();
 
+            [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
+                EntryPoint = "libvlc_clock")]
+            internal static extern long LibVLCClock();
 #if ANDROID
             [DllImport(Constants.LibraryName, CallingConvention = CallingConvention.Cdecl,
                 EntryPoint = "libvlc_media_player_set_android_context")]
@@ -764,6 +767,14 @@ namespace LibVLCSharp.Shared
         /// Example: "gcc version 4.2.3 (Ubuntu 4.2.3-2ubuntu6)"
         /// </summary>
         public string LibVLCCompiler => Native.LibVLCGetCompiler().FromUtf8()!;
+
+        /// <summary>
+        /// Return the current time as defined by LibVLC. The unit is the microsecond.
+        /// Time increases monotonically (regardless of time zone changes and RTC adjustments).
+        /// The origin is arbitrary but consistent across the whole system (e.g. the system uptime, the time since the system was booted).
+        /// On systems that support it, the POSIX monotonic clock is used.
+        /// </summary>
+        public long Clock => Native.LibVLCClock();
 
         #region Exit
 


### PR DESCRIPTION
### Description of Change ###

add libvlc clock binding. it could be useful for audio callbacks implementations 

### Issues Resolved ### 

- fixes https://github.com/mfkl/libvlcsharp-samples/issues/206

### API Changes ###

Added:
 - long Clock { get; } 

### Platforms Affected ### 

- Core (all platforms)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
