### PR TITLE
Maui winui

### DIFF
--- a/samples/LibVLCSharp.MAUI.Sample/AppShell.xaml
+++ b/samples/LibVLCSharp.MAUI.Sample/AppShell.xaml
@@ -5,10 +5,5 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:LibVLCSharp.MAUI.Sample"
     Shell.FlyoutBehavior="Disabled">
-
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
-
+    <ShellContent ContentTemplate="{DataTemplate local:MainPage}" Route="MainPage" />
 </Shell>

--- a/samples/LibVLCSharp.MAUI.Sample/LibVLCSharp.MAUI.Sample.csproj
+++ b/samples/LibVLCSharp.MAUI.Sample/LibVLCSharp.MAUI.Sample.csproj
@@ -2,17 +2,17 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>LibVLCSharp.MAUI.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
-
 		<!-- Display name -->
-		<ApplicationTitle>LibVLCSharp.MAUI.Sample</ApplicationTitle>
-
+		<ApplicationTitle>LibVLCSharp.MAUI.SampleX</ApplicationTitle>
+		<WindowsPackageType>None</WindowsPackageType>
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.libvlcsharp.maui.sample</ApplicationId>
+		<ApplicationId>com.companyname.libvlcsharp.maui.samplex</ApplicationId>
 		<ApplicationIdGuid>49861f9e-48d3-45c0-b6a8-f591ad6d2010</ApplicationIdGuid>
 
 		<!-- Versions -->
@@ -24,7 +24,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -63,5 +63,8 @@
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
 		<PackageReference Include="VideoLAN.LibVLC.iOS" Version="3.3.18" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
+		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
 	</ItemGroup>
 </Project>

--- a/samples/LibVLCSharp.MAUI.Sample/MainPage.xaml
+++ b/samples/LibVLCSharp.MAUI.Sample/MainPage.xaml
@@ -8,6 +8,6 @@
         <local:MainViewModel />
     </ContentPage.BindingContext>
 
-    <shared:VideoView x:Name="VideoView" MediaPlayer="{Binding MediaPlayer}" MediaPlayerChanged="VideoView_MediaPlayerChanged"  HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"/>
+    <shared:VideoView x:Name="VideoView" MediaPlayer="{Binding MediaPlayer}" MediaPlayerChanged="VideoView_MediaPlayerChanged"  HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" HandlerChanged="VideoView_HandlerChanged" />
 
 </ContentPage>

--- a/samples/LibVLCSharp.MAUI.Sample/MainPage.xaml.cs
+++ b/samples/LibVLCSharp.MAUI.Sample/MainPage.xaml.cs
@@ -12,7 +12,9 @@ namespace LibVLCSharp.MAUI.Sample
         protected override void OnAppearing()
         {
             base.OnAppearing();
+#if !WINDOWS
             ((MainViewModel)BindingContext).OnAppearing();
+#endif
         }
 
         protected override void OnDisappearing()
@@ -24,6 +26,19 @@ namespace LibVLCSharp.MAUI.Sample
         private void VideoView_MediaPlayerChanged(object sender, MediaPlayerChangedEventArgs e)
         {
             ((MainViewModel)BindingContext).OnVideoViewInitialized();
+        }
+
+        private void VideoView_HandlerChanged(object sender, EventArgs e)
+        {
+#if WINDOWS
+            var windowsView = ((LibVLCSharp.Platforms.Windows.VideoView)VideoView.Handler.PlatformView);
+
+            windowsView.Initialized += (s, e) =>
+            {
+                ((MainViewModel)BindingContext).Initialize(e.SwapChainOptions);
+                ((MainViewModel)BindingContext).OnAppearing();
+            };
+#endif
         }
     }
 }

--- a/samples/LibVLCSharp.MAUI.Sample/MainViewModel.cs
+++ b/samples/LibVLCSharp.MAUI.Sample/MainViewModel.cs
@@ -9,7 +9,9 @@ namespace LibVLCSharp.MAUI.Sample
 
         public MainViewModel()
         {
+#if !WINDOWS
             Initialize();
+#endif
         }
 
         private LibVLC LibVLC { get; set; }
@@ -33,9 +35,9 @@ namespace LibVLCSharp.MAUI.Sample
             }
         }
 
