### PR TITLE
fix windows-sdk+maui9 issue

### DIFF
--- a/src/LibVLCSharp.WinUI/LibVLCSharp.WinUI.csproj
+++ b/src/LibVLCSharp.WinUI/LibVLCSharp.WinUI.csproj
@@ -33,8 +33,36 @@ LibVLC needs to be installed separately, see VideoLAN.LibVLC.Windows.</Descripti
     </Page>
   </ItemGroup>
 
+  <!-- WindowsAppSDK is pinned per target-framework generation so we never force a consumer onto a
+       WindowsAppSDK newer than its .NET MAUI generation can use. WindowsAppSDK 1.8.x's build targets
+       copy Microsoft.Maui's HybridWebView.js from a path MAUI 9.0.x does not ship, causing MSB3030 in
+       consuming MAUI 9.0.x apps (WindowsAppSDK#6032). HybridWebView arrived in MAUI 9, so MAUI 8 lacks
+       that file too and is likewise exposed to 1.8 - hence every pre-net10 TFM (MAUI <= 9) stays below
+       1.8. 
+       MAUI pins WindowsAppSDK via its workload and consuming apps only roll it *up* to that floor,
+       so a pin at/below a generation's floor can never downgrade a consumer. Per Microsoft.Maui.Core's
+       NuGet dependency: MAUI 8.0.x resolves WindowsAppSDK 1.3.x-1.5.x, MAUI 9.0.x resolves 1.6.x-1.7.x
+       (and never 1.8). Overriding MAUI's pin is unsupported. Sources:
+         https://learn.microsoft.com/en-us/answers/questions/5645769/net-maui-compatibility-with-windowsappsdk-1-8 (override unsupported)
+         https://www.nuget.org/packages/Microsoft.Maui.Core/8.0.3 (WindowsAppSDK >= 1.3.230724000)
+         https://www.nuget.org/packages/Microsoft.Maui.Core/8.0.100 (WindowsAppSDK >= 1.5.240802000)
+         https://www.nuget.org/packages/Microsoft.Maui.Core/9.0.0 (WindowsAppSDK >= 1.6.240923002)
+         https://www.nuget.org/packages/Microsoft.Maui.Core/9.0.120 (WindowsAppSDK >= 1.7.250909003)
+         https://raw.githubusercontent.com/dotnet/maui/release/9.0.1xx/eng/Versions.props (MicrosoftWindowsAppSDKPackageVersion) -->
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net10.0'))">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
+  </ItemGroup>
+  <!-- net10-windows: pin MAUI 10.0.x's GA floor so consumers roll *up* as needed (e.g. MAUI 10.0.80+
+       rolls up to 1.8.251106002) rather than being forced higher. MAUI 10.0.0 (GA) floors at
+       WindowsAppSDK 1.7.250909003. Sources:
+         https://www.nuget.org/packages/Microsoft.Maui.Core/10.0.0 (WindowsAppSDK >= 1.7.250909003)
+         https://www.nuget.org/packages/Microsoft.Maui.Core/10.0.80 (WindowsAppSDK >= 1.8.251106002)
+         https://raw.githubusercontent.com/dotnet/maui/release/10.0.1xx/eng/Versions.props (MicrosoftWindowsAppSDKPackageVersion) -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250909003" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.251106002" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" NoWarn="NU1510" />


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

Sets the *floor* win-sdk versions per TFM target in the WinUI project to avoid conflicts with other consuming frameworks (Maui9 specifically).  Also documents the supporting source docs and various win-sdk floors per TFM.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes [#669](https://code.videolan.org/videolan/LibVLCSharp/-/work_items/669)

### API Changes ###


 None  (bould config only)

### Platforms Affected ### 

- WinUI
- Maui

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None (resolved build errors for apps targeting Maui9)

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->



### PR Checklist ###

- [ x] Rebased on top of the target branch at time of PR
- [x ] Changes adhere to coding standard
