### PR TITLE
avalonia sample target net8 and bump to avalonia 11.2.5

### DIFF
--- a/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
+++ b/samples/LibVLCSharp.Avalonia.Sample/LibVLCSharp.Avalonia.Sample.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="$([MSBuild]::IsOsPlatform('Windows'))">net6.0</TargetFramework>
-    <TargetFramework Condition="!$([MSBuild]::IsOsPlatform('Windows'))">netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
@@ -16,12 +15,12 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.4" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="3.0.16" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('OSX'))" Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
Bumped avalonia sample to use avalonia 11.2.5 and target net8

### Issues Resolved ### 
Just modernized the avalonia sample project a bit.

### API Changes ###
None

### Platforms Affected ### 
- Windows
- OSx
- Linux

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
run the sample and see big buck bunny. 
I cannot test on OSx myself so that may be a small risk. 

### PR Checklist ###

- [X ] Rebased on top of the target branch at time of PR
- [ X] Changes adhere to coding standard
