### PR TITLE
Improve UWP sample

### DIFF
--- a/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
+++ b/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
@@ -165,9 +165,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
-      <Version>3.0.1</Version>
-    </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
       <Version>3.3.2</Version>
     </PackageReference>

--- a/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
+++ b/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>LibVLCSharp.UWP.Sample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -163,13 +163,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.12</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
-      <Version>2.0.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
-      <Version>3.3.1</Version>
+      <Version>3.3.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
+++ b/samples/LibVLCSharp.UWP.Sample/LibVLCSharp.UWP.Sample.csproj
@@ -183,31 +183,6 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
+++ b/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
@@ -5,18 +5,11 @@
     xmlns:local="using:LibVLCSharp.UWP.Sample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:lvs="using:LibVLCSharp.Platforms.Windows"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-      <lvs:VideoView MediaPlayer="{x:Bind ViewModel.MediaPlayer}">
-            <interactivity:Interaction.Behaviors>
-                <interactivity:EventTriggerBehavior EventName="Initialized">
-                    <interactivity:InvokeCommandAction Command="{x:Bind ViewModel.InitializedCommand}"/>
-                </interactivity:EventTriggerBehavior>
-            </interactivity:Interaction.Behaviors>
-        </lvs:VideoView>
+        <lvs:VideoView Initialized="VideoView_Initialized" MediaPlayer="{x:Bind ViewModel.MediaPlayer}" />
     </Grid>
 </Page>

--- a/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
+++ b/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
@@ -9,15 +9,12 @@
     xmlns:lvs="using:LibVLCSharp.Platforms.Windows"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    <Page.DataContext>
-        <local:MainViewModel />
-    </Page.DataContext>
 
     <Grid>
-      <lvs:VideoView MediaPlayer="{Binding MediaPlayer}">
+      <lvs:VideoView MediaPlayer="{x:Bind ViewModel.MediaPlayer}">
             <interactivity:Interaction.Behaviors>
                 <interactivity:EventTriggerBehavior EventName="Initialized">
-                    <interactivity:InvokeCommandAction Command="{Binding InitializedCommand}"/>
+                    <interactivity:InvokeCommandAction Command="{x:Bind ViewModel.InitializedCommand}"/>
                 </interactivity:EventTriggerBehavior>
             </interactivity:Interaction.Behaviors>
         </lvs:VideoView>

--- a/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
+++ b/samples/LibVLCSharp.UWP.Sample/MainPage.xaml
@@ -6,7 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
     xmlns:lvs="using:LibVLCSharp.Platforms.Windows"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -17,9 +16,9 @@
     <Grid>
       <lvs:VideoView MediaPlayer="{Binding MediaPlayer}">
             <interactivity:Interaction.Behaviors>
-                <interactions:EventTriggerBehavior EventName="Initialized">
-                    <interactions:InvokeCommandAction Command="{Binding InitializedCommand}"/>
-                </interactions:EventTriggerBehavior>
+                <interactivity:EventTriggerBehavior EventName="Initialized">
+                    <interactivity:InvokeCommandAction Command="{Binding InitializedCommand}"/>
+                </interactivity:EventTriggerBehavior>
             </interactivity:Interaction.Behaviors>
         </lvs:VideoView>
     </Grid>

--- a/samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
+++ b/samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
@@ -12,6 +12,12 @@ namespace LibVLCSharp.UWP.Sample
         public MainPage()
         {
             InitializeComponent();
+            ViewModel = new MainViewModel();
         }
+
+        /// <summary>
+        /// Gets the view model.
+        /// </summary>
+        public MainViewModel ViewModel { get; }
     }
 }

--- a/samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
+++ b/samples/LibVLCSharp.UWP.Sample/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using LibVLCSharp.Platforms.Windows;
+using Windows.UI.Xaml.Controls;
 
 namespace LibVLCSharp.UWP.Sample
 {
@@ -19,5 +20,10 @@ namespace LibVLCSharp.UWP.Sample
         /// Gets the view model.
         /// </summary>
         public MainViewModel ViewModel { get; }
+
+        private void VideoView_Initialized(object sender, InitializedEventArgs e)
+        {
+            ViewModel.InitializedCommand.Execute(e);
+        }
     }
 }

--- a/samples/LibVLCSharp.UWP.Sample/Package.appxmanifest
+++ b/samples/LibVLCSharp.UWP.Sample/Package.appxmanifest
@@ -1,24 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package 
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  IgnorableNamespaces="uap uap5 mp">
+
   <Identity Name="6adbf218-caa7-4240-9689-3b74cf39ad2d" Publisher="CN=VideoLAN" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="6adbf218-caa7-4240-9689-3b74cf39ad2d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+
   <Properties>
     <DisplayName>LibVLCSharp.UWP.Sample</DisplayName>
     <PublisherDisplayName>VideoLAN</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
+
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
+
   <Resources>
     <Resource Language="x-generate" />
   </Resources>
+
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="LibVLCSharp.UWP.Sample.App">
-      <uap:VisualElements DisplayName="LibVLCSharp.UWP.Sample" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="LibVLCSharp.UWP.Sample" BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
-        </uap:DefaultTile>
-        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      <uap:VisualElements 
+        DisplayName="LibVLCSharp.UWP.Sample"
+		Square150x150Logo="Assets\Square150x150Logo.png"
+		Square44x44Logo="Assets\Square44x44Logo.png"
+		Description="LibVLCSharp.UWP.Sample"
+		BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" />
       </uap:VisualElements>
       <Extensions>
         <uap:Extension Category="windows.fileOpenPicker">

--- a/samples/LibVLCSharp.UWP.Sample/Properties/Default.rd.xml
+++ b/samples/LibVLCSharp.UWP.Sample/Properties/Default.rd.xml
@@ -21,7 +21,6 @@
       An Assembly element with Name="*Application*" applies to all assemblies in
       the application package. The asterisks are not wildcards.
     -->
-    <Assembly Name="*Application*" Dynamic="Required All" />
     
     
     <!-- Add your application specific runtime directives here. -->


### PR DESCRIPTION
### Description of Change ###

Updated the UWP sample to use the latest [supported version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-native) of [.NET Native](https://github.com/Microsoft/dotnet/blob/main/releases/UWP/net-native2.2/README.md) and [Windows SDK](https://learn.microsoft.com/en-us/windows/apps/windows-sdk). Enabled trimming and replaced binding markup with [x:Bind markup extension](https://learn.microsoft.com/en-us/windows/uwp/data-binding/data-binding-in-depth).
Updated the dependencies and removed the `XAML Behaviors` dependency.

### Issues Resolved ### 

- fixes #

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

The UWP sample application now launches more quickly as a result of trimming and the newly added option to bypass the splash screen.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

https://github.com/user-attachments/assets/4259094c-b318-4c36-bea1-f53db7297bc4

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