-        private void Initialize()
+        internal void Initialize(string[] swapchainOptions = null)
         {
-            LibVLC = new LibVLC(enableDebugLogs: true);
+            LibVLC = new LibVLC(enableDebugLogs: true, swapchainOptions);
             using var media = new Media(LibVLC, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
 
             MediaPlayer = new Shared.MediaPlayer(LibVLC)

--- a/samples/LibVLCSharp.MAUI.Sample/Properties/launchSettings.json
+++ b/samples/LibVLCSharp.MAUI.Sample/Properties/launchSettings.json
@@ -1,8 +1,8 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "MsixPackage",
-      "nativeDebugging": false
+      "commandName": "Project",
+      "nativeDebugging": true
     }
   }
 }

--- a/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/LibVLCSharp.MAUI.Sample.MediaElement.csproj
+++ b/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/LibVLCSharp.MAUI.Sample.MediaElement.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-    <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+	<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>LibVLCSharp.MAUI.Sample.MediaElement</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+	<WindowsPackageType>None</WindowsPackageType>
     <!-- Display name -->
     <ApplicationTitle>LibVLCSharp.MAUI.Sample.MediaElement</ApplicationTitle>
     <!-- App Identifier -->
@@ -21,9 +21,7 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- App Icon -->
@@ -48,6 +46,9 @@
   </ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
 		<PackageReference Include="VideoLAN.LibVLC.iOS" Version="3.3.18" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
+		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
 	</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\LibVLCSharp.MAUI\LibVLCSharp.MAUI.csproj" />

--- a/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainPage.xaml
+++ b/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainPage.xaml
@@ -4,17 +4,17 @@
              xmlns:local="clr-namespace:LibVLCSharp.MAUI.Sample.MediaElement"
              xmlns:vlc="clr-namespace:LibVLCSharp.MAUI;assembly=LibVLCSharp.MAUI"
              x:Class="LibVLCSharp.MAUI.Sample.MediaElement.MainPage"
-             Appearing="OnAppearing"
-             Disappearing="OnDisappearing">
+             Appearing="ContentPage_Appearing"
+             Disappearing="ContentPage_Disappearing">
 
     <ContentPage.BindingContext>
         <local:MainViewModel />
     </ContentPage.BindingContext>
 
-    <vlc:MediaPlayerElement MediaPlayer="{Binding MediaPlayer}" LibVLC="{Binding LibVLC}" EnableRendererDiscovery="True" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
+    <vlc:MediaPlayerElement x:Name="MediaPlayerElement" MediaPlayer="{Binding MediaPlayer}" LibVLC="{Binding LibVLC}" EnableRendererDiscovery="True" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
         <vlc:MediaPlayerElement.PlaybackControls>
             <vlc:PlaybackControls
-        	IsAspectRatioButtonVisible="True" IsSeekButtonVisible="True" IsCastButtonVisible="True" />
+        	IsAspectRatioButtonVisible="True" IsSeekButtonVisible="True" IsCastButtonVisible="True"/>
         </vlc:MediaPlayerElement.PlaybackControls>
 
     </vlc:MediaPlayerElement>

--- a/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainPage.xaml.cs
+++ b/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainPage.xaml.cs
@@ -13,17 +13,36 @@ namespace LibVLCSharp.MAUI.Sample.MediaElement
         public MainPage()
         {
             InitializeComponent();
+            MediaPlayerElement.PlaybackControls.VideoView.HandlerChanged += VideoView_HandlerChanged;
         }
 
-        void OnAppearing(object sender, System.EventArgs e)
+        private void VideoView_HandlerChanged(object sender, EventArgs e)
+        {
+#if WINDOWS
+            var windowsView = ((LibVLCSharp.Platforms.Windows.VideoView)MediaPlayerElement.PlaybackControls.VideoView.Handler.PlatformView);
+
+            windowsView.Initialized += (s, e) =>
+            {
+                ((MainViewModel)BindingContext).OnAppearing(e.SwapChainOptions);
+            };
+#endif
+        }
+
+        private void ContentPage_Appearing(object sender, EventArgs e)
         {
             base.OnAppearing();
+#if !WINDOWS
             ((MainViewModel)BindingContext).OnAppearing();
+#endif
         }
 
