### PR TITLE
Android: Ship new Android binding to NuGet

### DIFF
--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -17,7 +17,7 @@ var isCiBuild = BuildSystem.AzurePipelines.IsRunningOnAzurePipelines;
 var suffixVersion = $"alpha-{DateTime.Today.ToString("yyyyMMdd")}-{BuildSystem.AzurePipelines.Environment.Build.Id}";
 var feedzLVSSource = "https://f.feedz.io/videolan/preview/nuget/index.json";
 var FEEDZ = "FEEDZ";
-const uint totalPackageCount = 11;
+const uint totalPackageCount = 12;
 
 //////////////////////////////////////////////////////////////////////
 // PREPARATION

--- a/src/LibVLCSharp.Android.AWindowModern/LibVLCSharp.Android.AWindowModern.csproj
+++ b/src/LibVLCSharp.Android.AWindowModern/LibVLCSharp.Android.AWindowModern.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   
 </Project>

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -102,7 +102,6 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
   <Target Name="IncludeAWindow">
     <ItemGroup>
       <BuildOutputInPackage Condition="$(TargetFramework.Contains('monoandroid'))" Include="$(OutputPath)LibVLCSharp.Android.AWindow.dll" />
-      <BuildOutputInPackage Condition="$(TargetFramework.Contains('-android'))" Include="$(OutputPath)LibVLCSharp.Android.AWindowModern.dll" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
because PrivateAssets is broken on net6-android and newer toolchains.
