### PR TITLE
WPF ForegroundWindow: Support scaled video host

### DIFF
--- a/src/LibVLCSharp.WPF/README.md
+++ b/src/LibVLCSharp.WPF/README.md
@@ -58,6 +58,16 @@ The DataContext of the `VideoView` is propagated to your overlay content. This m
 
 *Note : This behavior is specific to the LibVLCSharp WPF implementation and is not (yet?) available to LibVLCSharp.Forms.Platforms.WPF*
 
+## WPF transforms support and limitations
+
+Applying layout and render transforms to the `VideoView` or one of its ancestors is partially supported by LibVLCSharp.WPF: 
+
+Translate transforms and uniform scale transforms are fully supported and correctly applied to the video and the overlay content. Using a `Viewbox` with a uniform stretch is also fully supported, as it is analogous to a uniform scale transform.
+
+Non-uniform scale transforms and negative scale factors (mirroring) have a limited support. That also applies to using a `Viewbox` with a non-uniform stretch.
+
+Other transforms (rotate, skew, ...) are currently not supported.
+
 ## Why should I reference this package in my project?
 
 If you want to create a video application using WPF and any supported .NET language, this package is made for you.


### PR DESCRIPTION
### Description of Change ###

Platform: WPF
Topic: Airspace issue and the `ForegroundWindow `workaround

`ForegroundWindow` now supports _scaled video host_. The sizing and scaling `ForegroundWindow` had to be fixed.

_Scaled video host_ means that a scale transformation has been applied to the `VideoView` or one of its ancestors up to the containing window. This is also the case when the WPF `Viewbox` is used.

We currently have two use cases for this fix: 
1. In our business WPF application, we apply a general scale transform to the root of the main window to scale up/down the UI. This is used to compensate potentially wrong DPI settings (Windows), but also to offer the user the possibility to choose a comfortable "zoom level" to work with, just like in modern web browsers.
2. We have multiple IP cameras and we want to display all of them on one screen, some of them are shown as thumbnails, the thumbnail uses a `Viewbox` to scale down the whole Control that contains the video (not only the `VideoView` itself).

### Issues Resolved ### 
No issue has been created for this matter.

Issue description: When `VideoView` is placed inside of a `Viewbox` or when a scale transformation affects `VideoView`, the video will be correctly scaled up/down. The `ForegroundWindow` however, will be correctly positioned at the top-left of the video but NOT correctly sized and scaled (see screenshots below).

### API Changes ###
 None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
None apart from described fix

### Before/After Screenshots ### 

For testing, I took `Example2.xaml`, wrapped `VideoView` in a `Viewbox`, added fixed `Width `and `Height` to `Viewbox` and added a semi-transparent background to the overlaid controls to be able to see the extent of the foreground window.

**Before**
![image](https://github.com/videolan/libvlcsharp/assets/20659254/36b44047-4b08-412e-b773-4a1d585280e7)
![image](https://github.com/videolan/libvlcsharp/assets/20659254/74fdba71-a087-401c-a5ea-5ef755159588)

**After**
![image](https://github.com/videolan/libvlcsharp/assets/20659254/dd4f5085-bb1e-4b2a-ac36-2405f466b1ff)
![image](https://github.com/videolan/libvlcsharp/assets/20659254/aace922f-f428-4b8b-990b-5afe2acb22ec)


### Testing Procedure ###
The changes only affect the platform WPF.

**Test case 1**
- Wrap `VideoView` or one of its ancestors in a `Viewbox`. Make sur to define `Width `and `Height` on `Viewbox`.
- Make sure `VideoView` has a foreground content (children of `VideoView`) with clearly visible bounds. For simplicity, just put a `Rectangle ` with a defined `Fill` and reduce the opacity to be able to see the background video.
- When the `Viewbox` is resized, the foreground content should also be correctly positioned and scaled.

**Test case 2**
- Instead of using a `Viewbox`, apply a `ScaleTransform` (as a `RenderTransform `or `Layout transform`) on `Viewbox` or one of its ancestors
- The foreground content should be correctly positioned and scaled


### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
