### PR TITLE
Avalonia VideoView fix

### DIFF
--- a/samples/LibVLCSharp.Avalonia.Sample/ViewModels/MainWindowViewModel.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Controls;
 using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.Avalonia.Sample.ViewModels
@@ -6,6 +7,9 @@ namespace LibVLCSharp.Avalonia.Sample.ViewModels
     public class MainWindowViewModel : ViewModelBase, IDisposable
     {
         private readonly LibVLC _libVlc = new LibVLC();
+        
+        public MediaPlayer MediaPlayer { get; }
+        
         public MainWindowViewModel()
         {
             MediaPlayer = new MediaPlayer(_libVlc);
@@ -13,12 +17,20 @@ namespace LibVLCSharp.Avalonia.Sample.ViewModels
 
         public void Play()
         {
+            if (Design.IsDesignMode)
+            {
+                return;
+            }
+            
             using var media = new Media(_libVlc, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
             MediaPlayer.Play(media);
         }
-
-        public MediaPlayer MediaPlayer { get; }
-
+        
+        public void Stop()
+        {            
+            MediaPlayer.Stop();
+        }
+   
         public void Dispose()
         {
             MediaPlayer?.Dispose();

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml
@@ -1,22 +1,11 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="clr-namespace:LibVLCSharp.Avalonia.Sample.ViewModels;assembly=LibVLCSharp.Avalonia.Sample"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:v="clr-namespace:LibVLCSharp.Avalonia.Sample.Views"
-        xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="LibVLCSharp.Avalonia.Sample.Views.MainWindow"
         Icon="/Assets/avalonia-logo.ico"
-        Title="LibVLCSharp.Avalonia.Sample"
-        Opened="OnOpened">
-
-    <Design.DataContext>
-        <vm:MainWindowViewModel />
-    </Design.DataContext>
-
-    <Panel>
-        <vlc:VideoView MediaPlayer="{Binding MediaPlayer}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-    </Panel>
-
+        Title="LibVLCSharp.Avalonia.Sample">
+    <v:VideoPlayer />
 </Window>

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml.cs
@@ -1,7 +1,5 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using LibVLCSharp.Avalonia.Sample.ViewModels;
-using System;
 
 namespace LibVLCSharp.Avalonia.Sample.Views
 {
@@ -16,12 +14,5 @@ namespace LibVLCSharp.Avalonia.Sample.Views
         {
             AvaloniaXamlLoader.Load(this);
         }
-
-        private void OnOpened(object sender, EventArgs e)
-        {
-            var vm = DataContext as MainWindowViewModel;
-            vm?.Play();
-        }
-                    
     }
 }

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
@@ -1,0 +1,27 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"
+             xmlns:viewModels="clr-namespace:LibVLCSharp.Avalonia.Sample.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="LibVLCSharp.Avalonia.Sample.Views.VideoPlayer"
+             DataContextChanged="OnDataContextChanged">
+
+    <Design.DataContext>
+        <viewModels:MainWindowViewModel />
+    </Design.DataContext>
+
+    <Grid RowDefinitions="Auto, *, Auto">
+        <Label Grid.Row="0" HorizontalAlignment="Center">Video Player</Label>
+
+        <vlc:VideoView Grid.Row="1" MediaPlayer="{Binding MediaPlayer}"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch" />
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="20" Margin="20" HorizontalAlignment="Center">
+            <Button Command="{Binding Play}">Play</Button>
+            <Button Command="{Binding Stop}">Stop</Button>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Avalonia.Controls;
+using LibVLCSharp.Avalonia.Sample.ViewModels;
+
+namespace LibVLCSharp.Avalonia.Sample.Views
+{
+    public partial class VideoPlayer : UserControl
+    {
+        public VideoPlayer()
+        {
+            InitializeComponent();
+        }
+
+        private void OnDataContextChanged(object sender, EventArgs e)
+        {
+            if (DataContext is MainWindowViewModel vm)
+            {
+                vm.Play();
+            }
+        }
+    }
+}

--- a/src/LibVLCSharp.Avalonia/VideoView.cs
+++ b/src/LibVLCSharp.Avalonia/VideoView.cs
@@ -47,6 +47,12 @@ namespace LibVLCSharp.Avalonia
                 Attach();
             }
         }
+        
+        /// <inheritdoc />
+        public VideoView()
+        {
+            Initialized += (_, _) => { Attach(); };
+        }
 
         private void Attach()
         {
@@ -90,12 +96,6 @@ namespace LibVLCSharp.Avalonia
         protected override IPlatformHandle CreateNativeControlCore(IPlatformHandle parent)
         {
             _platformHandle = base.CreateNativeControlCore(parent);
-
-            if (_mediaPlayer == null)
-                return _platformHandle;
-
-            Attach();
-
             return _platformHandle;
         }
 


### PR DESCRIPTION
### Description of Change ###

In `VideoView` `MediaPlayer` handle was not properly assigned when using it in windows child component (eg. user control).
This caused MediaPlayer to popout to separate window. 

Added Initialized event handler that calls `Attach()` when control is initialized. 
Removed unnecessary Attach call from  `CreateNativeControlCore`. 

Updated **Avalonia.Sample** so that VideoView is displayed through user control and added play and stop buttons.

### Issues Resolved ### 
- fixes #525

### API Changes ###
 None

### Platforms Affected ### 
- Avalonia

### Behavioral/Visual Changes ###
- Avalonia VideoView works properly in child controls

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
- Tested using Avalonia sample with windows desktop environment
 
### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
