### PR TITLE
Avalonia: Child content support for VideoView

### DIFF
--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
@@ -17,11 +17,15 @@
 
         <vlc:VideoView Grid.Row="1" MediaPlayer="{Binding MediaPlayer}"
                        HorizontalAlignment="Stretch"
-                       VerticalAlignment="Stretch" />
-
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="20" Margin="20" HorizontalAlignment="Center">
-            <Button Command="{Binding Play}">Play</Button>
-            <Button Command="{Binding Stop}">Stop</Button>
-        </StackPanel>
+                       VerticalAlignment="Stretch"
+                       PointerEntered="VideoViewOnPointerEntered"
+                       PointerExited="VideoViewOnPointerExited">
+            <Panel Name="ControlsPanel">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Background="#900000FF" Spacing="20">
+                    <Button Command="{Binding Play}" Margin="20">Play</Button>
+                    <Button Command="{Binding Stop}" Margin="20">Stop</Button>
+                </StackPanel>
+            </Panel>
+        </vlc:VideoView>
     </Grid>
 </UserControl>

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Controls;
+using Avalonia.Input;
 using LibVLCSharp.Avalonia.Sample.ViewModels;
 
 namespace LibVLCSharp.Avalonia.Sample.Views
@@ -17,6 +18,16 @@ namespace LibVLCSharp.Avalonia.Sample.Views
             {
                 vm.Play();
             }
+        }
+
+        private void VideoViewOnPointerEntered(object sender, PointerEventArgs e)
+        {
+            ControlsPanel.IsVisible = true;
+        }
+
+        private void VideoViewOnPointerExited(object sender, PointerEventArgs e)
+        {
+            ControlsPanel.IsVisible = false;
         }
     }
 }

--- a/src/LibVLCSharp.Avalonia/VideoView.cs
+++ b/src/LibVLCSharp.Avalonia/VideoView.cs
@@ -3,7 +3,12 @@ using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Metadata;
 using Avalonia.Platform;
+using Avalonia.VisualTree;
 using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.Avalonia
@@ -15,6 +20,7 @@ namespace LibVLCSharp.Avalonia
     {
         private IPlatformHandle? _platformHandle = null;
         private MediaPlayer? _mediaPlayer = null;
+        private Window? _floatingContent = null;
 
         /// <summary>
         /// MediaPlayer Data Bound property
@@ -28,6 +34,12 @@ namespace LibVLCSharp.Avalonia
                 o => o.MediaPlayer,
                 (o, v) => o.MediaPlayer = v,
                 defaultBindingMode: BindingMode.TwoWay);
+
+        /// <summary>
+        /// Defines the <see cref="Content"/> property.
+        /// </summary>
+        public static readonly StyledProperty<object?> ContentProperty =
+            AvaloniaProperty.Register<VideoView, object?>(nameof(Content));
 
         /// <summary>
         /// Gets or sets the MediaPlayer that will be displayed.
@@ -47,16 +59,97 @@ namespace LibVLCSharp.Avalonia
                 Attach();
             }
         }
