### PR TITLE
Add PreciseMediaTimer helper with sample and documentation

### DIFF
--- a/docs/precise-media-timer.md
+++ b/docs/precise-media-timer.md
@@ -1,0 +1,156 @@
+# PreciseMediaTimer
+
+## Overview
+`PreciseMediaTimer` is a helper class designed to provide smoother and more precise playback position updates for `MediaPlayer`.
+
+In LibVLC, `TimeChanged` events are tied to decoded frames and may be emitted at irregular intervals. This can result in visible jumps in progress bars, especially at low frame rates or near the end of playback.
+
+This helper interpolates the playback time between `TimeChanged` events using LibVLC’s monotonic clock (`LibVLC.Clock`), producing stable and high-frequency position updates suitable for UI scenarios.
+
+---
+
+## Problem
+
+`MediaPlayer.TimeChanged` alone is often insufficient for smooth progress bars because:
+
+- Events may be infrequent depending on the media frame rate
+- Reported timestamps can slightly lag behind the actual playback position
+- Near the end of playback, LibVLC may emit delayed timestamps that appear to go backwards
+
+This can cause UI issues such as:
+- Jittery progress bars
+- Small backward jumps near the end (e.g. stuck around ~90–95%)
+
+---
+
+## Solution
+
+`PreciseMediaTimer` addresses these issues by:
+
+1. Listening to `MediaPlayer.TimeChanged` events
+2. Storing the last known playback timestamp
+3. Using `LibVLC.Clock` to interpolate the current playback time between events
+4. Ignoring late backward timestamps near the end of the media (common VLC artefact)
+5. Emitting normalized position updates (`0.0` to `1.0`) at a steady interval
+
+This results in a smooth and stable progress bar without modifying LibVLC core behavior.
+
+---
+
+## Key Features
+
+- Smooth interpolation between VLC time updates
+- Handles delayed/backward timestamps near end of playback
+- Supports user seeks correctly
+- Lightweight and UI-framework agnostic
+- Emits normalized position values (0.0 → 1.0)
+
+---
+
+## Usage
+
+### 1. Create the timer
+
+```csharp
+var preciseTimer = new PreciseMediaTimer(mediaPlayer, libVLC);
+```
+
+### 2. Subscribe to position updates
+```csharp
+preciseTimer.PrecisePositionChanged += position =>
+{
+    // position is normalized between 0.0 and 1.0
+    progressBar.Value = position;
+};
+```
+
+### 3. Start the timer
+```csharp
+preciseTimer.Start();
+```
+
+### 4. Stop when not needed
+```csharp
+preciseTimer.Stop();
+```
+
+### 5. Dispose when finished
+```csharp
+preciseTimer.Dispose();
+```
+
+
+## Full Example
+
+```csharp
+var preciseTimer = new PreciseMediaTimer(mediaPlayer, libVLC);
+
+preciseTimer.PrecisePositionChanged += pos =>
+{
+    // Marshal to UI thread if required (WPF / WinUI / Avalonia, etc.)
+    Dispatcher.Invoke(() =>
+    {
+        progressBar.Value = pos;
+    });
+};
+
+// Start playback
+mediaPlayer.Play(media);
+preciseTimer.Start();
+
+// When closing the view / stopping playback
+void OnClose()
+{
+    preciseTimer?.Stop();
+    preciseTimer?.Dispose();
+    preciseTimer = null;
+
+    mediaPlayer?.Stop();
+    mediaPlayer?.Dispose();
+
+    libVLC?.Dispose();
+}
+```
+
+## Threading Notes
+`PrecisePositionChanged` is raised from a background timer thread.  
+UI frameworks (WPF, WinUI, Avalonia, etc.) should marshal updates to the UI thread:
+
+```csharp
+preciseTimer.PrecisePositionChanged += pos =>
+{
+    Dispatcher.Invoke(() =>
+    {
+        progressBar.Value = pos;
+    });
+};
+```
+
+## Lifecycle Notes
+
+`PreciseMediaTimer` should be stopped and disposed when the associated `MediaPlayer` or view is closed.
+
+Since the timer runs on a background thread and remains subscribed to `MediaPlayer.TimeChanged`, failing to dispose it may result in callbacks after the player or UI has been destroyed.
+
+Example:
+```csharp
+preciseTimer.Stop();
+preciseTimer.Dispose();
+```
+
+## When to Use
+Use `PreciseMediaTimer` when you need:
+
+- Smooth progress bar updates
+- High-frequency position interpolation
+- Stable UI feedback during playback
+
+It is especially useful for:
+
+- Media players
+- Custom timeline controls
+- Visual playback synchronization
+
+## When Not to Use
+If coarse position updates are sufficient and UI smoothness is not critical,  
+`MediaPlayer.TimeChanged` alone may be enough.

