### PR TITLE
Update to Avalonia 11

### DIFF
--- a/samples/LibVLCSharp.Avalonia.Sample/App.xaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/App.xaml
@@ -7,7 +7,6 @@
     </Application.DataTemplates>
 
     <Application.Styles>
-        <StyleInclude Source="resm:Avalonia.Themes.Default.DefaultTheme.xaml?assembly=Avalonia.Themes.Default"/>
-        <StyleInclude Source="resm:Avalonia.Themes.Default.Accents.BaseLight.xaml?assembly=Avalonia.Themes.Default"/>
+    <FluentTheme />
     </Application.Styles>
 </Application>

--- a/samples/LibVLCSharp.Avalonia.Sample/App.xaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/App.xaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using Themes = Avalonia.Themes;
 using LibVLCSharp.Avalonia.Sample.ViewModels;
 using LibVLCSharp.Avalonia.Sample.Views;
 using LibVLCSharp.Shared;
@@ -26,9 +25,6 @@ namespace LibVLCSharp.Avalonia.Sample
 
                 desktop.Exit += OnExit;
             }
-
-            var theme = new Themes.Default.DefaultTheme();
-            theme.TryGetResource("Button", out _);
 
             base.OnFrameworkInitializationCompleted();
         }

--- a/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
+++ b/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
@@ -16,8 +16,9 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.14" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.4" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="3.0.16" />

--- a/samples/LibVLCSharp.Avalonia.Sample/ViewLocator.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/ViewLocator.cs
@@ -12,7 +12,7 @@ namespace LibVLCSharp.Avalonia.Sample
     {
         public bool SupportsRecycling => false;
 
-        public IControl Build(object data)
+        public Control Build(object data)
         {
             var name = data.GetType().FullName.Replace("ViewModel", "View");
             var type = Type.GetType(name);

--- a/src/LibVLCSharp.Avalonia/LibVLCSharp.Avalonia.csproj
+++ b/src/LibVLCSharp.Avalonia/LibVLCSharp.Avalonia.csproj
@@ -18,7 +18,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.
     <PackageTags>$(PackageTags);avalonia</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.7" />
+    <PackageReference Include="Avalonia" Version="11.0.4" />
     <ProjectReference Include="..\LibVLCSharp\LibVLCSharp.csproj" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

Update project LibVLCSharp.Avalonia to Avalonia 11.04
Due to the difference between the 10 and 11 versions of Avalonia, it was impossible to use the current version LibVLCSharp in 11 Avalonia

### API Changes ###

Update Package Version:
- Avalonia 0.10.7 => 11.0.4
- Avalonia.Desktop 0.10.14 => 11.0.4
- Avalonia.ReactiveUI 0.10.14 => 11.0.4

Adding new Package:
- Avalonia.Themes.Fluent 11.0.4 => LibVLCSharp.Avalonia.Sample

Changed in LibVLCSharp.Avalonia.Sample:
 - public IControl Build(object data) =>public Control Build(object data) // Because in version 11 interface IControl was removed
-  `<StyleInclude Source="resm:Avalonia.Themes.Default.DefaultTheme.xaml?assembly=Avalonia.Themes.Default"/><StyleInclude Source="resm:Avalonia.Themes.Default.Accents.BaseLight.xaml?assembly=Avalonia.Themes.Default"/>` => `<FluentTheme />`

Removed in LibVLCSharp.Avalonia.Sample:
- using Themes = Avalonia.Themes;  // Because it wasn't used for anything and contradicted version 11
- var theme = new Themes.Default.DefaultTheme(); // Because it wasn't used for anything and contradicted version 11
- theme.TryGetResource("Button", out _); // Because it wasn't used for anything and contradicted version 11

<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Avalonia

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
This change does not require special testing, since it only transfers the library to version 11 of Avalonia. You can use the tests that were carried out for Avalonia.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