-        
+
+        /// <summary>
+        /// Gets or sets the content to display.
+        /// </summary>
+        [Content]
+        public object? Content
+        {
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
+        }
+
         /// <inheritdoc />
         public VideoView()
         {
             Initialized += (_, _) => { Attach(); };
+            ContentProperty.Changed.AddClassHandler<VideoView>((s, _) => s.InitializeNativeOverlay());
+            IsVisibleProperty.Changed.AddClassHandler<VideoView>((s, _) => s.ShowNativeOverlay(s.IsVisible));
+        }
+
+        private void UpdateOverlayPosition()
+        {
+            if (_floatingContent == null)
+                return;
+
+            bool forceSetWidth = false, forceSetHeight = false;
+            var topLeft = new Point();
+            var child = _floatingContent.Presenter?.Child;
+
+            if (child?.IsArrangeValid == true)
+            {
+                switch (child.HorizontalAlignment)
+                {
+                    case HorizontalAlignment.Right:
+                        topLeft = topLeft.WithX(Bounds.Width - _floatingContent.Bounds.Width);
+                        break;
+                    case HorizontalAlignment.Center:
+                        topLeft = topLeft.WithX((Bounds.Width - _floatingContent.Bounds.Width) / 2);
+                        break;
+                    case HorizontalAlignment.Stretch:
+                        forceSetWidth = true;
+                        break;
+                    case HorizontalAlignment.Left:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                switch (child.VerticalAlignment)
+                {
+                    case VerticalAlignment.Bottom:
+                        topLeft = topLeft.WithY(Bounds.Height - _floatingContent.Bounds.Height);
+                        break;
+                    case VerticalAlignment.Center:
+                        topLeft = topLeft.WithY((Bounds.Height - _floatingContent.Bounds.Height) / 2);
+                        break;
+                    case VerticalAlignment.Stretch:
+                        forceSetHeight = true;
+                        break;
+                    case VerticalAlignment.Top:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            if (forceSetWidth && forceSetHeight)
+                _floatingContent.SizeToContent = SizeToContent.Manual;
+            else if (forceSetHeight)
+                _floatingContent.SizeToContent = SizeToContent.Width;
+            else if (forceSetWidth)
+                _floatingContent.SizeToContent = SizeToContent.Height;
+            else
+                _floatingContent.SizeToContent = SizeToContent.Manual;
+
+            _floatingContent.Width = forceSetWidth ? Bounds.Width : double.NaN;
+            _floatingContent.Height = forceSetHeight ? Bounds.Height : double.NaN;
+
+            _floatingContent.MaxWidth = Bounds.Width;
+            _floatingContent.MaxHeight = Bounds.Height;
+
+            var newPosition = this.PointToScreen(topLeft);
+
+            if (newPosition != _floatingContent.Position)
+            {
+                _floatingContent.Position = newPosition;
+            }
         }
 
         private void Attach()
         {
-            if(_mediaPlayer == null || _platformHandle == null || !IsInitialized)
+            if (_mediaPlayer == null || _platformHandle == null || !IsInitialized)
                 return;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -92,6 +185,74 @@ namespace LibVLCSharp.Avalonia
             }
         }
 
+        private void InitializeNativeOverlay()
+        {
+            if (!this.IsAttachedToVisualTree())
+                return;
+
+            if (VisualRoot is not Window visualRoot)
+            {
+                return;
+            }
+
+            if (_floatingContent == null && Content != null)
+            {
+                _floatingContent = new Window()
+                {
+                    SystemDecorations = SystemDecorations.None,
+                    TransparencyLevelHint = new[] { WindowTransparencyLevel.Transparent },
+                    Background = Brushes.Transparent,
+                    SizeToContent = SizeToContent.WidthAndHeight,
+                    CanResize = false,
+                    ShowInTaskbar = false,
+                    ZIndex = int.MaxValue,
+                    Opacity = 1.0,
+                    DataContext = DataContext
+                };
+                _floatingContent.Bind(ContentControl.ContentProperty, this.GetObservable(ContentProperty));
+                _floatingContent.PointerEntered += FloatingContentOnPointerEvent;
+                _floatingContent.PointerExited += FloatingContentOnPointerEvent;
+                _floatingContent.PointerPressed += FloatingContentOnPointerEvent;
+                _floatingContent.PointerReleased += FloatingContentOnPointerEvent;
+
+                ContentProperty.Changed.AddClassHandler<VideoView>((o, _) => o.UpdateOverlayPosition());
+                BoundsProperty.Changed.AddClassHandler<VideoView>((o, _) => o.UpdateOverlayPosition());
+                visualRoot.PositionChanged += (_, _) => UpdateOverlayPosition();
+            }
+
+            ShowNativeOverlay(IsEffectivelyVisible);
+        }
+
+        private void FloatingContentOnPointerEvent(object? sender, PointerEventArgs e)
+        {
+            RaiseEvent(e);
+        }
+
+        private void ShowNativeOverlay(bool show)
+        {
+            if (_floatingContent == null || _floatingContent.IsVisible == show || VisualRoot is not Window visualRoot)
+                return;
+
+            if (show && this.IsAttachedToVisualTree())
+                _floatingContent.Show(visualRoot);
+            else
+                _floatingContent.Hide();
+        }
+
+        /// <inheritdoc />
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            InitializeNativeOverlay();
+        }
+
+        /// <inheritdoc />
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            ShowNativeOverlay(false);
+        }
+
         /// <inheritdoc />
         protected override IPlatformHandle CreateNativeControlCore(IPlatformHandle parent)
         {
@@ -103,6 +264,15 @@ namespace LibVLCSharp.Avalonia
         protected override void DestroyNativeControlCore(IPlatformHandle control)
         {
             Detach();
+            if (_floatingContent != null)
+            {
+                _floatingContent.PointerEntered -= FloatingContentOnPointerEvent;
+                _floatingContent.PointerExited -= FloatingContentOnPointerEvent;
+                _floatingContent.PointerPressed -= FloatingContentOnPointerEvent;
+                _floatingContent.PointerReleased -= FloatingContentOnPointerEvent;
+                _floatingContent.Close();
+                _floatingContent = null;
+            }
 
             base.DestroyNativeControlCore(control);
 


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

Allow content to be placed to **VideoView** so that it renders it on top of the media player. 

- Created bindable **Content** property for **VideoView**.
- When content is assigned or **VideoView** is attached to visual tree, tries to create a new transparent overlay window that is placed on top of the **VideoView**.
- Content is binded to windows content property.
- Uses **VideoView** Content and Bound property changed events to update overlay position.

Updated sample.

Solution is based on this PR: https://github.com/videolan/libvlcsharp/pull/294

### Issues Resolved ### 
- fixes #408


### API Changes ###
Added:
 - object VideoView.Content { get; set; } //Bindable Property

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Avalonia

### Behavioral/Visual Changes ###
If user places control inside VideoView it will be shown top of the video.

### Before/After Screenshots ### 
![image](https://github.com/videolan/libvlcsharp/assets/5374161/d25f5800-d059-4f79-b344-8f3117fc2264)

### Testing Procedure ###
- Tested with Windows 11

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
