### PR TITLE
Allow attaching overlay window to specified background element rather than the VideoView

### DIFF
--- a/src/LibVLCSharp.WPF/VideoView.cs
+++ b/src/LibVLCSharp.WPF/VideoView.cs
@@ -57,6 +57,11 @@ namespace LibVLCSharp.WPF
         private ForegroundWindow? ForegroundWindow { get; set; }
         private bool IsUpdatingContent { get; set; }
         private UIElement? ViewContent { get; set; }
+        
+        /// <summary>
+        /// Background element for this VideoView
+        /// </summary>
+        public FrameworkElement? BackgroundElement { get; set; } = null;
 
         /// <summary>
         /// ForegroundWindow management and MediaPlayer setup.
@@ -78,7 +83,7 @@ namespace LibVLCSharp.WPF
 
             _videoHwndHost = controlHost;
 
-            ForegroundWindow = new ForegroundWindow(_videoHwndHost)
+            ForegroundWindow = new ForegroundWindow(_videoHwndHost, BackgroundElement)
             {
                 OverlayContent = ViewContent
             };


### PR DESCRIPTION
### Description of Change ###

Allow the foreground window to be "attached" to a specified background element (copying its position and size) rather than being constrained by the VideoView position and size.
This makes the position and size of the foreground window overlay much more predictable so that controls in the overlay are always in the same place relative to the main window even if the position and dimensions of the VideoView changes.
If VideoView.BackgroundElement is not specified, the behavior is as before, so this change should not break anything.
It's only a minor change to code but is a big improvement to usability in my humble opinion.
Take my case as an example. My application is a fancy image gallery with video playback functions. The image zoom and drag functions in my app also work for videos, but they affect the foreground window, which is undesired behavior. So for cases such as mine being able to attach the foreground window overlay to a different control rather than the VideoView is necessary.
This pull request concerns only LibVLCSharp.WPF since that is what I use but other platforms may benefit from similar changes.

### Issues Resolved ### 
Variability in location/size of foreground overlay which is sometimes undesirable.

### API Changes ###
Added:
FrameworkElement? BackgroundElement { get; set; }

### Platforms Affected ### 
WPF

### Behavioral/Visual Changes ###
There is no change in functionality or appearance unless VideoView.BackgroundElement is set to a control. If set, the position and size of the ForegroundWindow (and consequently the child controls of the VideoView) will follow that background element, rather than following the VideoView. The video is not affected, only the foreground window.

### Before/After Screenshots ### 
<img width="1800" height="1350" alt="Screenshot 2025-07-18 20 40 59" src="https://github.com/user-attachments/assets/c56573c4-276f-465b-b9d5-6a8f03afdb8a" />
<img width="1800" height="1350" alt="Screenshot 2025-07-18 20 43 52" src="https://github.com/user-attachments/assets/132c0e7c-5947-4faf-b853-745f74c18127" />

### Testing Procedure ###
For this test, I used the following XAML, which resembles the layout in my actual application, but greatly simplified.
Fixed width and height of the VideoView is used here for demonstration purposes.
```
<Window x:Class="wpftestforvlc.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:local="clr-namespace:wpftestforvlc"
        mc:Ignorable="d"
        xmlns:vlc="clr-namespace:LibVLCSharp.WPF;assembly=LibVLCSharp.WPF"
        Title="MainWindow" Height="1080" Width="1440" Loaded="Window_Loaded">
    <Grid Name="MainGrid" Background="Black">
        <Button x:Name="button" Content="Play Video" HorizontalAlignment="Center" VerticalAlignment="Center" Click="button_Click" Margin="0" Padding="24,12,24,12" FontSize="32"/>
        <Viewbox Stretch="Uniform">
        <vlc:VideoView Width="1920" Height="1080" x:Name="videoView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{x:Null}">
            <Grid Background="Transparent">
                <Grid.RowDefinitions>
                    <RowDefinition/>
                    <RowDefinition Height="Auto"/>
                </Grid.RowDefinitions>
                <Grid Grid.Row="0">
                    <Label Foreground="White" Content="Top Left Text" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="32">
                        <Label.Effect>
                            <DropShadowEffect BlurRadius="4" ShadowDepth="4" Opacity="0.67" />
                        </Label.Effect>
                    </Label>
                    <Label Foreground="White" Content="Top Right Text" HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="32">
                        <Label.Effect>
                            <DropShadowEffect BlurRadius="4" ShadowDepth="4" Opacity="0.67" />
                        </Label.Effect>
                    </Label>
                </Grid>
                <Grid Grid.Row="1">
                    <Label Foreground="White" Content="Bottom Left Text" HorizontalAlignment="Left" VerticalAlignment="Bottom" FontSize="32">
                        <Label.Effect>
                            <DropShadowEffect BlurRadius="4" ShadowDepth="4" Opacity="0.67" />
                        </Label.Effect>
                    </Label>
                    <Label Foreground="White" Content="Bottom Right Text" HorizontalAlignment="Right" VerticalAlignment="Bottom" FontSize="32">
                        <Label.Effect>
                            <DropShadowEffect BlurRadius="4" ShadowDepth="4" Opacity="0.67" />
                        </Label.Effect>
                    </Label>
                </Grid>
            </Grid>
        </vlc:VideoView>
        </Viewbox>
    </Grid>
</Window>
```

Without changing BackgroundElement, the window will look like the first screenshot (same behavior as current LibVLCSharp.WPF)
By setting BackgroundElement in the window's constructor (or in Window_Initialized), as such:
```
        public MainWindow()
        {
            InitializeComponent();
            videoView.BackgroundElement = MainGrid;
        }
```
The window becomes like the second screenshot.
It seems important that this is set in the constructor or in Window_Initialized, otherwise VideoView.Visibility must start out Collapsed and the property must be set before the VideoView is shown. Otherwise the change does not take. It seems that the ForegroundWindow is being created as soon as the VideoView is fully loaded. So that is one small but important caveat to keep in mind. Making it recreate (or modify) the ForegroundWindow whenever BackgroundElement is changed would be possible, but would require more extensive code changes. I've tried to keep my code changes to a minimum.
For the test it is not necessary to play any video or even initialize the core, the difference is apparent with just that one line of code.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
