### PR TITLE
Add WS_CLIPCHILDREN window style to fix white window background

### DIFF
--- a/src/LibVLCSharp.WPF/User32Wrapper.cs
+++ b/src/LibVLCSharp.WPF/User32Wrapper.cs
@@ -36,7 +36,12 @@ namespace LibVLCSharp.WPF
             /// <summary>
             /// The window is initially visible.
             /// </summary>
-            WS_VISIBLE = 0x10000000
+            WS_VISIBLE = 0x10000000,
+
+            /// <summary>
+            /// Excludes the area occupied by child windows when drawing occurs within the parent window. This style is used when creating the parent window.
+            /// </summary>
+            WS_CLIPCHILDREN = 0x02000000
         }
 
 

--- a/src/LibVLCSharp.WPF/VideoHwndHost.cs
+++ b/src/LibVLCSharp.WPF/VideoHwndHost.cs
@@ -15,7 +15,7 @@ namespace LibVLCSharp.WPF
         protected override HandleRef BuildWindowCore(HandleRef hwndParent)
         {
             var windowHandle = User32Wrapper.CreateWindowEx(User32Wrapper.ExtendedWindow32Styles.WS_EX_TRANSPARENT, "static", string.Empty,
-                                                       User32Wrapper.Window32Styles.WS_CHILD | User32Wrapper.Window32Styles.WS_VISIBLE, 
+                                                       User32Wrapper.Window32Styles.WS_CHILD | User32Wrapper.Window32Styles.WS_VISIBLE | User32Wrapper.Window32Styles.WS_CLIPCHILDREN, 
                                                        0, 0, 0, 0, 
                                                        hwndParent.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
             return new HandleRef(this, windowHandle);


### PR DESCRIPTION
### Description of Change ###

Add WS_CLIPCHILDREN window style to fix white window background

### Issues Resolved ### 
fixes #[#555](https://code.videolan.org/videolan/LibVLCSharp/-/issues/555)

### API Changes ###
None

Added:
 - WS_CLIPCHILDREN Window32Style

Changed:
 - CreateWindowEx in HandleRef BuildWindowCore(HandleRef hwndParent)
 
### Platforms Affected ### 
- Windows WPF

### Behavioral/Visual Changes ###
The VideoView control's background is now stable

### Testing Procedure ###
I used a personal project that uses LibVLCSharp.Wpf to test my changes. 

### PR Checklist ###

- [ x] Rebased on top of the target branch at time of PR
- [ x] Changes adhere to coding standard
