### PR TITLE
Add macOS ARM64 support

### DIFF
--- a/src/LibVLCSharp/Shared/Core/Constants.cs
+++ b/src/LibVLCSharp/Shared/Core/Constants.cs
@@ -35,6 +35,7 @@ namespace LibVLCSharp.Shared
         internal const string Win64 = "win-x64";
         internal const string Win86 = "win-x86";
         internal const string MacOS64 = "osx-x64";
+        internal const string MacOSArm64 = "osx-arm64";
     }
 
     [Flags]

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -78,9 +78,8 @@ namespace LibVLCSharp.Shared
             {
                 arch = RuntimeInformation.ProcessArchitecture switch
                 {
-                    Architecture.X64 => Path.Combine(ArchitectureNames.MacOS64, Constants.Lib),
-                    Architecture.Arm64 => Path.Combine(ArchitectureNames.MacOSArm64, Constants.Lib),
-                    _ => Path.Combine(ArchitectureNames.MacOS64, Constants.Lib),
+                    Architecture.Arm64 => ArchitectureNames.MacOSArm64,
+                    _ => ArchitectureNames.MacOS64,
                 };
             }
             else if (PlatformHelper.IsWindows)
@@ -142,7 +141,7 @@ namespace LibVLCSharp.Shared
             paths.Add((string.Empty, libvlcPath3));
 
             // Add x64 folders as fallback for ARM64 to keep compatibility
-            if (arch == ArchitectureNames.WinArm64 || arch == Path.Combine(ArchitectureNames.MacOSArm64, Constants.Lib))
+            if (arch == ArchitectureNames.WinArm64 || arch == ArchitectureNames.MacOSArm64)
             {
                 var fallbackArchitecture = arch == ArchitectureNames.WinArm64
                     ? ArchitectureNames.Win64 : ArchitectureNames.MacOS64;
@@ -167,9 +166,8 @@ namespace LibVLCSharp.Shared
 
             if (PlatformHelper.IsMac)
             {
-                var libvlcPath4 = Path.Combine(Path.Combine(Path.GetDirectoryName(libvlcAssemblyLocation)!,
-                    Constants.Lib), $"{Constants.LibVLC}{LibraryExtension}");
-                var libvlccorePath4 = LibVLCCorePath(Path.Combine(Path.GetDirectoryName(libvlcAssemblyLocation)!, Constants.Lib));
+                var libvlcPath4 = Path.Combine(Path.GetDirectoryName(libvlcAssemblyLocation)!, $"{Constants.LibVLC}{LibraryExtension}");
+                var libvlccorePath4 = LibVLCCorePath(Path.GetDirectoryName(libvlcAssemblyLocation)!);
                 paths.Add((libvlccorePath4, libvlcPath4));
             }
 

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -194,6 +194,19 @@ namespace LibVLCSharp.Shared
                 loadResult = LoadNativeLibrary(libvlcPath, out LibvlcHandle);
                 if (!loadResult)
                     Log($"Failed to load required native libraries at {libvlcPath}");
+                
+#if NET5_0_OR_GREATER
+                // register custom resolver to load library from provided path
+                NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (dll, _, _) =>
+                {
+                    return dll switch
+                    {
+                        Constants.LibraryName => NativeLibrary.Load(libvlcPath),
+                        Constants.CoreLibraryName => NativeLibrary.Load(libvlccorePath),
+                        _ => IntPtr.Zero
+                    };
+                });
+#endif
                 return;
             }
 
@@ -203,8 +216,21 @@ namespace LibVLCSharp.Shared
             {
                 LoadNativeLibrary(libvlccore, out LibvlccoreHandle);
                 var loadResult = LoadNativeLibrary(libvlc, out LibvlcHandle);
-                if (loadResult)
-                    break;
+                if (!loadResult) continue;
+                
+#if NET5_0_OR_GREATER
+                // register custom resolver to load library from discovered path
+                NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (dll, _, _) =>
+                {
+                    return dll switch
+                    {
+                        Constants.LibraryName => NativeLibrary.Load(libvlc),
+                        Constants.CoreLibraryName => NativeLibrary.Load(libvlccore),
+                        _ => IntPtr.Zero
+                    };
+                });
+#endif
+                break;
             }
 
             if (!LibVLCLoaded)

--- a/src/LibVLCSharp/Shared/Core/Core.cs
+++ b/src/LibVLCSharp/Shared/Core/Core.cs
@@ -73,12 +73,16 @@ namespace LibVLCSharp.Shared
             var paths = new List<(string, string)>();
             string arch;
 
+#if !NET40 && !NETSTANDARD1_1
             if (PlatformHelper.IsMac)
             {
-                arch = Path.Combine(ArchitectureNames.MacOS64, Constants.Lib);
+                arch = RuntimeInformation.ProcessArchitecture switch
+                {
+                    Architecture.X64 => Path.Combine(ArchitectureNames.MacOS64, Constants.Lib),
+                    Architecture.Arm64 => Path.Combine(ArchitectureNames.MacOSArm64, Constants.Lib),
+                    _ => Path.Combine(ArchitectureNames.MacOS64, Constants.Lib),
+                };
             }
-
-#if !NET40 && !NETSTANDARD1_1
             else if (PlatformHelper.IsWindows)
             {
                 arch = RuntimeInformation.ProcessArchitecture switch
@@ -89,9 +93,8 @@ namespace LibVLCSharp.Shared
                     _ => PlatformHelper.IsX64BitProcess ? ArchitectureNames.Win64 : ArchitectureNames.Win86
                 };
             }
-#endif
-
             else
+#endif
             {
                 arch = PlatformHelper.IsX64BitProcess ? ArchitectureNames.Win64 : ArchitectureNames.Win86;
             }
@@ -138,11 +141,14 @@ namespace LibVLCSharp.Shared
 
             paths.Add((string.Empty, libvlcPath3));
 
-            // Add Win64 folders as fallback for WinArm64 to keep compatibility
-            if (arch == ArchitectureNames.WinArm64)
+            // Add x64 folders as fallback for ARM64 to keep compatibility
+            if (arch == ArchitectureNames.WinArm64 || arch == Path.Combine(ArchitectureNames.MacOSArm64, Constants.Lib))
             {
+                var fallbackArchitecture = arch == ArchitectureNames.WinArm64
+                    ? ArchitectureNames.Win64 : ArchitectureNames.MacOS64;
+                
                 var fallbackLibvlcDirPath1 = Path.Combine(Path.GetDirectoryName(libvlcAssemblyLocation)!,
-                    Constants.LibrariesRepositoryFolderName, ArchitectureNames.Win64);
+                    Constants.LibrariesRepositoryFolderName, fallbackArchitecture);
 
                 var fallbackLibvlccorePath1 = LibVLCCorePath(fallbackLibvlcDirPath1);
                 var fallbackLibvlcPath1 = LibVLCPath(fallbackLibvlcDirPath1);
@@ -151,7 +157,7 @@ namespace LibVLCSharp.Shared
                 if (!string.IsNullOrEmpty(assemblyLocation))
                 {
                     var fallbackLibvlcDirPath2 = Path.Combine(Path.GetDirectoryName(assemblyLocation)!,
-                        Constants.LibrariesRepositoryFolderName, ArchitectureNames.Win64);
+                        Constants.LibrariesRepositoryFolderName, fallbackArchitecture);
 
                     var fallbackLibvlccorePath2 = LibVLCCorePath(fallbackLibvlcDirPath2);
                     var fallbackLibvlcPath2 = LibVLCPath(fallbackLibvlcDirPath2);


### PR DESCRIPTION
<!-- Please target use the correct target branch for your PR (3.x for LibVLCSharp 3, current master is for LibVLCSharp/LibVLC 4). -->

### Description of Change ###

<!-- Describe your changes here. -->
Added Apple Silicon Mac support as Windows-style path structure.  
It still works with current `VideoLAN.LibVLC.Mac` package on x86, but it needs patched package with path structure changed and ARM64 files added to work on Apple Silicon.
PoC implementation of libvlc-nuget is available on [AnthonyKwon/libvlc-nuget](https://github.com/AnthonyKwon/libvlc-nuget). (It's not ready to be upstreamed yet as it uses hacky method to package)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue from https://code.videolan.org/videolan/LibVLCSharp/issues this PR addresses -->

- fixes [#363](https://code.videolan.org/videolan/LibVLCSharp/-/work_items/363)
- fixes [#365](https://code.videolan.org/videolan/LibVLCSharp/-/work_items/365)

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 - `internal const string ArchitectureNames.MacOSArm64` in `Constants.cs`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- build this fork as standard LibVLCSharp macOS build procedure with all dependencies
- or, trim every other mobile and tvOS targets and its dependencies except `net9.0-macos` and `net10.0-macos` from `TargetFramework` and build only with Xcode needed.
  Since you're going to test only with macOS target, other targets are not needed to be tested. 
  I used this method for testing since I was unable to successfully build on some mobile platform. (seems not relevant with these changes since I was not even able to build pure LibVLCSharp)

[build.webm](https://github.com/user-attachments/assets/8446eb4d-f68c-4ee2-bb1e-3fa54baed64d)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
