### PR TITLE
Add support to native Windows ARM64 with fallback to Win64

### DIFF
--- a/src/LibVLCSharp/Shared/Core/Constants.cs
+++ b/src/LibVLCSharp/Shared/Core/Constants.cs
@@ -30,6 +30,7 @@ namespace LibVLCSharp.Shared
 
     internal static class ArchitectureNames
     {
+        internal const string WinArm64 = "win-arm64";
         internal const string Win64 = "win-x64";
         internal const string Win86 = "win-x86";
         internal const string MacOS64 = "osx-x64";

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -77,6 +77,20 @@ namespace LibVLCSharp.Shared
             {
                 arch = Path.Combine(ArchitectureNames.MacOS64, Constants.Lib);
             }
+
+#if !NET40 && !NETSTANDARD1_1
+            else if (PlatformHelper.IsWindows)
+            {
+                arch = RuntimeInformation.ProcessArchitecture switch
+                {
+                    Architecture.X64 => ArchitectureNames.Win64,
+                    Architecture.X86 => ArchitectureNames.Win86,
+                    Architecture.Arm64 => ArchitectureNames.WinArm64,
+                    _ => PlatformHelper.IsX64BitProcess ? ArchitectureNames.Win64 : ArchitectureNames.Win86
+                };
+            }
+#endif
+
             else
             {
                 arch = PlatformHelper.IsX64BitProcess ? ArchitectureNames.Win64 : ArchitectureNames.Win86;
@@ -123,6 +137,27 @@ namespace LibVLCSharp.Shared
             var libvlcPath3 = LibVLCPath(Path.GetDirectoryName(libvlcAssemblyLocation)!);
 
             paths.Add((string.Empty, libvlcPath3));
+
+            // Add Win64 folders as fallback for WinArm64 to keep compatibility
+            if (arch == ArchitectureNames.WinArm64)
+            {
+                var fallbackLibvlcDirPath1 = Path.Combine(Path.GetDirectoryName(libvlcAssemblyLocation)!,
+                    Constants.LibrariesRepositoryFolderName, ArchitectureNames.Win64);
+
+                var fallbackLibvlccorePath1 = LibVLCCorePath(fallbackLibvlcDirPath1);
+                var fallbackLibvlcPath1 = LibVLCPath(fallbackLibvlcDirPath1);
+                paths.Add((fallbackLibvlccorePath1, fallbackLibvlcPath1));
+            
+                if (!string.IsNullOrEmpty(assemblyLocation))
+                {
+                    var fallbackLibvlcDirPath2 = Path.Combine(Path.GetDirectoryName(assemblyLocation)!,
+                        Constants.LibrariesRepositoryFolderName, ArchitectureNames.Win64);
+
+                    var fallbackLibvlccorePath2 = LibVLCCorePath(fallbackLibvlcDirPath2);
+                    var fallbackLibvlcPath2 = LibVLCPath(fallbackLibvlcDirPath2);
+                    paths.Add((fallbackLibvlccorePath2, fallbackLibvlcPath2));
+                }
+            }
 
             if (PlatformHelper.IsMac)
             {


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

Add support to native Windows ARM64 with fallback to Win64.
It allows LibVLCSharp to detect win-arm64 in Core.cs and add fallback to win-x64 folders to preserve compatibility.
It complements mfkl/libvlc-nuget#53 and corresponding [PR](https://github.com/mfkl/libvlc-nuget/pull/55) , which added ARM64 binaries, allowing WPF apps on Windows ARM devices to load LibVLC natively.

### Issues Resolved ### 
- fixes [issue#586](https://code.videolan.org/videolan/LibVLCSharp/-/issues/586) 

### API Changes ###

Added:
 - internal const string ArchitectureNames.WinArm64 in Constants.cs
 - else if (PlatformHelper.IsWindows) { ... } branch in Core.cs to detect Architecture.Arm64
 - Fallback search paths for win-x64 when running on win-arm64 in Core.cs


### Platforms Affected ### 
- Windows ARM64
- Windows X64 (now including inside branch else if (PlatformHelper.IsWindows) )
- Windows ARM64 (now including inside branch else if (PlatformHelper.IsWindows) )

### Behavioral/Visual Changes ###
None


### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
git clone https://github.com/micha102/libvlcsharp.git
exclude Android, iOS and few others
dotnet pack src/LibVLCSharp/LibVLCSharp.csproj -c Win32Release
dotnet pack src/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj -c Win32Release

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
