### PR TITLE
Added back PrivateAssets=All to remove the dependency to AWindowModern

### DIFF
--- a/samples/LibVLCSharp.MAUI.Sample/LibVLCSharp.MAUI.Sample.csproj
+++ b/samples/LibVLCSharp.MAUI.Sample/LibVLCSharp.MAUI.Sample.csproj
@@ -7,6 +7,8 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<RunAOTCompilation>false</RunAOTCompilation>
+		<AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
 
 		<!-- Display name -->
 		<ApplicationTitle>LibVLCSharp.MAUI.Sample</ApplicationTitle>

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -56,7 +56,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
      <Compile Include="Platforms\Android\**\*.cs" />
-     <ProjectReference Include="..\LibVLCSharp.Android.AWindowModern\LibVLCSharp.Android.AWindowModern.csproj" />
+     <ProjectReference Include="..\LibVLCSharp.Android.AWindowModern\LibVLCSharp.Android.AWindowModern.csproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="$(DefineConstants.Contains('APPLE'))">
     <Compile Include="Platforms\Apple\**\*.cs" />


### PR DESCRIPTION
Attempt to fix the invalid dependency to AWindowModern from LibVLCSharp for android