### PR TITLE
fix: TypeLoadException on ARM64 by replacing vsnprintf with _vscprintf

### DIFF
--- a/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
+++ b/src/LibVLCSharp/Shared/Helpers/MarshalUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -61,8 +61,8 @@ namespace LibVLCSharp.Shared.Helpers
             [DllImport(Constants.Libc, EntryPoint = "vsnprintf", CallingConvention = CallingConvention.Cdecl)]
             public static extern int vsnprintf_linux(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args);
 
-            [DllImport(Constants.Msvcrt, EntryPoint = "vsnprintf", CallingConvention = CallingConvention.Cdecl)]
-            public static extern int vsnprintf_windows(IntPtr buffer, UIntPtr size, IntPtr format, IntPtr args);
+            [DllImport(Constants.Msvcrt, EntryPoint = "_vscprintf", CallingConvention = CallingConvention.Cdecl)]
+            public static extern int vscprintf_windows(IntPtr format, IntPtr args);
 #pragma warning restore IDE1006 // Naming Styles
         }
 
@@ -181,7 +181,11 @@ namespace LibVLCSharp.Shared.Helpers
             return Native.vsnprintf_linux(buffer, size, format, args);
 #else
             if (PlatformHelper.IsWindows)
-                return Native.vsnprintf_windows(buffer, size, format, args);
+            {
+                if (buffer == IntPtr.Zero && size == UIntPtr.Zero)
+                    return Native.vscprintf_windows(format, args);
+                return -1;
+            }
             else if (PlatformHelper.IsLinux)
                 return Native.vsnprintf_linux(buffer, size, format, args);
             return -1;


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

<!-- Describe your changes here. -->

Replaced the P/Invoke targeting `vsnprintf` in `msvcrt.dll` with `_vscprintf` for calculating required buffer lengths during logging on Windows platforms. 

### Rationale for Change
When running LibVLCSharp on ARM64 Windows devices, developers experience a constant stream of `System.TypeLoadException` warnings in their diagnostic logs (`Unresolved P/Invoke method 'msvcrt!vsnprintf_windows'`). While this doesn't crash the application, it creates significant noise and prevents LibVLC logs from being properly formatted and dispatched on ARM64.

Historically, `msvcrt.dll` did not export the standard C99 `vsnprintf` function. While modern x86 and x64 builds of Windows silently patched `msvcrt.dll` to include a `vsnprintf` forwarder (resolving to the modern UCRT), Microsoft did not include this forwarder in the ARM64 version of `msvcrt.dll`. 

Because `vsnprintf` is physically missing on ARM64 `msvcrt.dll`, the runtime fails to resolve the entry point, causing the noisy first-chance exceptions. However, `msvcrt.dll` *does* universally export `_vscprintf` (a Microsoft-specific function explicitly designed to count characters without writing them) across all architectures. By switching to `_vscprintf` to calculate the required buffer size, we avoid the missing entry point on ARM64 while retaining 100% compatibility across all legacy and modern Windows platforms.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None. No public-facing API signatures or contracts were altered. The change is entirely internal to `LibVLCSharp.Shared.Helpers.MarshalUtils`.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

* **ARM64 Windows:** `GetLogMessage` now successfully formats and dispatches log messages. The application diagnostic logs are no longer flooded with `TypeLoadException` warnings caused by unresolved P/Invokes.
* **x86 / x64 Windows:** No functional change. `_vscprintf` calculates the buffer size identically to how `vsnprintf(IntPtr.Zero, UIntPtr.Zero, ...)` behaved previously.


### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