--- a/samples/LibVLCSharp.WPF.Sample/PreciseTimerSample.xaml
+++ b/samples/LibVLCSharp.WPF.Sample/PreciseTimerSample.xaml
@@ -1,0 +1,28 @@
+﻿<Window x:Class="LibVLCSharp.WPF.Sample.PreciseTimerSample"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vlc="clr-namespace:LibVLCSharp.WPF;assembly=LibVLCSharp.WPF"
+        Title="Precise Timer Sample" Height="450" Width="800">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Video -->
+        <vlc:VideoView x:Name="VideoView" Grid.Row="0"/>
+
+        <!-- Progress Bars -->
+        <StackPanel Grid.Row="1" Margin="10">
+            
+            <TextBlock Text="Precise Progress" Margin="0,10,0,0"/>
+            <ProgressBar x:Name="SmoothProgress" Height="20" Minimum="0" Maximum="1"/>
+
+            <Button Content="Start Precise Timer Test"
+                    Click="PreciseTimerClassTest_Click"
+                    Margin="0,10,0,0"/>
+
+        </StackPanel>
+    </Grid>
+</Window>

--- a/samples/LibVLCSharp.WPF.Sample/PreciseTimerSample.xaml.cs
+++ b/samples/LibVLCSharp.WPF.Sample/PreciseTimerSample.xaml.cs
@@ -1,0 +1,58 @@
+﻿using LibVLCSharp.Shared;
+using LibVLCSharp.Shared.Helpers;
+using System;
+using System.Windows;
+
+namespace LibVLCSharp.WPF.Sample
+{
+    public partial class PreciseTimerSample : Window
+    {
+        private LibVLC _libVLC;
+        private MediaPlayer _mediaPlayer;
+        private PreciseMediaTimer? _preciseTimer;
+
+        public PreciseTimerSample()
+        {
+            InitializeComponent();
+
+            Core.Initialize();
+
+            _libVLC = new LibVLC();
+            _mediaPlayer = new MediaPlayer(_libVLC);
+
+            VideoView.MediaPlayer = _mediaPlayer;
+        }
+
+        private void PreciseTimerClassTest_Click(object sender, RoutedEventArgs e)
+        {
+            var media = new Media(_libVLC, new Uri("https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/dash/ForBiggerEscapesVideo.mp4"));
+            _mediaPlayer.Play(media);
+
+            _preciseTimer?.Dispose();
+            _preciseTimer = new PreciseMediaTimer(_mediaPlayer, _libVLC);
+
+            _preciseTimer.PrecisePositionChanged += pos =>
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    SmoothProgress.Value = pos;
+                });
+            };
+
+            _preciseTimer.Start();
+        }
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            _preciseTimer?.Dispose();
+            _preciseTimer = null;
+
+            _mediaPlayer?.Stop();
+            _mediaPlayer?.Dispose();
+
+            _libVLC?.Dispose();
+        }
+
+    }
+}

