### PR TITLE
WinUI: Changed the way to detect a WinUI application

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <DefineConstants>$(DefineConstants);UWP;WINDOWS_MODERN</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
+  <PropertyGroup Condition="$(UseWinUI) == true">
     <DefineConstants>$(DefineConstants);WINUI;WINDOWS_MODERN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">

--- a/src/LibVLCSharp/LibVLCSharp.csproj
+++ b/src/LibVLCSharp/LibVLCSharp.csproj
@@ -73,7 +73,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
   </ItemGroup>
   
-  <ItemGroup Condition="$(TargetFramework.StartsWith('uap')) Or $(TargetFramework.StartsWith('net6.0-windows10')) ">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('uap')) Or $(UseWinUI) == true">
     <Compile Include="Platforms\Windows\**\*.cs" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <Page Include="Themes\Generic.xaml">
@@ -82,7 +82,7 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.* packages.</Descri
     </Page>
   </ItemGroup>
   
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10')) ">
+  <ItemGroup Condition="$(UseWinUI) == true">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change ###

Prior to this change, LibVLCSharp detected WinUI usage by `TargetFramework.StartsWith('net6.0-windows10')`, which was not always correct.
Microsoft recommends specifying `<UseWinUI>true</UseWinUI>` for WinUI applications, which seems to be a more correct way to detect a WinUI application.

### Issues Resolved ### 

 None

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Windows
- WinUI

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
