### PR TITLE
Fix a typo in MediaPlayer property name

### DIFF
--- a/src/LibVLCSharp/Shared/MediaPlayer.cs
+++ b/src/LibVLCSharp/Shared/MediaPlayer.cs
@@ -902,7 +902,7 @@ namespace LibVLCSharp.Shared
         /// <para></para>
         /// LibVLC 2.2.0 or later
         /// </summary>
-        public bool ProgramScambled => Native.LibVLCMediaPlayerProgramScrambled(NativeReference) != 0;
+        public bool ProgramScrambled => Native.LibVLCMediaPlayerProgramScrambled(NativeReference) != 0;
 
         /// <summary>
         /// Display the next frame (if supported)


### PR DESCRIPTION
### Description of Change ###
Fix a typo in ProgramScrambled property name. Master branch is also affected.

### API Changes ###
Changed:
 - MediaPlayer.ProgramScambled => MediaPlayer.ProgramScrambled

### Platforms Affected ### 
- Core (all platforms)
