### PR TITLE
Avalonia: fix exception thrown when UserControl is unloaded

### DIFF
--- a/buildsystem/build.cake
+++ b/buildsystem/build.cake
@@ -26,7 +26,11 @@ var libraryProjects = new string[]
     "../src/LibVLCSharp.WinForms/LibVLCSharp.WinForms.csproj",
     "../src/LibVLCSharp.WPF/LibVLCSharp.WPF.csproj",
 };
-var testCsproj = "../src/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj";
+var testCsprojs = new string[]
+{
+    "../src/LibVLCSharp.Tests/LibVLCSharp.Tests.csproj",
+    "../src/LibVLCSharp.Avalonia.Tests/LibVLCSharp.Avalonia.Tests.csproj",
+};
 
 var packagesDir = "../packages";
 var isCiBuild = BuildSystem.AzurePipelines.IsRunningOnAzurePipelines;
@@ -100,7 +104,10 @@ Task("Test")
         Loggers = new []{ "console;verbosity=detailed" }
     };
 
-    DotNetTest(testCsproj, settings);
+    foreach(var project in testCsprojs)
+    {
+        DotNetTest(project, settings);
+    }
 });
 
 Task("CIDeploy")

--- a/src/LibVLCSharp.Avalonia.Tests/LibVLCSharp.Avalonia.Tests.csproj
+++ b/src/LibVLCSharp.Avalonia.Tests/LibVLCSharp.Avalonia.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>    
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../LibVLCSharp.Avalonia/LibVLCSharp.Avalonia.csproj" />
+  </ItemGroup>
+ 
+
+</Project>

--- a/src/LibVLCSharp.Avalonia.Tests/TestAppBuilder.cs
+++ b/src/LibVLCSharp.Avalonia.Tests/TestAppBuilder.cs
@@ -1,0 +1,9 @@
+﻿using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<LibVLCSharp.Avalonia.Tests.App>()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/src/LibVLCSharp.Avalonia.Tests/VideoViewTests.cs
+++ b/src/LibVLCSharp.Avalonia.Tests/VideoViewTests.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using NUnit.Framework;
+
+namespace LibVLCSharp.Avalonia.Tests
+{
+    public class VideoViewTests
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        [AvaloniaTest]
+        public void VideoView_Should_Be_Removed_From_VisualTree_When_Parent_Is_Removed(bool withContent)
+        {
+            // Setup controls:
+            var videoView = new VideoView
+            {
+                Name = "VideoView",
+                Content = withContent ? new TextBox() { Name = "VideoViewTextBox", Text = "" } : null
+            };
+            var secondView = new TextBox() { Name = "Second", Text = "" };
+            var window = new Window { Content = videoView };
+
+            // Open window:
+            window.Show();
+            // change Content of window:
+            window.Content = secondView;
+            // wait for the UI to process the change:
+            window.Dispatcher.RunJobs();
+
+            var RemovedVideoView = window.FindDescendantOfType<VideoView>(false, t => t.Name == "VideoView");
+            var secondTextBox = window.FindDescendantOfType<TextBox>(false, t => t.Name == "Second");
+            Assert.That(RemovedVideoView, Is.Null);
+            Assert.That(secondTextBox, Is.Not.Null);
+        }
+    }
+}

--- a/src/LibVLCSharp.Avalonia.Tests/VideoViewTests.cs
+++ b/src/LibVLCSharp.Avalonia.Tests/VideoViewTests.cs
@@ -23,10 +23,18 @@ namespace LibVLCSharp.Avalonia.Tests
 
             // Open window:
             window.Show();
-            // change Content of window:
-            window.Content = secondView;
-            // wait for the UI to process the change:
-            window.Dispatcher.RunJobs();
+            try
+            {                
+                // change Content of window:
+                window.Content = secondView;
+                // wait for the UI to process the change:
+                window.Dispatcher.RunJobs();
+            }
+            catch
+            {
+                // fail the test if any exception occurs during the process
+                Assert.Fail("An exception occurred while changing the window content.");
+            }
 
             var RemovedVideoView = window.FindDescendantOfType<VideoView>(false, t => t.Name == "VideoView");
             var secondTextBox = window.FindDescendantOfType<TextBox>(false, t => t.Name == "Second");

--- a/src/LibVLCSharp.Avalonia.Tests/app.axaml
+++ b/src/LibVLCSharp.Avalonia.Tests/app.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="LibVLCSharp.Avalonia.Tests.App">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/src/LibVLCSharp.Avalonia.Tests/app.axaml.cs
+++ b/src/LibVLCSharp.Avalonia.Tests/app.axaml.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace LibVLCSharp.Avalonia.Tests
+{
+    public class App : Application
+    {
+        public override void Initialize()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/LibVLCSharp.Avalonia/VideoView.cs
+++ b/src/LibVLCSharp.Avalonia/VideoView.cs
@@ -149,6 +149,11 @@ namespace LibVLCSharp.Avalonia
             _floatingContent.MaxWidth = Bounds.Width;
             _floatingContent.MaxHeight = Bounds.Height;
 
+            if (!this.IsAttachedToVisualTree())
+            {
+                return;
+            }
+
             var newPosition = this.PointToScreen(topLeft);
 
             if (newPosition != _floatingContent.Position)


### PR DESCRIPTION
### Description of Change ###
i have create a test project `LibVLCSharp.Avalonia.Tests` which reference and test `LibVLCSharp.Avalonia` project
i have added only two tests to assure of `VideoView` removal correctly when it has a content or without a content

```c#
[TestCase(true)]
[TestCase(false)]
[AvaloniaTest]
public void VideoView_Should_Be_Removed_From_VisualTree_When_Parent_Is_Removed(bool withContent)
{
    // Setup controls:
    var videoView = new VideoView
    {
        Name = "VideoView",
        Content = withContent ? new TextBox() { Name = "VideoViewTextBox", Text = "" } : null
    };
    var secondView = new TextBox() { Name = "Second", Text = "" };
    var window = new Window { Content = videoView };
    // Open window:
    window.Show();
    try
    {                
        // change Content of window:
        window.Content = secondView;
        // wait for the UI to process the change:
        window.Dispatcher.RunJobs();
    }
    catch
    {
        // fail the test if any exception occurs during the process
        Assert.Fail("An exception occurred while changing the window content.");
    }
    var RemovedVideoView = window.FindDescendantOfType<VideoView>(false, t => t.Name == "VideoView");
    var secondTextBox = window.FindDescendantOfType<TextBox>(false, t => t.Name == "Second");
    Assert.That(RemovedVideoView, Is.Null);
    Assert.That(secondTextBox, Is.Not.Null);
}
```
this test was pass in contentless VedioView and Fail in the other one .... in order to make it pass in both cases i have added a guard before the problem line `PointToScreen`:
```c#
 if (!this.IsAttachedToVisualTree())
 {
       return;
 }

var newPosition = this.PointToScreen(topLeft);
```

this test should be the same test for the problem in https://github.com/videolan/libvlcsharp/pull/371


the other files is just add to make a test environment  Taken from [Avalonia docs : Headless Testing with NUnit](https://docs.avaloniaui.net/docs/testing/headless-nunit)
- app.axaml
- app.axaml.cs
- TestAppBuilder.cs

