### PR TITLE
CI: remove GTK from macOS builds

### DIFF
--- a/src/LibVLCSharp.Mac.slnx
+++ b/src/LibVLCSharp.Mac.slnx
@@ -73,38 +73,6 @@
     <BuildType Solution="AppStore|x64" Project="Debug" />
     <BuildType Solution="AppStore|x86" Project="Debug" />
   </Project>
-  <Project Path="LibVLCSharp.Forms.Platforms.GTK/LibVLCSharp.Forms.Platforms.GTK.csproj">
-    <BuildType Solution="Ad-Hoc|Any CPU" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|ARM" Project="Release" />
-    <BuildType Solution="Ad-Hoc|ARM64" Project="Release" />
-    <BuildType Solution="Ad-Hoc|iPhone" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|iPhoneSimulator" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|x64" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|x86" Project="Debug" />
-    <BuildType Solution="AppStore|Any CPU" Project="Debug" />
-    <BuildType Solution="AppStore|ARM" Project="Release" />
-    <BuildType Solution="AppStore|ARM64" Project="Release" />
-    <BuildType Solution="AppStore|iPhone" Project="Debug" />
-    <BuildType Solution="AppStore|iPhoneSimulator" Project="Debug" />
-    <BuildType Solution="AppStore|x64" Project="Debug" />
-    <BuildType Solution="AppStore|x86" Project="Debug" />
-  </Project>
-  <Project Path="LibVLCSharp.GTK/LibVLCSharp.GTK.csproj">
-    <BuildType Solution="Ad-Hoc|Any CPU" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|ARM" Project="Release" />
-    <BuildType Solution="Ad-Hoc|ARM64" Project="Release" />
-    <BuildType Solution="Ad-Hoc|iPhone" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|iPhoneSimulator" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|x64" Project="Debug" />
-    <BuildType Solution="Ad-Hoc|x86" Project="Debug" />
-    <BuildType Solution="AppStore|Any CPU" Project="Debug" />
-    <BuildType Solution="AppStore|ARM" Project="Release" />
-    <BuildType Solution="AppStore|ARM64" Project="Release" />
-    <BuildType Solution="AppStore|iPhone" Project="Debug" />
-    <BuildType Solution="AppStore|iPhoneSimulator" Project="Debug" />
-    <BuildType Solution="AppStore|x64" Project="Debug" />
-    <BuildType Solution="AppStore|x86" Project="Debug" />
-  </Project>
   <Project Path="LibVLCSharp.MAUI/LibVLCSharp.MAUI.csproj">
     <BuildType Solution="Ad-Hoc|*" Project="Debug" />
     <BuildType Solution="AppStore|*" Project="Debug" />


### PR DESCRIPTION
not included anymore on CI agents and deprecated for years anyway. Windows still builds it.