### PR TITLE
Lib vlc options builder

### DIFF
--- a/src/LibVLCSharp/Shared/LibVLC.cs
+++ b/src/LibVLCSharp/Shared/LibVLC.cs
@@ -206,7 +206,7 @@ namespace LibVLCSharp.Shared
         /// <code>
         /// var options = new LibVLCOptionsBuilder()
         ///     .EnableDebugLogs()
-        ///     .SetAudioResampler(\"soxr\")
+        ///     .SetAudioResampler("soxr")
         ///     .Build();
         ///
         /// using var libvlc = new LibVLC(options);
@@ -216,11 +216,10 @@ namespace LibVLCSharp.Shared
         /// <param name="options">An instance of <see cref="LibVLCOptions"/> containing libvlc configuration parameters.</param>
 
         public LibVLC(LibVLCOptions options)
-    : base(() => MarshalUtils.CreateWithOptions(options.Options, Native.LibVLCNew), Native.LibVLCRelease)
+        : base(() => MarshalUtils.CreateWithOptions(options.Options, Native.LibVLCNew), Native.LibVLCRelease)
         {
             _gcHandle = GCHandle.Alloc(this);
         }
-
 
         /// <summary>
         /// Create and initialize a libvlc instance.

--- a/src/LibVLCSharp/Shared/LibVLCOptions.cs
+++ b/src/LibVLCSharp/Shared/LibVLCOptions.cs
@@ -210,10 +210,5 @@ namespace LibVLCSharp.Shared
         {
             Options = options?.ToArray() ?? new string[0];
         }
-
-        /// <summary>
-        /// Gets an empty LibVLCOptions instance.
-        /// </summary>
-        public static LibVLCOptions Empty => new LibVLCOptions(new string[0]);
     }
 }

--- a/src/LibVLCSharp/Shared/LibVLCOptions.cs
+++ b/src/LibVLCSharp/Shared/LibVLCOptions.cs
@@ -166,15 +166,6 @@ namespace LibVLCSharp.Shared
             return this;
         }
 
-        /// <summary>
-        /// Adds a raw libvlc command-line option.
-        /// </summary>
-        /// <param name="rawOption">The full option string to add.</param>
-        public LibVLCOptionsBuilder AddRaw(string rawOption)
-        {
-            _options.Add(rawOption);
-            return this;
-        }
 
         /// <summary>
         /// Builds the final LibVLCOptions object including any platform-specific defaults.

--- a/src/LibVLCSharp/Shared/LibVLCOptions.cs
+++ b/src/LibVLCSharp/Shared/LibVLCOptions.cs
@@ -7,6 +7,8 @@ namespace LibVLCSharp.Shared
     /// <summary>
     /// Fluent builder for constructing LibVLC options.
     /// Mirrors many common libvlc command line parameters.
+    /// See https://wiki.videolan.org/VLC_command-line_help for more details about available parameters.
+    /// OPTIONS ARE PROVIDED AS-IS, WITHOUT ANY GUARANTEE OF FORWARD/BACKWARD COMPATIBILITY.
     /// </summary>
     public class LibVLCOptionsBuilder
     {
@@ -172,7 +174,7 @@ namespace LibVLCSharp.Shared
         /// </summary>
         public LibVLCOptions Build()
         {
-            var finalOptions = _options.ToList();
+            var finalOptions = _options;
 
             if (_includeDebugLogs)
                 finalOptions.Add("--verbose=2");

--- a/src/LibVLCSharp/Shared/LibVLCOptions.cs
+++ b/src/LibVLCSharp/Shared/LibVLCOptions.cs
@@ -206,12 +206,12 @@ namespace LibVLCSharp.Shared
         /// <param name="options">The options to include.</param>
         public LibVLCOptions(IEnumerable<string>? options)
         {
-            Options = options?.ToArray() ?? Array.Empty<string>();
+            Options = options?.ToArray() ?? new string[0];
         }
 
         /// <summary>
         /// Gets an empty LibVLCOptions instance.
         /// </summary>
-        public static LibVLCOptions Empty => new LibVLCOptions(Array.Empty<string>());
+        public static LibVLCOptions Empty => new LibVLCOptions(new string[0]);
     }
 }

