### PR TITLE
Fix Avalonia VideoView failing to update Content position when shifted.

### DIFF
--- a/src/LibVLCSharp.Avalonia/VideoView.cs
+++ b/src/LibVLCSharp.Avalonia/VideoView.cs
@@ -80,7 +80,7 @@ namespace LibVLCSharp.Avalonia
 
         private void UpdateOverlayPosition()
         {
-            if (_floatingContent == null)
+            if (_floatingContent == null || !IsVisible)
                 return;
 
             bool forceSetWidth = false, forceSetHeight = false;
@@ -216,7 +216,8 @@ namespace LibVLCSharp.Avalonia
                 _floatingContent.PointerReleased += FloatingContentOnPointerEvent;
 
                 ContentProperty.Changed.AddClassHandler<VideoView>((o, _) => o.UpdateOverlayPosition());
-                BoundsProperty.Changed.AddClassHandler<VideoView>((o, _) => o.UpdateOverlayPosition());
+                
+                visualRoot.LayoutUpdated += (_, _) => UpdateOverlayPosition();
                 visualRoot.PositionChanged += (_, _) => UpdateOverlayPosition();
             }
 

--- a/src/LibVLCSharp.Avalonia/VideoView.cs
+++ b/src/LibVLCSharp.Avalonia/VideoView.cs
@@ -145,6 +145,47 @@ namespace LibVLCSharp.Avalonia
             {
                 _floatingContent.Position = newPosition;
             }
+            
+            if (_floatingContent.Content is Visual content && VisualRoot is Visual root && this is Visual videoView && child != null)
+            {
+                content.Clip = GetVisibleRegionAsGeometry(root, videoView, child.Margin);
+            }
+        }
+        
+        private static RectangleGeometry? GetVisibleRegionAsGeometry(Visual parent, Visual child, Thickness childMargin)
+        {
+            var childPosition = child.TranslatePoint(new Point(0, 0), parent);
+
+            if (!childPosition.HasValue) return null;
+        
+            var topDistance = childPosition.Value.Y + childMargin.Top;
+            var leftDistance = childPosition.Value.X + childMargin.Left;
+            var bottomDistance = parent.Bounds.Height - (childPosition.Value.Y + child.Bounds.Height + childMargin.Bottom);
+            var rightDistance = parent.Bounds.Width - (childPosition.Value.X + child.Bounds.Width + childMargin.Right);
+        
+            var region = new Rect(0, 0, child.Bounds.Width, child.Bounds.Height);
+        
+            if (topDistance < 0)
+            {
+                region = new Rect(region.X, region.Y - topDistance, region.Width, region.Height + topDistance);
+            }
+        
+            if (leftDistance < 0)
+            {
+                region = new Rect(region.X - leftDistance, region.Y, region.Width + leftDistance, region.Height);
+            }
+        
+            if (rightDistance < 0)
+            {
+                region = region.WithWidth(region.Width + rightDistance);
+            }
+        
+            if (bottomDistance < 0)
+            {
+                region = region.WithHeight(region.Height + bottomDistance);
+            }
+        
+            return new RectangleGeometry(region);
         }
 
         private void Attach()


### PR DESCRIPTION
### Description of Change ###

Adds an event handler for `VideoView.VisualRoot.LayoutUpdated `in `InitializeNativeOverlay()`.
Remove event handler for `BoundsProperty.Changed` as it's no longer needed.
Adds to the guard clause in `UpdateOverlayPosition()` so LayoutUpdated doesn't pelt a IsVisible = false VideoView with updates; Layout is updated on being made visible.

### Issues Resolved ### 
[Fixes 645](https://code.videolan.org/videolan/LibVLCSharp/-/issues/645)

### API Changes ###
 None

### Platforms Affected ### 
- Avalonia Desktop

### Behavioral/Visual Changes ###
VideoView Content now moves correctly when being shifted by grid splitters.

### Before/After Screenshots ### 

![Before = bottom, After = top](https://github.com/user-attachments/assets/f2abe0b3-5c7d-4366-8c5f-084846ffa63c)


### Testing Procedure ###
All testing was performed on Manjaro Linux.
- Tested with and without video playback.
- Tested behavior while VideoView.IsVisible = false.
- Tested changing VideoView.Content.
The tests where performed using [this](https://code.videolan.org/Odalith/vlctest/-/tree/master?ref_type=heads) application;


### PR Checklist ###

- [-] Rebased on top of the target branch at time of PR
- [-] Changes adhere to coding standard
