### PR TITLE
Improved Avalonia Sample Hack

### DIFF
--- a/samples/LibVLCSharp.Avalonia.Sample/ViewModels/MainWindowViewModel.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/ViewModels/MainWindowViewModel.cs
@@ -22,7 +22,7 @@ namespace LibVLCSharp.Avalonia.Sample.ViewModels
                 return;
             }
             
-            using var media = new Media(_libVlc, new Uri("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"));
+            using var media = new Media(_libVlc, new Uri("https://www.w3schools.com/tags/mov_bbb.mp4"));
             MediaPlayer.Play(media);
         }
         

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml
@@ -1,11 +1,26 @@
 <Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:v="clr-namespace:LibVLCSharp.Avalonia.Sample.Views"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="LibVLCSharp.Avalonia.Sample.Views.MainWindow"
-        Icon="/Assets/avalonia-logo.ico"
-        Title="LibVLCSharp.Avalonia.Sample">
-    <v:VideoPlayer />
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+		xmlns:v="clr-namespace:LibVLCSharp.Avalonia.Sample.Views"
+		mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+		x:Class="LibVLCSharp.Avalonia.Sample.Views.MainWindow"
+		Icon="/Assets/avalonia-logo.ico"
+		Title="LibVLCSharp.Avalonia.Sample">
+	<Grid Name="teste" RowDefinitions="Auto, *, Auto">
+		<Label Grid.Row="0" 
+			   Content="Video Player"
+			   HorizontalAlignment="Center"/>
+		<v:VideoPlayer Grid.Row="1" 
+					   MediaPlayer="{Binding MediaPlayer}"
+					   HorizontalAlignment="Stretch"
+					   VerticalAlignment="Stretch">
+			<Panel Name="ControlsPanel">
+				<StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Background="#900000FF" Spacing="20">
+					<Button Command="{Binding Play}" Margin="20">Play</Button>
+					<Button Command="{Binding Stop}" Margin="20">Stop</Button>
+				</StackPanel>
+			</Panel>
+		</v:VideoPlayer>
+	</Grid>
 </Window>

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 
 namespace LibVLCSharp.Avalonia.Sample.Views

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml
@@ -1,31 +1,11 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"
-             xmlns:viewModels="clr-namespace:LibVLCSharp.Avalonia.Sample.ViewModels"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="LibVLCSharp.Avalonia.Sample.Views.VideoPlayer"
-             DataContextChanged="OnDataContextChanged">
-
-    <Design.DataContext>
-        <viewModels:MainWindowViewModel />
-    </Design.DataContext>
-
-    <Grid RowDefinitions="Auto, *, Auto">
-        <Label Grid.Row="0" HorizontalAlignment="Center">Video Player</Label>
-
-        <vlc:VideoView Grid.Row="1" MediaPlayer="{Binding MediaPlayer}"
-                       HorizontalAlignment="Stretch"
-                       VerticalAlignment="Stretch"
-                       PointerEntered="VideoViewOnPointerEntered"
-                       PointerExited="VideoViewOnPointerExited">
-            <Panel Name="ControlsPanel">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Background="#900000FF" Spacing="20">
-                    <Button Command="{Binding Play}" Margin="20">Play</Button>
-                    <Button Command="{Binding Stop}" Margin="20">Stop</Button>
-                </StackPanel>
-            </Panel>
-        </vlc:VideoView>
-    </Grid>
+<UserControl xmlns="https://github.com/avaloniaui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:vlc="clr-namespace:LibVLCSharp.Avalonia;assembly=LibVLCSharp.Avalonia"			
+			 x:Class="LibVLCSharp.Avalonia.Sample.Views.VideoPlayer">
+	<ContentControl.Template>
+		<ControlTemplate>
+			<vlc:VideoView Content="{TemplateBinding Content}"
+						   MediaPlayer="{TemplateBinding MediaPlayer}"/>
+		</ControlTemplate>
+	</ContentControl.Template>
 </UserControl>

--- a/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
+++ b/samples/LibVLCSharp.Avalonia.Sample/Views/VideoPlayer.axaml.cs
@@ -1,33 +1,38 @@
-﻿using System;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
-using LibVLCSharp.Avalonia.Sample.ViewModels;
+using Avalonia.Data;
+using LibVLCSharp.Shared;
 
 namespace LibVLCSharp.Avalonia.Sample.Views
 {
     public partial class VideoPlayer : UserControl
     {
+        private MediaPlayer? _mediaPlayer = null;
+
+        public static readonly DirectProperty<VideoPlayer, MediaPlayer?> MediaPlayerProperty =
+            VideoView.MediaPlayerProperty.AddOwner<VideoPlayer>(
+                getter: o => o.MediaPlayer,
+                setter: (o, v) => o.MediaPlayer = v,
+                defaultBindingMode: BindingMode.TwoWay);
+
+        public MediaPlayer? MediaPlayer
+        {
+            get => _mediaPlayer;
+            set => SetAndRaise(MediaPlayerProperty, ref _mediaPlayer, value);
+        }
+
         public VideoPlayer()
         {
             InitializeComponent();
         }
 
-        private void OnDataContextChanged(object sender, EventArgs e)
-        {
-            if (DataContext is MainWindowViewModel vm)
-            {
-                vm.Play();
-            }
-        }
-
-        private void VideoViewOnPointerEntered(object sender, PointerEventArgs e)
-        {
-            ControlsPanel.IsVisible = true;
-        }
-
-        private void VideoViewOnPointerExited(object sender, PointerEventArgs e)
-        {
-            ControlsPanel.IsVisible = false;
-        }
+        //We can forward pointer events (or any other as needed) from VideoView to VideoPlayer or just handle them using the child element of VideoPlayer.
+        /// <vlc:VideoView Content="{TemplateBinding Content}"
+        ///                PointerEntered="VideoView_PointerEvent"
+        ///                MediaPlayer="{TemplateBinding MediaPlayer}"/>
+        //private void VideoView_PointerEvent(object? sender, PointerEventArgs e)
+        //{
+        //    this.RaiseEvent(e);
+        //}
     }
 }


### PR DESCRIPTION
Improved the previous LibVLCSharp.Avalonia.Samples VideoPlayer hack and made it more reusable.

### Description of Change ###

-Transformed VideoPlayer into a more reusable component with it's own MediaPlayer DirectProperty that takes ownership of VideoView.MediaPlayerProperty (...but does taking ownership even matter!?)
-The .axml now defines a ControlTemplate where VideoView's MediaPlayer and Content are TemplateBinded
-Removed any reference to a ViewModel in the VideoPlayer
-Now it is possible to set the overlay directly on VideoPlayer instead of VideoView

```
<Window>
   <VideoPlayer {Binding MediaPlayer}>
       <Panel> <- we can use the top level container to handle pointer events
           ...some other controls
       </Panel>
   </VideoPlayer>
</Window>
```

Note: VideoPlayer pointer events don't trigger, but we can wire them like this if really needed:

VideoPlayer.axml:
```
 <vlc:VideoView Content="{TemplateBinding Content}"
                           PointerEntered="VideoView_PointerEvent"
                           ...any other event needed
                           MediaPlayer="{TemplateBinding MediaPlayer}"/>
```
                           
VideoPlayer.axml.cs:
```
private void VideoView_PointerEvent(object? sender, PointerEventArgs e)
{
    this.RaiseEvent(e);
}
```

This could also be integrated into the library:

-VideoPlayer would become the new VideoView
-The old VideoView would become NativeVideoView

### Issues Resolved ### 
None

### API Changes ###
None

### Platforms Affected ### 

None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