-        void OnDisappearing(object sender, System.EventArgs e)
+        private void ContentPage_Disappearing(object sender, EventArgs e)
         {
             base.OnDisappearing();
+
+            // this is a hack to get the mediaplayer/libvlc objects databinding disabled before disposing of them in the viewmodel OnDisappearing function. The MediaElement control and MAUI lifecycle shutdown procedure don't play nice together, so sometimes, on destroy, media element events are being unsubscribed on an already disposed mediaplayer instance, causing a memory violation exception.
+            MediaPlayerElement.MediaPlayer = null;
+            MediaPlayerElement.LibVLC = null;
             ((MainViewModel)BindingContext).OnDisappearing();
         }
     }

--- a/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainViewModel.cs
+++ b/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/MainViewModel.cs
@@ -46,11 +46,11 @@ namespace LibVLCSharp.MAUI.Sample.MediaElement
         /// <summary>
         /// Initialize LibVLC and playback when page appears
         /// </summary>
-        public void OnAppearing()
+        public void OnAppearing(string[] swapchainOptions = null)
         {
             if (LibVLC == null)
             {
-                LibVLC = new LibVLC(enableDebugLogs: true);
+                LibVLC = new LibVLC(enableDebugLogs: true, swapchainOptions);
             }
 
             if (MediaPlayer == null)
@@ -70,11 +70,11 @@ namespace LibVLCSharp.MAUI.Sample.MediaElement
         /// </summary>
         public void OnDisappearing()
         {
-            MediaPlayer?.Dispose();
-            MediaPlayer = null;
-
-            LibVLC?.Dispose();
-            LibVLC = null;
+            _mediaPlayer?.Stop();
+            _mediaPlayer?.Dispose();
+            _mediaPlayer = null;
+            _libVLC?.Dispose();
+            _libVLC = null;
         }
 
         /// <summary>

--- a/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/Properties/launchSettings.json
+++ b/samples/MAUI/LibVLCSharp.MAUI.Sample.MediaElement/Properties/launchSettings.json
@@ -1,8 +1,8 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "MsixPackage",
-      "nativeDebugging": false
+      "commandName": "Project",
+      "nativeDebugging": true
     }
   }
 }

--- a/src/LibVLCSharp.MAUI/Handlers/VideoViewHandler.cs
+++ b/src/LibVLCSharp.MAUI/Handlers/VideoViewHandler.cs
@@ -3,6 +3,8 @@
 using VideoViewImpl = LibVLCSharp.Platforms.Android.VideoView;
 #elif IOS
 using VideoViewImpl = LibVLCSharp.Platforms.iOS.VideoView;
+#elif WINUI
+using VideoViewImpl = LibVLCSharp.Platforms.Windows.VideoView;
 #endif 
 
 namespace LibVLCSharp.MAUI

--- a/src/LibVLCSharp.MAUI/LibVLCSharp.MAUI.csproj
+++ b/src/LibVLCSharp.MAUI/LibVLCSharp.MAUI.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
+++ b/src/LibVLCSharp/Platforms/Windows/VideoViewBase.cs
@@ -41,7 +41,7 @@ namespace LibVLCSharp.Platforms.Windows
         /// </summary>
         public VideoViewBase()
         {
-            DefaultStyleKey = typeof(VideoViewBase);
+            DefaultStyleKey = typeof(VideoView);
 
             Unloaded += (s, e) => DestroySwapChain();
 #if !WINUI

--- a/src/LibVLCSharp/Themes/Generic.xaml
+++ b/src/LibVLCSharp/Themes/Generic.xaml
@@ -3,10 +3,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vlc="using:LibVLCSharp.Platforms.Windows">
 
-    <Style TargetType="vlc:VideoViewBase">
+    <Style TargetType="vlc:VideoView">
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="vlc:VideoViewBase">
+                <ControlTemplate TargetType="vlc:VideoView">
                     <SwapChainPanel x:Name="SwapChainPanel" />
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Getting lots of these
```
DEP0900: Failed to unregister application "49861f9e-48d3-45c0-b6a8-f591ad6d2010_1.0.0.1_x64__9zz4h110yvjzm". [0x80073CFA] 
```
Unsure why. Impossible to uninstall existing appx that match this app ID.

On 3.x, on WinUI, the `LibVLC` object is built using string parameters retrieved from an initialized VideoView (see the plan WinUI sample code). Will have to re-work the code to handle this in the MAUI sample for WinUI support.