--- a/src/LibVLCSharp/Shared/Helpers/PreciseMediaTimer.cs
+++ b/src/LibVLCSharp/Shared/Helpers/PreciseMediaTimer.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Timers;
+
+namespace LibVLCSharp.Shared.Helpers
+{
+    /// <summary>
+    /// Provides a more precise playback timer for a <see cref="MediaPlayer"/> by
+    /// interpolating the current playback time using LibVLC's monotonic clock.
+    /// </summary>
+    /// <remarks>
+    /// This helper is useful for UI scenarios such as smooth progress bars,
+    /// where <see cref="MediaPlayer.Time"/> updates are not frequent enough
+    /// and can cause visible jumps.
+    ///
+    /// The timer listens to <see cref="MediaPlayer.TimeChanged"/> events to store
+    /// the last known playback timestamp, and then uses <see cref="LibVLC.Clock"/>
+    /// to interpolate the current playback time between updates.
+    ///
+    /// This class is cross-platform and does not depend on any specific UI framework.
+    /// UI updates should be marshalled to the UI thread by the consumer.
+    /// </remarks>
+    public sealed class PreciseMediaTimer : IDisposable
+    {
+        private readonly MediaPlayer _mp;
+        private readonly LibVLC _libVLC;
+        private readonly Timer _timer;
+
+        private long _lastTs;
+        private long _lastClock;
+        private float _lastRate;
+        private bool _hasFirstUpdate;
+
+        private long _lastInterpolatedTime;
+
+        /// <summary>
+        /// Occurs when a new interpolated playback position is available.
+        /// The value is normalized between 0.0 and 1.0.
+        /// </summary>
+        public event Action<double>? PrecisePositionChanged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreciseMediaTimer"/> class.
+        /// </summary>
+        /// <param name="mp">The associated <see cref="MediaPlayer"/> instance.</param>
+        /// <param name="libVLC">The associated <see cref="LibVLC"/> instance.</param>
+        /// <param name="intervalMs">
+        /// The interpolation update interval in milliseconds. Default is 50 ms.
+        /// </param>
+        public PreciseMediaTimer(MediaPlayer mp, LibVLC libVLC, int intervalMs = 16)
+        {
+            _mp = mp ?? throw new ArgumentNullException(nameof(mp));
+            _libVLC = libVLC ?? throw new ArgumentNullException(nameof(libVLC));
+
+            _timer = new Timer(intervalMs)
+            {
+                AutoReset = true
+            };
+
+            _timer.Elapsed += OnTick;
+            _mp.TimeChanged += OnTimeChanged;
+        }
+
+        /// <summary>
+        /// Handles native TimeChanged events and stores the last known playback state.
+        /// </summary>
+        private void OnTimeChanged(object? sender, MediaPlayerTimeChangedEventArgs e)
+        {
+            // Compare against the current interpolated playback time instead of the last raw VLC timestamp.
+            // LibVLC timestamps can lag behind the interpolated value, which represents the actual
+            // playback head position used by the UI.
+            if (_hasFirstUpdate && e.Time < _lastInterpolatedTime && _mp.Length > 0)
+            {
+                var progress = (double)_lastInterpolatedTime / _mp.Length;
+
+                // If we are near the end of the media, this backward jump is most likely
+                // a known LibVLC artefact (late TimeChanged event). Ignore it to avoid
+                // progress bar snapping backwards (e.g., the "stuck at ~92%" issue).
+                if (progress > 0.9)
+                    return;
+            }
+
+            // Accept the new timestamp and update the interpolation reference point.
+            // This also correctly handles real user-initiated seeks.
+            _lastTs = e.Time;
+            _lastClock = _libVLC.Clock;
+            _lastRate = _mp.Rate;
+
+            // Reset the monotonic floor to the new VLC time so interpolation resumes from here.
+            _lastInterpolatedTime = e.Time;
+            _hasFirstUpdate = true;
+        }
+
+        /// <summary>
+        /// Performs time interpolation using the LibVLC monotonic clock.
+        /// </summary>
+        private void OnTick(object? sender, ElapsedEventArgs e)
+        {
+            if (!_hasFirstUpdate || _mp.Length <= 0)
+                return;
+
+            if (_mp.State == VLCState.Ended)
+            {
+                PrecisePositionChanged?.Invoke(1.0);
+                return;
+            }
+
+            if (_mp.State != VLCState.Playing)
+                return;
+
+            var nowClock = _libVLC.Clock;
+            var deltaMs = (nowClock - _lastClock) / 1000;
+            var interpolatedTime = _lastTs + (long)(deltaMs * _lastRate);
+
+            if (interpolatedTime < _lastInterpolatedTime - 1000)
+                _lastInterpolatedTime = interpolatedTime;
+            else if (interpolatedTime < _lastInterpolatedTime)
+                interpolatedTime = _lastInterpolatedTime;
+
+            _lastInterpolatedTime = interpolatedTime;
+
+            if (interpolatedTime >= _mp.Length)
+                interpolatedTime = _mp.Length;
+
+            var position = (double)interpolatedTime / _mp.Length;
+
+            if (position < 0.0)
+                position = 0.0;
+            if (position > 1.0)
+                position = 1.0;
+
+            PrecisePositionChanged?.Invoke(position);
+        }
+
+        /// <summary>
+        /// Starts the interpolation timer.
+        /// </summary>
+        public void Start()
+        {
+            _hasFirstUpdate = false;
+            _lastInterpolatedTime = 0;
+            _timer.Start();
+        }
+
+        /// <summary>
+        /// Stops the interpolation timer.
+        /// </summary>
+        public void Stop() => _timer.Stop();
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="PreciseMediaTimer"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            _timer.Stop();
+            _timer.Elapsed -= OnTick;
+            _mp.TimeChanged -= OnTimeChanged;
+            _timer.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

This PR introduces a `PreciseMediaTimer` helper that provides smoother and more precise playback position updates for `MediaPlayer`.

`MediaPlayer.TimeChanged` events are tied to decoded frames and may be emitted at irregular intervals. This can cause jittery progress bars and, in some cases, small backward jumps near the end of playback due to delayed timestamps.

The new helper interpolates playback time using `LibVLC.Clock` to provide high-frequency, stable position updates suitable for UI scenarios. It also ignores late backward timestamps near the end of the media while still allowing legitimate user seeks.

This PR includes:
- A new helper class: `PreciseMediaTimer`
- A WPF sample demonstrating usage
- Documentation explaining the problem, solution, lifecycle, and usage

### Issues Resolved ### 

- Related to the "Add more precise timer for progress bar scenarios" issue discussed on GitLab:
  https://code.videolan.org/videolan/LibVLCSharp/-/issues/449

### API Changes ###

Added:
- `PreciseMediaTimer` helper class for interpolated playback position updates

### Platforms Affected ### 

- Core (all platforms)

### Behavioral/Visual Changes ###

Improves smoothness and stability of progress bar updates when using the new `PreciseMediaTimer` helper.  
No behavior changes for existing users unless they opt-in to use the helper.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Run the WPF sample project.
2. Start media playback.
3. Subscribe to `PreciseMediaTimer.PrecisePositionChanged`.
4. Observe that the progress bar updates smoothly with high-frequency interpolation.
5. Seek forward/backward and verify that legitimate seeks are handled correctly.
6. Let the media play near the end and verify that no backward jumps occur due to delayed `TimeChanged` events.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard