### PR TITLE
Fixed trace.assert not accounting for hwndSource

### DIFF
--- a/src/LibVLCSharp.WPF/ForegroundWindow.cs
+++ b/src/LibVLCSharp.WPF/ForegroundWindow.cs
@@ -76,9 +76,17 @@ namespace LibVLCSharp.WPF
             }
 
             _wndhost = GetWindow(_bckgnd);
-            Trace.Assert(_wndhost != null);
+
             if (_wndhost == null)
             {
+                if (PresentationSource.FromVisual(_bckgnd) is HwndSource)
+                {
+                    // Possibly Hosted WPF in a non-window source.
+                    // Therefore overlay would not be supported.
+                    return;
+                }
+
+                Trace.Assert(false, "VideoView is not hosted in a Window or HwndSource.");
                 return;
             }
 


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

<!-- Describe your changes here. -->
LibVLCSharp.WPF's Foreground window class tries to access the parent window in order to apply foreground elements. A Trace.Assert() fails if GetWindow() is null but a wpf is not necessarily in a Window, it could be hosted in a HwndSource. The changes account for this change and only fail the assertion if the parent is neither a Window or a HwndSource.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

No existing issue. Fixes a crash when LibVLCSharp.WPF is hosted in a HwndSource instead of a Window.

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

1. Host a LibVLCSharp.WPF VideoView inside a WPF application where the control is hosted by an HwndSource instead of a Window.
2. Initialize the VideoView and verify that ForegroundWindow no longer triggers an assertion failure.
3. Verify that normal WPF Window hosting behavior remains unchanged.
4. Verify that video playback and foreground element handling continue to work as expected.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
