### PR TITLE
Add support for iOS and MacOS for the Unity support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants>$(DefineConstants);UNITY</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(UNITY_IOS)=='true'">
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);UNITY_IOS</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="!$(DefineConstants.Contains('ANDROID')) and !$(DefineConstants.Contains('APPLE')) and !$(DefineConstants.Contains('UWP'))">
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(UNITY_IOS)=='true'">
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>$(DefineConstants);UNITY_IOS</DefineConstants>
+    <DefineConstants>$(DefineConstants);UNITY_IOS;UNITY</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="!$(DefineConstants.Contains('ANDROID')) and !$(DefineConstants.Contains('APPLE')) and !$(DefineConstants.Contains('UWP'))">
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>

--- a/src/LibVLCSharp/Core/Constants.cs
+++ b/src/LibVLCSharp/Core/Constants.cs
@@ -8,10 +8,17 @@ namespace LibVLCSharp
         internal const string LibraryName = "@rpath/DynamicMobileVLCKit.framework/DynamicMobileVLCKit";
 #elif TVOS
         internal const string LibraryName = "@rpath/TVVLCKit.framework/TVVLCKit";
+#elif UNITY_IOS
+        internal const string LibraryName = "@rpath/vlc.framework/vlc";
 #else
         internal const string LibraryName = "libvlc";
 #endif
+
+#if UNITY_IOS
+        internal const string CoreLibraryName = "@rpath/vlccore.framework/vlccore";
+#else
         internal const string CoreLibraryName = "libvlccore";
+#endif
 
         /// <summary>
         /// The name of the folder that contains the per-architecture folders
@@ -26,7 +33,11 @@ namespace LibVLCSharp
         internal const string MacLibraryExtension = ".dylib";
         internal const string Lib = "lib";
         internal const string LibVLC = "libvlc";
+#if UNITY_IOS
+        internal const string UnityPlugin = "@rpath/VLCUnityPlugin.framework/VLCUnityPlugin";
+#else
         internal const string UnityPlugin = "VLCUnityPlugin";
+#endif
     }
 
     internal static class ArchitectureNames

--- a/src/LibVLCSharp/Core/Core.Unity.cs
+++ b/src/LibVLCSharp/Core/Core.Unity.cs
@@ -34,10 +34,14 @@ namespace LibVLCSharp
             }
 
             if (PlatformHelper.IsMac)
-                Native.SetPluginPath(libvlcDirectoryPath! + "/VLCUnity/Plugins/MacOS/x86_64/vlc/plugins/" + ":" + libvlcDirectoryPath! + "/PlugIns/");
+            {
+                var arch = PlatformHelper.IsArm64BitProcess ? "arm64" : "x86_64";
+                Native.SetPluginPath($"{libvlcDirectoryPath!}/VLCUnity/Plugins/macOS/{arch}/vlc/plugins/:{libvlcDirectoryPath!}/PlugIns/");
+            }
             else
+            {
                 Native.SetPluginPath(libvlcDirectoryPath!);
-
+            }
             libvlcDirectoryPath = $"{libvlcDirectoryPath}\\Plugins";
 
             InitializeDesktop(libvlcDirectoryPath);

--- a/src/LibVLCSharp/Core/Core.Unity.cs
+++ b/src/LibVLCSharp/Core/Core.Unity.cs
@@ -24,7 +24,9 @@ namespace LibVLCSharp
         /// <exception cref="VLCException"></exception>
         internal static void InitializeUnity(string? libvlcDirectoryPath = null)
         {
-            if(!PlatformHelper.IsWindows) return; // only VLC for Unity on Windows currently requires pre-initialization logic
+            // only VLC for Unity on Windows and MacOS currently requires pre-initialization logic
+            if(!PlatformHelper.IsWindows && !PlatformHelper.IsMac)
+              return;
 
             if(string.IsNullOrEmpty(libvlcDirectoryPath))
             {

--- a/src/LibVLCSharp/Core/Core.Unity.cs
+++ b/src/LibVLCSharp/Core/Core.Unity.cs
@@ -33,7 +33,10 @@ namespace LibVLCSharp
                 throw new VLCException("Please provide UnityEngine.Application.dataPath to Core.Initialize for proper initialization.");
             }
 
-            Native.SetPluginPath(libvlcDirectoryPath!);
+            if (PlatformHelper.IsMac)
+                Native.SetPluginPath(libvlcDirectoryPath! + "/VLCUnity/Plugins/MacOS/x86_64/vlc/plugins/" + ":" + libvlcDirectoryPath! + "/PlugIns/");
+            else
+                Native.SetPluginPath(libvlcDirectoryPath!);
 
             libvlcDirectoryPath = $"{libvlcDirectoryPath}\\Plugins";
 

--- a/src/LibVLCSharp/Helpers/PlatformHelper.cs
+++ b/src/LibVLCSharp/Helpers/PlatformHelper.cs
@@ -64,5 +64,12 @@ namespace LibVLCSharp
         /// Returns true if running in 64bit process, false otherwise
         /// </summary>
         public static bool IsX64BitProcess => IntPtr.Size == 8;
+
+#if !NET45
+        /// <summary>
+        /// Returns true if running in ARM64 process, false otherwise
+        /// </summary>
+        public static bool IsArm64BitProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+#endif
     }
 }


### PR DESCRIPTION

### Description of Change ###

These changes are changing the Constants and path for plugins when building for `/p:UNITY=true`. In the case of iOS, a `/p:UNITY_IOS=true` will be necessary to build the libVLCSharp assembly with the correct path constant for referencing the frameworks.

Note that `SetPluginPath` must be available . 

### Platforms Affected ### 

- Unity (iOS and macOS)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Use `buildsystem/build-unity.sh` to compile, and potentially add `/p:UNITY_IOS=true` to test the iOS part.

Unfortunately, testing that everything works correctly is a bit more tedious and require first some changes in thre videolan/vlc-unity project.

I'll update the MR with the adequate steps when the Unity parts are merged.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
