### PR TITLE
Fix inverted return value in Media.Statistics property

### DIFF
--- a/src/LibVLCSharp/Media.cs
+++ b/src/LibVLCSharp/Media.cs
@@ -484,7 +484,7 @@ namespace LibVLCSharp
         /// structure that contain the statistics about the media
         /// </summary>
         public MediaStats Statistics => Native.LibVLCMediaGetStats(NativeReference, out var mediaStats)
-            ? default : mediaStats;
+            ? mediaStats : default;
 
         MediaEventManager? _eventManager;
         /// <summary>


### PR DESCRIPTION
Swapped `default `and `mediaStats `to correctly return the populated struct.