--- a/src/LibVLCSharp/Shared/LibVLCOptions.cs
+++ b/src/LibVLCSharp/Shared/LibVLCOptions.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibVLCSharp.Shared
+{
+    /// <summary>
+    /// Fluent builder for constructing LibVLC options.
+    /// Mirrors many common libvlc command line parameters.
+    /// </summary>
+    public class LibVLCOptionsBuilder
+    {
+        private readonly List<string> _options = new();
+        private bool _includeDebugLogs = false;
+
+#if UWP || ANDROID
+        private bool _audioResamplerOverridden = false;
+#endif
+
+        /// <summary>
+        /// Enables verbose debug logging by adding "--verbose=2".
+        /// </summary>
+        public LibVLCOptionsBuilder EnableDebugLogs()
+        {
+            _includeDebugLogs = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the verbosity level of the log output.
+        /// </summary>
+        /// <param name="level">Verbosity level (e.g. 0=errors only, 2=debug).</param>
+        public LibVLCOptionsBuilder SetVerbosity(int level)
+        {
+            _options.Add($"--verbose={level}");
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the audio resampler module.
+        /// </summary>
+        /// <param name="resampler">The name of the resampler (e.g. speex_resampler, soxr).</param>
+        public LibVLCOptionsBuilder SetAudioResampler(string resampler)
+        {
+            _options.Add($"--audio-resampler={resampler}");
+#if UWP || ANDROID
+            _audioResamplerOverridden = true;
+#endif
+            return this;
+        }
+
+#if UWP || ANDROID
+        /// <summary>
+        /// Disables the default resampler for the current platform.
+        /// </summary>
+        public LibVLCOptionsBuilder DisableDefaultResampler()
+        {
+            _audioResamplerOverridden = true;
+            return this;
+        }
+#endif
+
+        /// <summary>
+        /// Sets the audio output module (e.g. "--aout=directsound").
+        /// </summary>
+        /// <param name="output">The audio output module name.</param>
+        public LibVLCOptionsBuilder SetAudioOutput(string output)
+        {
+            _options.Add($"--aout={output}");
+            return this;
+        }
+
+        /// <summary>
+        /// Disables video output.
+        /// </summary>
+        public LibVLCOptionsBuilder DisableVideo()
+        {
+            _options.Add("--no-video");
+            return this;
+        }
+
+        /// <summary>
+        /// Disables audio output.
+        /// </summary>
+        public LibVLCOptionsBuilder DisableAudio()
+        {
+            _options.Add("--no-audio");
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the network caching value in milliseconds.
+        /// </summary>
+        /// <param name="milliseconds">Caching delay in ms (e.g. 300).</param>
+        public LibVLCOptionsBuilder SetNetworkCaching(int milliseconds)
+        {
+            _options.Add($"--network-caching={milliseconds}");
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the file caching value in milliseconds.
+        /// </summary>
+        /// <param name="milliseconds">Caching delay in ms (e.g. 300).</param>
+        public LibVLCOptionsBuilder SetFileCaching(int milliseconds)
+        {
+            _options.Add($"--file-caching={milliseconds}");
+            return this;
+        }
+
+        /// <summary>
+        /// Enables hardware-accelerated decoding using the specified method.
+        /// </summary>
+        /// <param name="method">Decoding method (e.g. dxva2, vaapi, d3d11va).</param>
+        public LibVLCOptionsBuilder EnableHardwareDecoding(string method)
+        {
+            _options.Add($"--avcodec-hw={method}");
+            return this;
+        }
+
+        /// <summary>
+        /// Enables dropping of late video frames.
+        /// </summary>
+        public LibVLCOptionsBuilder DropLateFrames()
+        {
+            _options.Add("--drop-late-frames");
+            return this;
+        }
+
+        /// <summary>
+        /// Enables frame skipping.
+        /// </summary>
+        public LibVLCOptionsBuilder SkipFrames()
+        {
+            _options.Add("--skip-frames");
+            return this;
+        }
+
+        /// <summary>
+        /// Enables or disables use of Xlib.
+        /// </summary>
+        /// <param name="enabled">True to enable Xlib, false to disable.</param>
+        public LibVLCOptionsBuilder UseXlib(bool enabled)
+        {
+            _options.Add(enabled ? "--xlib" : "--no-xlib");
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom libvlc option.
+        /// </summary>
+        /// <param name="option">The command-line option to add.</param>
+        public LibVLCOptionsBuilder AddOption(string option)
+        {
+            _options.Add(option);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds multiple custom libvlc options.
+        /// </summary>
+        /// <param name="options">The options to add.</param>
+        public LibVLCOptionsBuilder AddOptions(IEnumerable<string> options)
+        {
+            _options.AddRange(options);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a raw libvlc command-line option.
+        /// </summary>
+        /// <param name="rawOption">The full option string to add.</param>
+        public LibVLCOptionsBuilder AddRaw(string rawOption)
+        {
+            _options.Add(rawOption);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the final LibVLCOptions object including any platform-specific defaults.
+        /// </summary>
+        public LibVLCOptions Build()
+        {
+            var finalOptions = _options.ToList();
+
+            if (_includeDebugLogs)
+                finalOptions.Add("--verbose=2");
+
+#if UWP
+            finalOptions.Add("--aout=winstore");
+            if (!_audioResamplerOverridden)
+                finalOptions.Add("--audio-resampler=speex_resampler");
+#elif ANDROID
+            if (!_audioResamplerOverridden)
+                finalOptions.Add("--audio-resampler=soxr");
+#endif
+
+            return new LibVLCOptions(finalOptions);
+        }
+    }
+
+    /// <summary>
+    /// Represents the finalized LibVLC options as an array of command-line arguments.
+    /// </summary>
+    public class LibVLCOptions
+    {
+        /// <summary>
+        /// Gets the collection of command-line arguments.
+        /// </summary>
+        public string[] Options { get; }
+
+        /// <summary>
+        /// Initializes a new instance of LibVLCOptions with the specified options.
+        /// </summary>
+        /// <param name="options">The options to include.</param>
+        public LibVLCOptions(IEnumerable<string>? options)
+        {
+            Options = options?.ToArray() ?? Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets an empty LibVLCOptions instance.
+        /// </summary>
+        public static LibVLCOptions Empty => new LibVLCOptions(Array.Empty<string>());
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Added a builder pattern for `LibVLCOptions`.

This change introduces a `LibVLCOptionsBuilder` class to simplify and structure the creation of LibVLC initialization options. The builder provides a fluent, discoverable API for composing commonly used options, improving readability and reducing the chance of misconfigured strings.

Maintains compatibility with old LibVLC constructors to avoid problems for developers when updating to version with this change.

### Issues Resolved ### 

Fixes #654 (Parameter `--audio-resampler` for UWP causes audio to stutter)

### API Changes ###

Added:
 - class `LibVLCOptionsBuilder`
 - LibVLCOptionsBuilder AddOption(string option)
 - LibVLCOptionsBuilder AddOptions(IEnumerable<string> options)
 - LibVLCOptionsBuilder SetVerbosity(int level)
 - LibVLCOptionsBuilder EnableDebugLogs()
 - LibVLCOptionsBuilder SetAudioResampler(string resampler)
 - LibVLCOptionsBuilder SetAudioOutput(string output)
 - LibVLCOptionsBuilder DisableVideo()
 - LibVLCOptionsBuilder DisableAudio()
 - LibVLCOptionsBuilder SetNetworkCaching(int milliseconds)
 - LibVLCOptionsBuilder SetFileCaching(int milliseconds)
 - LibVLCOptionsBuilder EnableHardwareDecoding(string method)
 - LibVLCOptionsBuilder DropLateFrames()
 - LibVLCOptionsBuilder SkipFrames()
 - LibVLCOptionsBuilder UseXlib(bool enabled)
 - LibVLCOptionsBuilder Build() : LibVLCOptions

#if UWP || ANDROID
 - LibVLCOptionsBuilder DisableDefaultResampler()
#endif

 - class `LibVLCOptions`
 - LibVLCOptions(string[] options)
 - string[] LibVLCOptions.Options { get; }
 - static LibVLCOptions LibVLCOptions.Empty { get; }

Removed.

- LibVLC.PatchOptions()

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Verified that `LibVLCOptionsBuilder` produces correct and expected LibVLC option strings
- Confirmed that usage of the builder allows to avoid problematic parameter `--audio-resampler=speex_resampler"` on UWP

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR  
- [x] Changes adhere to coding standard  
- [x] New API is documented and tested  
