### PR TITLE
mac ci: remove unecessary SDK install

### DIFF
--- a/buildsystem/base-template.yml
+++ b/buildsystem/base-template.yml
@@ -23,14 +23,6 @@ steps:
     arguments: 'install cake.tool --global'
 
 - bash: |
-   yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
-   yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
-   yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-28"
-   yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
-  displayName: 'Install Android SDK 27 and 28'
-  condition: eq( variables['Agent.OS'], 'Darwin' )
-
-- bash: |
    dotnet tool update --global uno.check --add-source https://api.nuget.org/v3/index.json
    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator
   displayName: 'Run uno.check'


### PR DESCRIPTION
since we don't build samples on mac ci anymore