### PR TITLE
Added Clear method, support for alpha

### DIFF
--- a/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
+++ b/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
@@ -205,7 +205,7 @@ namespace LibVLCSharp.Platforms.Windows
                     BufferCount = 2,
                     SwapEffect = SwapEffect.FlipSequential,
                     Flags = SwapChainFlags.None,
-                    AlphaMode = AlphaMode.Unspecified
+                    AlphaMode = AlphaMode.Premultiplied
                 };
 
                 _swapChain = new SharpDX.DXGI.SwapChain1(dxgiFactory, _d3D11Device, ref swapChainDescription);

--- a/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
+++ b/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
@@ -90,6 +90,22 @@ namespace LibVLCSharp.Platforms.Windows
         }
 
         /// <summary>
+        /// Clears the current view restoring the initial visual state.
+        /// This is a LibVLCSharp UWP-specific workaround for the following issue: https://code.videolan.org/videolan/vlc/-/issues/23667 
+        /// </summary>
+        public void Clear()
+        {
+            if (_loaded && _swapChain is not null && _deviceContext is not null)
+            {
+                using var backBuffer = _swapChain.GetBackBuffer<Texture2D>(0);
+                using var target = new RenderTargetView(_d3D11Device, backBuffer);
+
+                _deviceContext.ClearRenderTargetView(target, new RawColor4(0, 0, 0, 0));
+                _swapChain.Present(0, PresentFlags.None);
+            }
+        }
+
+        /// <summary>
         /// Gets the swapchain parameters to pass to the <see cref="LibVLC"/> constructor.
         /// If you don't pass them to the <see cref="LibVLC"/> constructor, the video won't
         /// be displayed in your application.


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

This PR adds a `Clear` method to the UWP/WinUI `VideoViewBase` that can be used to clear the underlying `SwapChain` to restore the original visual appearance.
This is needed as currently the D3D11 vout retains the last rendered frame after the playback is completed. While in many scenarios this is desirable, an alternative is still needed.

Additionally, this changes the SwapChain's `AlphaMode` from `Unspecified` to `Premultiplied`, so that `Clear` actually turns the VideoView actually transparent, and not black. (This is needed in my scenario and the initial VideoView is actually transparent and not black--let me know if this work for you too or we can find a different solution)

### API Changes ###

Added:
 - void VideoViewBase.Clear()

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

`SwapChain.AlphaMode` was changed, but by looking at `direct3d11.c#975`, this should have no effect on the actual video rendering, as the surface is always painted black before of any frame:
`ID3D11DeviceContext_ClearRenderTargetView(sys->d3d_dev.d3dcontext, sys->d3drenderTargetView, **blackRGBA**);`

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
